### PR TITLE
Fixing tests and args

### DIFF
--- a/src/bin/teleport.rs
+++ b/src/bin/teleport.rs
@@ -36,7 +36,12 @@ use teleport::{
 #[structopt(name = "teleport", about = "A tool for CoinSwap")]
 struct ArgsWithWalletFile {
     /// Wallet file
-    #[structopt(default_value = "wallet.teleport", parse(from_os_str), long)]
+    #[structopt(
+        default_value = "wallet.teleport",
+        parse(from_os_str),
+        long,
+        short = "w"
+    )]
     wallet_file_name: PathBuf,
 
     /// Dont broadcast transactions, only output their transaction hex string

--- a/tests/test_standard_coinswap.rs
+++ b/tests/test_standard_coinswap.rs
@@ -1,4 +1,5 @@
 use bitcoin::util::amount::Amount;
+use bitcoin::util::amount::Amount;
 use bitcoincore_rpc::{Client, RpcApi};
 
 use bip39::Mnemonic;
@@ -11,6 +12,7 @@ use teleport::{
 use serde_json::Value;
 
 use std::{
+    fs,
     convert::TryFrom,
     path::PathBuf,
     sync::{Arc, RwLock},
@@ -28,6 +30,10 @@ static MAKER2: &str = "tests/maker-wallet-2";
 fn create_wallet_and_import(filename: PathBuf) -> Wallet {
     let mnemonic = Mnemonic::generate(12).unwrap();
     let seedphrase = mnemonic.to_string();
+
+    if filename.exists() {
+        fs::remove_file(&filename).unwrap();
+    }
 
     let mut wallet = Wallet::init(
         &filename,

--- a/tests/test_standard_coinswap.rs
+++ b/tests/test_standard_coinswap.rs
@@ -14,6 +14,7 @@ use serde_json::Value;
 use std::{
     fs,
     convert::TryFrom,
+    fs,
     path::PathBuf,
     sync::{Arc, RwLock},
     thread, time,


### PR DESCRIPTION
add: short form for wallet-file-name clap arg
fix: remove test wallets if they already existed when running coinswap integration test