### PR TITLE
fix: create temp file dir, handle fs errors when running test, update…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 /docs/fidelity_bonds.md
 Cargo.lock
+*/temp-files


### PR DESCRIPTION
The temporary files and temporary directory are checked to exist when the test starts, and deleted if they do(in cases of where the tests fail).
If the test passes, the temp files & dir are deleted.
Edited the .gitignore to exclude temp-file directory that is created

