### PR TITLE
New Test Framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoincore-rpc = "0.13"
-#bitcoincore-rpc = {git="https://github.com/rust-bitcoin/rust-bitcoincore-rpc"}
 bip39 = {version = "1.0.1", features = ["rand"] }
-bitcoin = {version = "0.26", features = ["rand"] }
+bitcoin = {version = "0.30", features = ["rand"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.16.1", features = ["full"] }
@@ -22,6 +20,7 @@ tokio-socks = "0.5"
 reqwest = { version = "0.11", default-features = false, features = ["socks"] }
 chrono = "0.4"
 clap = { version = "4.3.19", features = ["derive"] }
+bitcoind = {version = "0.32", features = ["25_0"] }
 
 #Empty default feature set, (helpful to generalise in github actions)
 [features]

--- a/README.md
+++ b/README.md
@@ -47,19 +47,6 @@ cargo build
 
 The project includes both unit and integration tests. The integration tests simulate a standard coinswap protocol involving a Taker and two Makers.
 
-To run integration tests, ensure you have a `bitcoind` node running in `regtest` mode on the default port, along with a sample `bitcoin.conf` file as shown:
-
-```conf
-regtest=1
-fallbackfee=0.0001
-server=1
-txindex=1
-rpcuser=regtestrpcuser
-rpcpassword=regtestrpcpass
-```
-
-You'll also need a legacy wallet named `teleport` with sufficient funds (> 0.15 BTC) loaded in Bitcoin Core.
-
 Run integration tests with:
 
 ```sh

--- a/src/bin/teleport.rs
+++ b/src/bin/teleport.rs
@@ -20,8 +20,8 @@ use teleport::{
         },
     },
     wallet::{
-        fidelity::YearAndMonth, CoinToSpend, Destination, DisplayAddressType, SendAmount,
-        WalletMode,
+        fidelity::YearAndMonth, CoinToSpend, Destination, DisplayAddressType, RPCConfig,
+        SendAmount, WalletMode,
     },
 };
 
@@ -177,6 +177,7 @@ fn main() -> Result<(), TeleportError> {
             };
             run_maker(
                 &args.wallet_file_name,
+                &RPCConfig::default(),
                 port,
                 Some(WalletMode::Testing),
                 maker_special_behavior,

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ pub enum TeleportError {
     Network(Box<dyn error::Error + Send>),
     Disk(io::Error),
     Protocol(&'static str),
-    Rpc(bitcoincore_rpc::Error),
+    Rpc(bitcoind::bitcoincore_rpc::Error),
     Socks(tokio_socks::Error),
     Wallet(WalletError),
     Market(DirectoryServerError),
@@ -33,8 +33,8 @@ impl From<io::Error> for TeleportError {
     }
 }
 
-impl From<bitcoincore_rpc::Error> for TeleportError {
-    fn from(e: bitcoincore_rpc::Error) -> TeleportError {
+impl From<bitcoind::bitcoincore_rpc::Error> for TeleportError {
+    fn from(e: bitcoind::bitcoincore_rpc::Error) -> TeleportError {
         TeleportError::Rpc(e)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 extern crate bitcoin;
-extern crate bitcoincore_rpc;
+extern crate bitcoind;
 
 pub mod error;
 pub mod maker;
@@ -9,7 +9,7 @@ pub mod market;
 pub mod protocol;
 pub mod scripts;
 pub mod taker;
-mod utill;
+pub mod utill;
 pub mod wallet;
 // Diasable watchtower for now. Handle contract watching
 // individually for maker and Taker.

--- a/src/maker/mod.rs
+++ b/src/maker/mod.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use bitcoin::Network;
-use bitcoincore_rpc::RpcApi;
+use bitcoind::bitcoincore_rpc::RpcApi;
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
     net::TcpListener,

--- a/src/market/directory.rs
+++ b/src/market/directory.rs
@@ -27,6 +27,7 @@ fn network_enum_to_string(network: Network) -> &'static str {
         Network::Testnet => "testnet",
         Network::Signet => "signet",
         Network::Regtest => panic!("dont use directory servers if using regtest"),
+        _ => todo!(),
     }
 }
 

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -2,10 +2,13 @@ use bitcoin::secp256k1;
 
 #[derive(Debug)]
 pub enum ContractError {
-    Keys(bitcoin::util::key::Error),
     Secp(secp256k1::Error),
     Protocol(&'static str),
     Script(bitcoin::blockdata::script::Error),
+    Hash(bitcoin::hashes::Error),
+    Key(bitcoin::key::Error),
+    Sighash(bitcoin::sighash::Error),
+    Addrs(bitcoin::address::Error),
 }
 
 impl From<secp256k1::Error> for ContractError {
@@ -14,14 +17,32 @@ impl From<secp256k1::Error> for ContractError {
     }
 }
 
-impl From<bitcoin::util::key::Error> for ContractError {
-    fn from(value: bitcoin::util::key::Error) -> Self {
-        Self::Keys(value)
-    }
-}
-
 impl From<bitcoin::blockdata::script::Error> for ContractError {
     fn from(value: bitcoin::blockdata::script::Error) -> Self {
         Self::Script(value)
+    }
+}
+
+impl From<bitcoin::hashes::Error> for ContractError {
+    fn from(value: bitcoin::hashes::Error) -> Self {
+        Self::Hash(value)
+    }
+}
+
+impl From<bitcoin::key::Error> for ContractError {
+    fn from(value: bitcoin::key::Error) -> Self {
+        Self::Key(value)
+    }
+}
+
+impl From<bitcoin::sighash::Error> for ContractError {
+    fn from(value: bitcoin::sighash::Error) -> Self {
+        Self::Sighash(value)
+    }
+}
+
+impl From<bitcoin::address::Error> for ContractError {
+    fn from(value: bitcoin::address::Error) -> Self {
+        Self::Addrs(value)
     }
 }

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -62,8 +62,8 @@
 use std::fmt::Display;
 
 use bitcoin::{
-    secp256k1::{SecretKey, Signature},
-    OutPoint, PublicKey, Script, Transaction,
+    secp256k1::{ecdsa::Signature, SecretKey},
+    OutPoint, PublicKey, ScriptBuf, Transaction,
 };
 
 use serde::{Deserialize, Serialize};
@@ -89,7 +89,7 @@ pub struct ContractTxInfoForSender {
     pub hashlock_nonce: SecretKey,
     pub timelock_pubkey: PublicKey,
     pub senders_contract_tx: Transaction,
-    pub multisig_redeemscript: Script,
+    pub multisig_redeemscript: ScriptBuf,
     pub funding_input_value: u64,
 }
 
@@ -104,7 +104,7 @@ pub struct ReqContractSigsForSender {
 /// Contract Sigs requesting information for the Receiver side of the hop.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ContractTxInfoForRecvr {
-    pub multisig_redeemscript: Script,
+    pub multisig_redeemscript: ScriptBuf,
     pub contract_tx: Transaction,
 }
 
@@ -119,9 +119,9 @@ pub struct ReqContractSigsForRecvr {
 pub struct FundingTxInfo {
     pub funding_tx: Transaction,
     pub funding_tx_merkleproof: String,
-    pub multisig_redeemscript: Script,
+    pub multisig_redeemscript: ScriptBuf,
     pub multisig_nonce: SecretKey,
-    pub contract_redeemscript: Script,
+    pub contract_redeemscript: ScriptBuf,
     pub hashlock_nonce: SecretKey,
 }
 
@@ -161,15 +161,15 @@ pub struct ContractSigsForRecvrAndSender {
 /// Message to Transfer `HashPreimage` from Taker to Makers.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct HashPreimage {
-    pub senders_multisig_redeemscripts: Vec<Script>,
-    pub receivers_multisig_redeemscripts: Vec<Script>,
+    pub senders_multisig_redeemscripts: Vec<ScriptBuf>,
+    pub receivers_multisig_redeemscripts: Vec<ScriptBuf>,
     pub preimage: [u8; 32],
 }
 
 /// Multisig Privatekeys used in the last step of coinswap to perform privatekey handover.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MultisigPrivkey {
-    pub multisig_redeemscript: Script,
+    pub multisig_redeemscript: ScriptBuf,
     pub key: SecretKey,
 }
 
@@ -258,7 +258,7 @@ pub struct ContractSigsForSender {
 pub struct SenderContractTxInfo {
     pub contract_tx: Transaction,
     pub timelock_pubkey: PublicKey,
-    pub multisig_redeemscript: Script,
+    pub multisig_redeemscript: ScriptBuf,
     pub funding_amount: u64,
 }
 

--- a/src/scripts/maker.rs
+++ b/src/scripts/maker.rs
@@ -14,6 +14,7 @@ use crate::{error::TeleportError, wallet::WalletMode};
 #[tokio::main]
 pub async fn run_maker(
     wallet_file_name: &PathBuf,
+    rpc_config: &RPCConfig,
     port: u16,
     wallet_mode: Option<WalletMode>,
     maker_behavior: MakerBehavior,
@@ -23,7 +24,7 @@ pub async fn run_maker(
     let onion_addrs = "myhiddenserviceaddress.onion:6102".to_string();
     let maker = Maker::init(
         wallet_file_name,
-        &RPCConfig::default(),
+        rpc_config,
         port,
         onion_addrs,
         wallet_mode,

--- a/src/scripts/recovery.rs
+++ b/src/scripts/recovery.rs
@@ -1,9 +1,9 @@
+use bitcoind::bitcoincore_rpc::RpcApi;
 use crate::{
     error::TeleportError,
     protocol::contract::Hash160,
     wallet::{RPCConfig, Wallet, WalletSwapCoin},
 };
-use bitcoincore_rpc::RpcApi;
 use std::path::PathBuf;
 
 pub fn recover_from_incomplete_coinswap(
@@ -42,7 +42,7 @@ pub fn recover_from_incomplete_coinswap(
             .import_wallet_contract_redeemscript(&swapcoin.1.get_contract_redeemscript())
             .unwrap();
 
-        let signed_contract_tx = swapcoin.1.get_fully_signed_contract_tx();
+        let signed_contract_tx = swapcoin.1.get_fully_signed_contract_tx()?;
         if dont_broadcast {
             let txhex = bitcoin::consensus::encode::serialize_hex(&signed_contract_tx);
             println!(

--- a/src/scripts/recovery.rs
+++ b/src/scripts/recovery.rs
@@ -1,9 +1,9 @@
-use bitcoind::bitcoincore_rpc::RpcApi;
 use crate::{
     error::TeleportError,
     protocol::contract::Hash160,
     wallet::{RPCConfig, Wallet, WalletSwapCoin},
 };
+use bitcoind::bitcoincore_rpc::RpcApi;
 use std::path::PathBuf;
 
 pub fn recover_from_incomplete_coinswap(

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -4,9 +4,9 @@ use crate::protocol::error::ContractError;
 pub enum WalletError {
     File(std::io::Error),
     Json(serde_json::Error),
-    Rpc(bitcoincore_rpc::Error),
+    Rpc(bitcoind::bitcoincore_rpc::Error),
     Protocol(String),
-    BIP32(bitcoin::util::bip32::Error),
+    BIP32(bitcoin::bip32::Error),
     BIP39(bip39::Error),
     Contract(ContractError),
 }
@@ -23,14 +23,14 @@ impl From<serde_json::Error> for WalletError {
     }
 }
 
-impl From<bitcoincore_rpc::Error> for WalletError {
-    fn from(value: bitcoincore_rpc::Error) -> Self {
+impl From<bitcoind::bitcoincore_rpc::Error> for WalletError {
+    fn from(value: bitcoind::bitcoincore_rpc::Error) -> Self {
         Self::Rpc(value)
     }
 }
 
-impl From<bitcoin::util::bip32::Error> for WalletError {
-    fn from(value: bitcoin::util::bip32::Error) -> Self {
+impl From<bitcoin::bip32::Error> for WalletError {
+    fn from(value: bitcoin::bip32::Error) -> Self {
         Self::BIP32(value)
     }
 }

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, convert::TryFrom, io::Read, path::PathBuf};
 
 use bip39::Mnemonic;
-use bitcoin::{util::bip32::ExtendedPrivKey, Network, OutPoint, Script};
+use bitcoin::{bip32::ExtendedPrivKey, Network, OutPoint, ScriptBuf};
 use std::fs::File;
 
 use super::{error::WalletError, SwapCoin};
@@ -24,21 +24,22 @@ struct FileData {
     external_index: u32,
     incoming_swapcoins: Vec<IncomingSwapCoin>,
     outgoing_swapcoins: Vec<OutgoingSwapCoin>,
-    prevout_to_contract_map: HashMap<OutPoint, Script>,
+    prevout_to_contract_map: HashMap<OutPoint, ScriptBuf>,
 }
 
 pub struct WalletStore {
+    // Wallet store name should match the bitcoin core watch-only wallet name
     pub(crate) wallet_name: String,
     pub(crate) network: Network,
     pub(super) master_key: ExtendedPrivKey,
     pub(super) external_index: u32,
     pub(crate) offer_maxsize: u64,
     /// Map of multisig reedemscript to incoming swapcoins.
-    pub(super) incoming_swapcoins: HashMap<Script, IncomingSwapCoin>,
+    pub(super) incoming_swapcoins: HashMap<ScriptBuf, IncomingSwapCoin>,
     /// Map of multisig reedemscript to outgoing swapcoins.
-    pub(super) outgoing_swapcoins: HashMap<Script, OutgoingSwapCoin>,
-    pub(super) prevout_to_contract_map: HashMap<OutPoint, Script>,
-    pub(super) fidelity_scripts: HashMap<Script, u32>,
+    pub(super) outgoing_swapcoins: HashMap<ScriptBuf, OutgoingSwapCoin>,
+    pub(super) prevout_to_contract_map: HashMap<OutPoint, ScriptBuf>,
+    pub(super) fidelity_scripts: HashMap<ScriptBuf, u32>,
     //TODO: Add last synced height and Wallet birthday.
 }
 
@@ -53,13 +54,13 @@ impl TryFrom<FileData> for WalletStore {
             .incoming_swapcoins
             .iter()
             .map(|sc| (sc.get_multisig_redeemscript(), sc.clone()))
-            .collect::<HashMap<Script, IncomingSwapCoin>>();
+            .collect::<HashMap<_, _>>();
 
         let outgoing_swapcoins = file_data
             .outgoing_swapcoins
             .iter()
             .map(|sc| (sc.get_multisig_redeemscript(), sc.clone()))
-            .collect::<HashMap<Script, OutgoingSwapCoin>>();
+            .collect::<HashMap<_, _>>();
 
         let timelocked_script_index_map = generate_fidelity_scripts(&xprv);
 

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -1,7 +1,8 @@
 use bitcoin::{
-    secp256k1::{self, Secp256k1, SecretKey, Signature},
-    util::bip143::SigHashCache,
-    Address, OutPoint, PublicKey, Script, SigHashType, Transaction, TxIn, TxOut,
+    absolute::LockTime,
+    secp256k1::{self, ecdsa::Signature, Secp256k1, SecretKey},
+    sighash::{EcdsaSighashType, SighashCache},
+    Address, OutPoint, PublicKey, Script, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
 };
 
 use crate::protocol::{
@@ -11,6 +12,7 @@ use crate::protocol::{
         read_pubkeys_from_multisig_redeemscript, read_timelock_pubkey_from_contract,
         sign_contract_tx, verify_contract_tx_sig,
     },
+    error::ContractError,
     messages::Preimage,
     Hash160,
 };
@@ -25,7 +27,7 @@ pub struct IncomingSwapCoin {
     pub other_pubkey: PublicKey,
     pub other_privkey: Option<SecretKey>,
     pub contract_tx: Transaction,
-    pub contract_redeemscript: Script,
+    pub contract_redeemscript: ScriptBuf,
     pub hashlock_privkey: SecretKey,
     pub funding_amount: u64,
     pub others_contract_sig: Option<Signature>,
@@ -39,7 +41,7 @@ pub struct OutgoingSwapCoin {
     pub my_privkey: SecretKey,
     pub other_pubkey: PublicKey,
     pub contract_tx: Transaction,
-    pub contract_redeemscript: Script,
+    pub contract_redeemscript: ScriptBuf,
     pub timelock_privkey: SecretKey,
     pub funding_amount: u64,
     pub others_contract_sig: Option<Signature>,
@@ -53,28 +55,28 @@ pub struct WatchOnlySwapCoin {
     pub sender_pubkey: PublicKey,
     pub receiver_pubkey: PublicKey,
     pub contract_tx: Transaction,
-    pub contract_redeemscript: Script,
+    pub contract_redeemscript: ScriptBuf,
     pub funding_amount: u64,
 }
 
 pub trait SwapCoin {
-    fn get_multisig_redeemscript(&self) -> Script;
+    fn get_multisig_redeemscript(&self) -> ScriptBuf;
     fn get_contract_tx(&self) -> Transaction;
-    fn get_contract_redeemscript(&self) -> Script;
+    fn get_contract_redeemscript(&self) -> ScriptBuf;
     fn get_timelock_pubkey(&self) -> PublicKey;
     fn get_timelock(&self) -> u16;
     fn get_hashlock_pubkey(&self) -> PublicKey;
     fn get_hashvalue(&self) -> Hash160;
     fn get_funding_amount(&self) -> u64;
-    fn verify_contract_tx_receiver_sig(&self, sig: &Signature) -> bool;
-    fn verify_contract_tx_sender_sig(&self, sig: &Signature) -> bool;
+    fn verify_contract_tx_receiver_sig(&self, sig: &Signature) -> Result<(), WalletError>;
+    fn verify_contract_tx_sender_sig(&self, sig: &Signature) -> Result<(), WalletError>;
     fn apply_privkey(&mut self, privkey: SecretKey) -> Result<(), WalletError>;
 }
 
 pub trait WalletSwapCoin: SwapCoin {
     fn get_my_pubkey(&self) -> PublicKey;
     fn get_other_pubkey(&self) -> &PublicKey;
-    fn get_fully_signed_contract_tx(&self) -> Transaction;
+    fn get_fully_signed_contract_tx(&self) -> Result<Transaction, WalletError>;
     fn is_hash_preimage_known(&self) -> bool;
 }
 
@@ -85,7 +87,7 @@ macro_rules! impl_walletswapcoin {
                 let secp = Secp256k1::new();
                 PublicKey {
                     compressed: true,
-                    key: secp256k1::PublicKey::from_secret_key(&secp, &self.my_privkey),
+                    inner: secp256k1::PublicKey::from_secret_key(&secp, &self.my_privkey),
                 }
             }
 
@@ -93,7 +95,7 @@ macro_rules! impl_walletswapcoin {
                 &self.other_pubkey
             }
 
-            fn get_fully_signed_contract_tx(&self) -> Transaction {
+            fn get_fully_signed_contract_tx(&self) -> Result<Transaction, WalletError> {
                 if self.others_contract_sig.is_none() {
                     panic!("invalid state: others_contract_sig not known");
                 }
@@ -103,15 +105,17 @@ macro_rules! impl_walletswapcoin {
                 let index = 0;
                 let secp = Secp256k1::new();
                 let sighash = secp256k1::Message::from_slice(
-                    &SigHashCache::new(&self.contract_tx).signature_hash(
-                        index,
-                        &multisig_redeemscript,
-                        self.funding_amount,
-                        SigHashType::All,
-                    )[..],
+                    &SighashCache::new(&self.contract_tx)
+                        .segwit_signature_hash(
+                            index,
+                            &multisig_redeemscript,
+                            self.funding_amount,
+                            EcdsaSighashType::All,
+                        )
+                        .map_err(ContractError::Sighash)?[..],
                 )
-                .unwrap();
-                let sig_mine = secp.sign(&sighash, &self.my_privkey);
+                .map_err(ContractError::Secp)?;
+                let sig_mine = secp.sign_ecdsa(&sighash, &self.my_privkey);
 
                 let mut signed_contract_tx = self.contract_tx.clone();
                 apply_two_signatures_to_2of2_multisig_spend(
@@ -122,7 +126,7 @@ macro_rules! impl_walletswapcoin {
                     &mut signed_contract_tx.input[index],
                     &multisig_redeemscript,
                 );
-                signed_contract_tx
+                Ok(signed_contract_tx)
             }
 
             fn is_hash_preimage_known(&self) -> bool {
@@ -155,7 +159,7 @@ macro_rules! impl_swapcoin_getters {
             self.contract_tx.clone()
         }
 
-        fn get_contract_redeemscript(&self) -> Script {
+        fn get_contract_redeemscript(&self) -> ScriptBuf {
             self.contract_redeemscript.clone()
         }
 
@@ -170,14 +174,14 @@ impl IncomingSwapCoin {
         my_privkey: SecretKey,
         other_pubkey: PublicKey,
         contract_tx: Transaction,
-        contract_redeemscript: Script,
+        contract_redeemscript: ScriptBuf,
         hashlock_privkey: SecretKey,
         funding_amount: u64,
     ) -> Self {
         let secp = Secp256k1::new();
         let hashlock_pubkey = PublicKey {
             compressed: true,
-            key: secp256k1::PublicKey::from_secret_key(&secp, &hashlock_privkey),
+            inner: secp256k1::PublicKey::from_secret_key(&secp, &hashlock_privkey),
         };
         assert!(
             hashlock_pubkey == read_hashlock_pubkey_from_contract(&contract_redeemscript).unwrap()
@@ -201,25 +205,29 @@ impl IncomingSwapCoin {
         tx: &Transaction,
         input: &mut TxIn,
         redeemscript: &Script,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), WalletError> {
         if self.other_privkey.is_none() {
-            return Err("unable to sign: incomplete coinswap for this input");
+            return Err(WalletError::Protocol(
+                "unable to sign: incomplete coinswap for this input".to_string(),
+            ));
         }
         let secp = Secp256k1::new();
         let my_pubkey = self.get_my_pubkey();
 
         let sighash = secp256k1::Message::from_slice(
-            &SigHashCache::new(tx).signature_hash(
-                index,
-                redeemscript,
-                self.funding_amount,
-                SigHashType::All,
-            )[..],
+            &SighashCache::new(tx)
+                .segwit_signature_hash(
+                    index,
+                    redeemscript,
+                    self.funding_amount,
+                    EcdsaSighashType::All,
+                )
+                .map_err(ContractError::Sighash)?[..],
         )
-        .unwrap();
+        .map_err(ContractError::Secp)?;
 
-        let sig_mine = secp.sign(&sighash, &self.my_privkey);
-        let sig_other = secp.sign(&sighash, &self.other_privkey.unwrap());
+        let sig_mine = secp.sign_ecdsa(&sighash, &self.my_privkey);
+        let sig_other = secp.sign_ecdsa(&sighash, &self.other_privkey.unwrap());
 
         apply_two_signatures_to_2of2_multisig_spend(
             &my_pubkey,
@@ -239,23 +247,27 @@ impl IncomingSwapCoin {
         input: &mut TxIn,
         input_value: u64,
         hash_preimage: &[u8],
-    ) {
+    ) -> Result<(), WalletError> {
         let secp = Secp256k1::new();
         let sighash = secp256k1::Message::from_slice(
-            &SigHashCache::new(tx).signature_hash(
-                index,
-                &self.contract_redeemscript,
-                input_value,
-                SigHashType::All,
-            )[..],
+            &SighashCache::new(tx)
+                .segwit_signature_hash(
+                    index,
+                    &self.contract_redeemscript,
+                    input_value,
+                    EcdsaSighashType::All,
+                )
+                .map_err(ContractError::Sighash)?[..],
         )
-        .unwrap();
+        .map_err(ContractError::Secp)?;
 
-        let sig_hashlock = secp.sign(&sighash, &self.hashlock_privkey);
-        input.witness.push(sig_hashlock.serialize_der().to_vec());
-        input.witness[0].push(SigHashType::All as u8);
+        let sig_hashlock = secp.sign_ecdsa(&sighash, &self.hashlock_privkey);
+        let mut sig_hashlock_bytes = sig_hashlock.serialize_der().to_vec();
+        sig_hashlock_bytes.push(EcdsaSighashType::All as u8);
+        input.witness.push(sig_hashlock_bytes);
         input.witness.push(hash_preimage.to_vec());
         input.witness.push(self.contract_redeemscript.to_bytes());
+        Ok(())
     }
 
     pub fn sign_hashlocked_transaction_input(
@@ -264,17 +276,17 @@ impl IncomingSwapCoin {
         tx: &Transaction,
         input: &mut TxIn,
         input_value: u64,
-    ) {
+    ) -> Result<(), WalletError> {
         if self.hash_preimage.is_none() {
             panic!("invalid state, unable to sign: preimage unknown");
         }
-        self.sign_hashlocked_transaction_input_given_preimage(
+        Ok(self.sign_hashlocked_transaction_input_given_preimage(
             index,
             tx,
             input,
             input_value,
             &self.hash_preimage.unwrap(),
-        )
+        )?)
     }
 
     pub fn create_hashlock_spend_without_preimage(
@@ -288,15 +300,15 @@ impl IncomingSwapCoin {
                     txid: self.contract_tx.txid(),
                     vout: 0, //contract_tx is one-input-one-output
                 },
-                sequence: 1, //hashlock spends must have 1 because of the `OP_CSV 1`
-                witness: Vec::new(),
-                script_sig: Script::new(),
+                sequence: Sequence(1), //hashlock spends must have 1 because of the `OP_CSV 1`
+                witness: Witness::new(),
+                script_sig: ScriptBuf::new(),
             }],
             output: vec![TxOut {
                 script_pubkey: destination_address.script_pubkey(),
                 value: self.contract_tx.output[0].value - miner_fee,
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             version: 2,
         };
         let index = 0;
@@ -307,18 +319,19 @@ impl IncomingSwapCoin {
             &mut tx.input[0],
             self.contract_tx.output[0].value,
             &preimage,
-        );
+        )
+        .unwrap();
         tx
     }
 
-    pub fn verify_contract_tx_sig(&self, sig: &Signature) -> bool {
-        verify_contract_tx_sig(
+    pub fn verify_contract_tx_sig(&self, sig: &Signature) -> Result<(), WalletError> {
+        Ok(verify_contract_tx_sig(
             &self.contract_tx,
             &self.get_multisig_redeemscript(),
             self.funding_amount,
             &self.other_pubkey,
             sig,
-        )
+        )?)
     }
 }
 
@@ -327,14 +340,14 @@ impl OutgoingSwapCoin {
         my_privkey: SecretKey,
         other_pubkey: PublicKey,
         contract_tx: Transaction,
-        contract_redeemscript: Script,
+        contract_redeemscript: ScriptBuf,
         timelock_privkey: SecretKey,
         funding_amount: u64,
     ) -> Self {
         let secp = Secp256k1::new();
         let timelock_pubkey = PublicKey {
             compressed: true,
-            key: secp256k1::PublicKey::from_secret_key(&secp, &timelock_privkey),
+            inner: secp256k1::PublicKey::from_secret_key(&secp, &timelock_privkey),
         };
         assert!(
             timelock_pubkey == read_timelock_pubkey_from_contract(&contract_redeemscript).unwrap()
@@ -357,23 +370,28 @@ impl OutgoingSwapCoin {
         tx: &Transaction,
         input: &mut TxIn,
         input_value: u64,
-    ) {
+    ) -> Result<(), WalletError> {
         let secp = Secp256k1::new();
         let sighash = secp256k1::Message::from_slice(
-            &SigHashCache::new(tx).signature_hash(
-                index,
-                &self.contract_redeemscript,
-                input_value,
-                SigHashType::All,
-            )[..],
+            &SighashCache::new(tx)
+                .segwit_signature_hash(
+                    index,
+                    &self.contract_redeemscript,
+                    input_value,
+                    EcdsaSighashType::All,
+                )
+                .map_err(ContractError::Sighash)?[..],
         )
-        .unwrap();
+        .map_err(ContractError::Secp)?;
 
-        let sig_timelock = secp.sign(&sighash, &self.timelock_privkey);
-        input.witness.push(sig_timelock.serialize_der().to_vec());
-        input.witness[0].push(SigHashType::All as u8);
+        let sig_timelock = secp.sign_ecdsa(&sighash, &self.timelock_privkey);
+
+        let mut sig_timelock_bytes = sig_timelock.serialize_der().to_vec();
+        sig_timelock_bytes.push(EcdsaSighashType::All as u8);
+        input.witness.push(sig_timelock_bytes);
         input.witness.push(Vec::new());
         input.witness.push(self.contract_redeemscript.to_bytes());
+        Ok(())
     }
 
     pub fn create_timelock_spend(&self, destination_address: &Address) -> Transaction {
@@ -384,15 +402,15 @@ impl OutgoingSwapCoin {
                     txid: self.contract_tx.txid(),
                     vout: 0, //contract_tx is one-input-one-output
                 },
-                sequence: self.get_timelock() as u32,
-                witness: Vec::new(),
-                script_sig: Script::new(),
+                sequence: Sequence(self.get_timelock() as u32),
+                witness: Witness::new(),
+                script_sig: ScriptBuf::new(),
             }],
             output: vec![TxOut {
                 script_pubkey: destination_address.script_pubkey(),
                 value: self.contract_tx.output[0].value - miner_fee,
             }],
-            lock_time: 0,
+            lock_time: LockTime::ZERO,
             version: 2,
         };
         let index = 0;
@@ -401,7 +419,8 @@ impl OutgoingSwapCoin {
             &tx.clone(),
             &mut tx.input[0],
             self.contract_tx.output[0].value,
-        );
+        )
+        .unwrap();
         tx
     }
 
@@ -419,23 +438,23 @@ impl OutgoingSwapCoin {
         )?)
     }
 
-    pub fn verify_contract_tx_sig(&self, sig: &Signature) -> bool {
-        verify_contract_tx_sig(
+    pub fn verify_contract_tx_sig(&self, sig: &Signature) -> Result<(), WalletError> {
+        Ok(verify_contract_tx_sig(
             &self.contract_tx,
             &self.get_multisig_redeemscript(),
             self.funding_amount,
             &self.other_pubkey,
             sig,
-        )
+        )?)
     }
 }
 
 impl WatchOnlySwapCoin {
     pub fn new(
-        multisig_redeemscript: &Script,
+        multisig_redeemscript: &ScriptBuf,
         receiver_pubkey: PublicKey,
         contract_tx: Transaction,
-        contract_redeemscript: Script,
+        contract_redeemscript: ScriptBuf,
         funding_amount: u64,
     ) -> Result<WatchOnlySwapCoin, WalletError> {
         let (pubkey1, pubkey2) = read_pubkeys_from_multisig_redeemscript(multisig_redeemscript)?;
@@ -465,22 +484,22 @@ impl_walletswapcoin!(OutgoingSwapCoin);
 impl SwapCoin for IncomingSwapCoin {
     impl_swapcoin_getters!();
 
-    fn get_multisig_redeemscript(&self) -> Script {
+    fn get_multisig_redeemscript(&self) -> ScriptBuf {
         let secp = Secp256k1::new();
         create_multisig_redeemscript(
             &self.other_pubkey,
             &PublicKey {
                 compressed: true,
-                key: secp256k1::PublicKey::from_secret_key(&secp, &self.my_privkey),
+                inner: secp256k1::PublicKey::from_secret_key(&secp, &self.my_privkey),
             },
         )
     }
 
-    fn verify_contract_tx_receiver_sig(&self, sig: &Signature) -> bool {
+    fn verify_contract_tx_receiver_sig(&self, sig: &Signature) -> Result<(), WalletError> {
         self.verify_contract_tx_sig(sig)
     }
 
-    fn verify_contract_tx_sender_sig(&self, sig: &Signature) -> bool {
+    fn verify_contract_tx_sender_sig(&self, sig: &Signature) -> Result<(), WalletError> {
         self.verify_contract_tx_sig(sig)
     }
 
@@ -488,7 +507,7 @@ impl SwapCoin for IncomingSwapCoin {
         let secp = Secp256k1::new();
         let pubkey = PublicKey {
             compressed: true,
-            key: secp256k1::PublicKey::from_secret_key(&secp, &privkey),
+            inner: secp256k1::PublicKey::from_secret_key(&secp, &privkey),
         };
         if pubkey != self.other_pubkey {
             return Err(WalletError::Protocol("not correct privkey".to_string()));
@@ -501,22 +520,22 @@ impl SwapCoin for IncomingSwapCoin {
 impl SwapCoin for OutgoingSwapCoin {
     impl_swapcoin_getters!();
 
-    fn get_multisig_redeemscript(&self) -> Script {
+    fn get_multisig_redeemscript(&self) -> ScriptBuf {
         let secp = Secp256k1::new();
         create_multisig_redeemscript(
             &self.other_pubkey,
             &PublicKey {
                 compressed: true,
-                key: secp256k1::PublicKey::from_secret_key(&secp, &self.my_privkey),
+                inner: secp256k1::PublicKey::from_secret_key(&secp, &self.my_privkey),
             },
         )
     }
 
-    fn verify_contract_tx_receiver_sig(&self, sig: &Signature) -> bool {
+    fn verify_contract_tx_receiver_sig(&self, sig: &Signature) -> Result<(), WalletError> {
         self.verify_contract_tx_sig(sig)
     }
 
-    fn verify_contract_tx_sender_sig(&self, sig: &Signature) -> bool {
+    fn verify_contract_tx_sender_sig(&self, sig: &Signature) -> Result<(), WalletError> {
         self.verify_contract_tx_sig(sig)
     }
 
@@ -524,7 +543,7 @@ impl SwapCoin for OutgoingSwapCoin {
         let secp = Secp256k1::new();
         let pubkey = PublicKey {
             compressed: true,
-            key: secp256k1::PublicKey::from_secret_key(&secp, &privkey),
+            inner: secp256k1::PublicKey::from_secret_key(&secp, &privkey),
         };
         if pubkey == self.other_pubkey {
             Ok(())
@@ -541,7 +560,7 @@ impl SwapCoin for WatchOnlySwapCoin {
         let secp = Secp256k1::new();
         let pubkey = PublicKey {
             compressed: true,
-            key: secp256k1::PublicKey::from_secret_key(&secp, &privkey),
+            inner: secp256k1::PublicKey::from_secret_key(&secp, &privkey),
         };
         if pubkey == self.sender_pubkey || pubkey == self.receiver_pubkey {
             Ok(())
@@ -550,30 +569,30 @@ impl SwapCoin for WatchOnlySwapCoin {
         }
     }
 
-    fn get_multisig_redeemscript(&self) -> Script {
+    fn get_multisig_redeemscript(&self) -> ScriptBuf {
         create_multisig_redeemscript(&self.sender_pubkey, &self.receiver_pubkey)
     }
 
     //potential confusion here:
     //verify sender sig uses the receiver_pubkey
     //verify receiver sig uses the sender_pubkey
-    fn verify_contract_tx_sender_sig(&self, sig: &Signature) -> bool {
-        verify_contract_tx_sig(
+    fn verify_contract_tx_sender_sig(&self, sig: &Signature) -> Result<(), WalletError> {
+        Ok(verify_contract_tx_sig(
             &self.contract_tx,
             &self.get_multisig_redeemscript(),
             self.funding_amount,
             &self.receiver_pubkey,
             sig,
-        )
+        )?)
     }
 
-    fn verify_contract_tx_receiver_sig(&self, sig: &Signature) -> bool {
-        verify_contract_tx_sig(
+    fn verify_contract_tx_receiver_sig(&self, sig: &Signature) -> Result<(), WalletError> {
+        Ok(verify_contract_tx_sig(
             &self.contract_tx,
             &self.get_multisig_redeemscript(),
             self.funding_amount,
             &self.sender_pubkey,
             sig,
-        )
+        )?)
     }
 }


### PR DESCRIPTION
This PR includes.

- Migration to rust-bitcoin v0.30.
- A New test framework using `bitcoind` crate to automatically spawn regtest nodes and connect Makers and Taker wallets to it.


This gives us more flexibility to create various blockchain scenarios like reorgs and removes any setup requirement for running the integration test.