### PR TITLE
Generic Improvements.

### DIFF
--- a/src/bin/teleport.rs
+++ b/src/bin/teleport.rs
@@ -2,7 +2,6 @@ use clap::{Parser, Subcommand};
 use std::{path::PathBuf, sync::Arc};
 
 use coinswap::{
-    error::TeleportError,
     maker::{start_maker_server, Maker, MakerBehavior},
     scripts::{
         market::download_and_display_offers,
@@ -14,7 +13,8 @@ use coinswap::{
     taker::{SwapParams, Taker, TakerBehavior},
     utill::setup_logger,
     wallet::{
-        fidelity::YearAndMonth, CoinToSpend, Destination, DisplayAddressType, RPCConfig, SendAmount,
+        fidelity::YearAndMonth, CoinToSpend, Destination, DisplayAddressType, RPCConfig,
+        SendAmount, WalletError,
     },
 };
 
@@ -131,7 +131,7 @@ enum WalletArgsSubcommand {
     },
 }
 
-fn main() -> Result<(), TeleportError> {
+fn main() -> Result<(), WalletError> {
     setup_logger();
     let args = ArgsWithWalletFile::parse();
     // let args = ArgsWithWalletFile::from_args();

--- a/src/maker/error.rs
+++ b/src/maker/error.rs
@@ -1,4 +1,4 @@
-use std::sync::{PoisonError, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{MutexGuard, PoisonError, RwLockReadGuard, RwLockWriteGuard};
 
 use bitcoin::secp256k1;
 
@@ -36,6 +36,12 @@ impl<'a, T> From<PoisonError<RwLockReadGuard<'a, T>>> for MakerError {
 
 impl<'a, T> From<PoisonError<RwLockWriteGuard<'a, T>>> for MakerError {
     fn from(_: PoisonError<RwLockWriteGuard<'a, T>>) -> Self {
+        Self::MutexPossion
+    }
+}
+
+impl<'a, T> From<PoisonError<MutexGuard<'a, T>>> for MakerError {
+    fn from(_: PoisonError<MutexGuard<'a, T>>) -> Self {
         Self::MutexPossion
     }
 }

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -437,8 +437,7 @@ impl Maker {
 
         // Update the connection state.
         self.connection_state
-            .write()
-            .unwrap()
+            .lock()?
             .insert(ip, (connection_state.clone(), Instant::now()));
 
         Ok(MakerToTakerMessage::ReqContractSigsAsRecvrAndSender(
@@ -456,6 +455,12 @@ impl Maker {
         message: ContractSigsForRecvrAndSender,
         ip: IpAddr,
     ) -> Result<(), MakerError> {
+        if let MakerBehavior::CloseAtSenersAndRecvrsContractSigs = self.behavior {
+            return Err(MakerError::General(
+                "Special Behavior: Closing connection Before Receving Sender's and Receiver's Contract Sigs",
+            ));
+        }
+
         if message.receivers_sigs.len() != connection_state.incoming_swapcoins.len() {
             return Err(MakerError::General(
                 "invalid number of reciever's signatures",
@@ -513,8 +518,7 @@ impl Maker {
 
         // Update the connection state.
         self.connection_state
-            .write()
-            .unwrap()
+            .lock()?
             .insert(ip, (connection_state.clone(), Instant::now()));
 
         Ok(())

--- a/src/taker/error.rs
+++ b/src/taker/error.rs
@@ -1,0 +1,65 @@
+use bitcoin::Txid;
+
+use bitcoind::bitcoincore_rpc::Error as RpcError;
+
+use crate::{
+    error::{NetError, ProtocolError},
+    market::directory::DirectoryServerError,
+    wallet::WalletError,
+};
+
+#[derive(Debug)]
+pub enum TakerError {
+    IO(std::io::Error),
+    ContractsBroadcasted(Vec<Txid>),
+    RPCError(RpcError),
+    NotEnoughMakersInOfferBook,
+    Wallet(WalletError),
+    Directory(DirectoryServerError),
+    Net(NetError),
+    Socks(tokio_socks::Error),
+    Protocol(ProtocolError),
+    SendAmountNotSet,
+}
+
+impl From<RpcError> for TakerError {
+    fn from(value: RpcError) -> Self {
+        Self::RPCError(value)
+    }
+}
+
+impl From<WalletError> for TakerError {
+    fn from(value: WalletError) -> Self {
+        Self::Wallet(value)
+    }
+}
+
+impl From<DirectoryServerError> for TakerError {
+    fn from(value: DirectoryServerError) -> Self {
+        Self::Directory(value)
+    }
+}
+
+impl From<std::io::Error> for TakerError {
+    fn from(value: std::io::Error) -> Self {
+        Self::IO(value)
+    }
+}
+
+impl From<NetError> for TakerError {
+    fn from(value: NetError) -> Self {
+        Self::Net(value)
+    }
+}
+
+impl From<tokio_socks::Error> for TakerError {
+    fn from(value: tokio_socks::Error) -> Self {
+        Self::Socks(value)
+    }
+}
+
+impl From<ProtocolError> for TakerError {
+    fn from(value: ProtocolError) -> Self {
+        Self::Protocol(value)
+    }
+}

--- a/src/taker/mod.rs
+++ b/src/taker/mod.rs
@@ -1,4 +1,5 @@
 mod config;
+pub mod error;
 pub mod offers;
 mod routines;
 mod taker;

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -4,13 +4,13 @@ use tokio::sync::mpsc;
 
 use bitcoin::Network;
 
-use crate::{error::TeleportError, protocol::messages::Offer};
+use crate::protocol::messages::Offer;
 
 use crate::market::directory::{
     sync_maker_addresses_from_directory_servers, DirectoryServerError, TOR_ADDR,
 };
 
-use super::{config::TakerConfig, routines::download_maker_offer};
+use super::{config::TakerConfig, error::TakerError, routines::download_maker_offer};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OfferAndAddress {
@@ -99,7 +99,7 @@ impl OfferBook {
         &mut self,
         network: Network,
         config: &TakerConfig,
-    ) -> Result<Vec<OfferAndAddress>, TeleportError> {
+    ) -> Result<Vec<OfferAndAddress>, TakerError> {
         let offers =
             sync_offerbook_with_addresses(get_advertised_maker_addresses(network).await?, config)
                 .await;


### PR DESCRIPTION
Fixes #1
Fixes #17 

This PR completes the addition of dedicated error structs for each component. 

- The original `TeleportError` is removed.
- Two new high-level erros `NetError` and `PrtocoError`.
- A new `TakerError` is added which includes all the Taker generated errors.

Some code-level improvements have also been added.

- Maker's `ConnectionState` uses a `Mutex` instead of `RwLock`. This ensures connection states are held by only one thread at a time. As there are two threads currently that read and write in `ConnectionState`, this seems to be fixing the spurious dead look situation in the `abort1` case.

- Taker codes are improved a bit. The behavior remains the same. The code is made more clear and rusty.    