### PR TITLE
Abort3 case3

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,11 @@ If you're interested in contributing to the project, explore the [open issues](h
   - [x] Case 1: Maker drops **before** sending sender's signature. Taker tries with another Maker and moves on.
   - [x] Case 2: Maker drops **before** sending sender's signature. Taker doesn't have any new Maker. Recovers from swap.
   - [x] Case 3: Maker drops **after** sending sender's signatures. Taker doesn't have any new Maker. Recovers from swap.
-- [x] Finish building a flexible and robust Test-Framework with `bitcoind` backend.
-- [ ] Abort 3: Maker aborts **after setup**. Taker and other Makers identify this and recovers back via contract tx. Taker bans the aborting Maker's fidelity bond.
-  - [x] Case1: Maker Drops at `ContractSigsForRecvrAndSender`. Does not broadcasts the funding txs.
-  - [x] Case2: Maker drops at `ContractSigsForRecvr` after broadcasting funding txs. Taker and other Makers recover.
+- [x] Build a flexible Test-Framework with `bitcoind` backend.
+- [x] Abort 3: Maker aborts **after setup**. Taker and other Makers identify this and recovers back via contract tx. Taker bans the aborting Maker's fidelity bond.
+  - [x] Case1: Maker Drops at `ContractSigsForRecvrAndSender`. Does not broadcasts the funding txs. Taker and Other Maker recovers. Maker gets banned.
+  - [x] Case2: Maker drops at `ContractSigsForRecvr` after broadcasting funding txs. Taker and other Makers recover. Maker gets banned.
+  - [x] Case3L Maker Drops at `HashPreimage` message and doesn't respond back with privkeys. Taker and other Maker recovers. Maker gets banned.
 - [ ] Malice 1: Taker broadcasts contract immaturely. Other Makers identify this, get their funds back via contract tx.
 - [ ] Malice 2: One of the Makers broadcast contract immaturely. The Taker identify this, bans the Maker's fidelity bond, other Makers get back funds via contract tx.
 - [ ] Fix all clippy warnings.

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -558,6 +558,10 @@ impl Maker {
         &self,
         message: HashPreimage,
     ) -> Result<MakerToTakerMessage, MakerError> {
+        if let MakerBehavior::CloseAtHashPreimage = self.behavior {
+            return Err(MakerError::General("Special Behavior: CloseAtHashPreimage"));
+        }
+
         let hashvalue = Hash160::hash(&message.preimage);
         for multisig_redeemscript in &message.senders_multisig_redeemscripts {
             let mut wallet_write = self.wallet.write()?;
@@ -570,9 +574,12 @@ impl Maker {
             }
             incoming_swapcoin.hash_preimage = Some(message.preimage);
         }
-        //TODO tell preimage to watchtowers
 
-        log::info!("received preimage for hashvalue={}", hashvalue);
+        log::info!(
+            "[{}] received preimage for hashvalue={}",
+            self.config.port,
+            hashvalue
+        );
         let mut swapcoin_private_keys = Vec::<MultisigPrivkey>::new();
 
         for multisig_redeemscript in &message.receivers_multisig_redeemscripts {

--- a/src/maker/maker.rs
+++ b/src/maker/maker.rs
@@ -41,6 +41,7 @@ pub enum MakerBehavior {
     CloseAtProofOfFunding,
     CloseAtContractSigsForRecvrAndSender,
     CloseAtContractSigsForRecvr,
+    CloseAtHashPreimage,
 }
 /// A structure denoting expectation of type of taker message.
 /// Used in the [ConnectionState] structure.
@@ -312,7 +313,7 @@ pub fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), MakerErr
                         let mut outgoings = Vec::new();
                         let mut incomings = Vec::new();
                         // Something is broadcasted. Report, Recover and Abort.
-                        log::error!(
+                        log::warn!(
                             "[{}] Contract txs broadcasted!! txid: {} Recovering from ongoing swaps.",
                             maker.config.port,
                             txid,

--- a/src/taker/taker.rs
+++ b/src/taker/taker.rs
@@ -1730,6 +1730,11 @@ impl Taker {
 
         // Start the loop to keep checking for timelock maturity, and spend from the contract asap.
         loop {
+            // Break early if nothing to broadcast.
+            // This happens only when init_first_hop() fails at `NotEnoughMakersInOfferBook`
+            if outgoing_infos.is_empty() {
+                return Ok(());
+            }
             for ((reedemscript, contract), (timelock, timelocked_tx)) in outgoing_infos.iter() {
                 // We have already broadcasted this tx, so skip
                 if timelock_boardcasted.contains(&timelocked_tx) {

--- a/tests/abort3_case3.rs
+++ b/tests/abort3_case3.rs
@@ -1,0 +1,111 @@
+#![cfg(feature = "integration-test")]
+use bitcoin::Amount;
+use coinswap::{
+    maker::{start_maker_server, MakerBehavior},
+    taker::SwapParams,
+    test_framework::*,
+};
+use std::{thread, time::Duration};
+
+/// ABORT 3: Maker Drops After Setup
+/// Case 3: CloseAtHashPreimage
+///
+/// Maker closes connection at hash preimage handling. Funding txs are already broadcasted.
+/// The Maker will loose contract txs fees in that case, so it's not a malice.
+/// Taker waits for the response until timeout. Aborts if the Maker doesn't show up.
+#[tokio::test]
+async fn abort3_case2_close_at_contract_sigs_for_recvr() {
+    // ---- Setup ----
+
+    // 6102 is naughty. And theres not enough makers.
+    let makers_config_map = [
+        (6102, MakerBehavior::CloseAtHashPreimage),
+        (16102, MakerBehavior::Normal),
+    ];
+
+    // Initiate test framework, Makers.
+    // Taker has normal behavior.
+    let (test_framework, taker, makers) =
+        TestFramework::init(None, makers_config_map.into(), None).await;
+
+    // Fund the Taker and Makers with 3 utxos of 0.05 btc each.
+    for _ in 0..3 {
+        let taker_address = taker
+            .write()
+            .unwrap()
+            .get_wallet_mut()
+            .get_next_external_address()
+            .unwrap();
+        test_framework.send_to_address(&taker_address, Amount::from_btc(0.05).unwrap());
+        makers.iter().for_each(|maker| {
+            let maker_addrs = maker
+                .get_wallet()
+                .write()
+                .unwrap()
+                .get_next_external_address()
+                .unwrap();
+            test_framework.send_to_address(&maker_addrs, Amount::from_btc(0.05).unwrap());
+        })
+    }
+
+    // confirm balances
+    test_framework.generate_1_block();
+
+    // ---- Start Servers and attempt Swap ----
+
+    // Start the Maker server threads
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker_clone = maker.clone();
+            let thread = thread::spawn(move || {
+                start_maker_server(maker_clone).unwrap();
+            });
+            thread
+        })
+        .collect::<Vec<_>>();
+
+    // Start swap
+    thread::sleep(Duration::from_secs(20)); // Take a delay because Makers take time to fully setup.
+    let swap_params = SwapParams {
+        send_amount: 500000,
+        maker_count: 2,
+        tx_count: 3,
+        required_confirms: 1,
+        fee_rate: 1000,
+    };
+
+    // Spawn a Taker coinswap thread.
+    let taker_clone = taker.clone();
+    let taker_thread = thread::spawn(move || {
+        taker_clone
+            .write()
+            .unwrap()
+            .send_coinswap(swap_params)
+            .unwrap();
+    });
+
+    // Wait for Taker swap thread to conclude.
+    taker_thread.join().unwrap();
+
+    // Wait for Maker threads to conclude.
+    makers.iter().for_each(|maker| maker.shutdown().unwrap());
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
+
+    // ---- After Swap checks ----
+    // TODO: Do balance asserts
+    // Maker gets banned for being naughty.
+    assert_eq!(
+        "localhost:6102",
+        taker.read().unwrap().get_bad_makers()[0]
+            .address
+            .to_string()
+    );
+
+    // Stop test and clean everything.
+    // comment this line if you want the wallet directory and bitcoind to live. Can be useful for
+    // after test debugging.
+    test_framework.stop();
+}


### PR DESCRIPTION
Adds the Abort3 Case 3 situation where Maker drops after getting the `HashPreimage` message and doesn't revert back with PrivKeys. 

Taker and other Makers recover. 