### PR TITLE
 clippy: Too complex type used in two find functions (#45)

### DIFF
--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -681,7 +681,7 @@ impl Taker {
     async fn send_sigs_init_next_hop(
         &mut self,
         maker_refund_locktime: u16,
-        funding_tx_infos: &Vec<FundingTxInfo>,
+        funding_tx_infos: &[FundingTxInfo],
     ) -> Result<(NextPeerInfo, ContractSigsAsRecvrAndSender), TakerError> {
         let reconnect_timeout_sec = self.config.reconnect_attempt_timeout_sec;
         // Configurable reconnection attempts for testing
@@ -762,7 +762,7 @@ impl Taker {
     async fn send_sigs_init_next_hop_once(
         &mut self,
         maker_refund_locktime: u16,
-        funding_tx_infos: &Vec<FundingTxInfo>,
+        funding_tx_infos: &[FundingTxInfo],
     ) -> Result<(NextPeerInfo, ContractSigsAsRecvrAndSender), TakerError> {
         let this_maker = &self
             .ongoing_swap_state
@@ -846,8 +846,8 @@ impl Taker {
 
             // Struct for information related to the next peer
             let next_maker_info = NextPeerInfoArgs {
-                next_peer_multisig_pubkeys: &next_peer_multisig_pubkeys,
-                next_peer_hashlock_pubkeys: &next_peer_hashlock_pubkeys,
+                next_peer_multisig_pubkeys: next_peer_multisig_pubkeys.clone(),
+                next_peer_hashlock_pubkeys: next_peer_hashlock_pubkeys.clone(),
                 next_maker_refund_locktime: maker_refund_locktime,
                 next_maker_fee_rate: self.ongoing_swap_state.swap_params.fee_rate,
             };
@@ -855,7 +855,11 @@ impl Taker {
                 send_proof_of_funding_and_init_next_hop(
                     &mut socket_reader,
                     &mut socket_writer,
-                    (&this_maker, &funding_tx_infos, &this_maker_contract_txs),
+                    ThisMakerInfo {
+                        this_maker: this_maker.clone(), // Assuming OfferAndAddress is Clone
+                        funding_tx_infos: funding_tx_infos.to_vec(),
+                        this_maker_contract_txs: this_maker_contract_txs.clone(),
+                    },
                     next_maker_info,
                     self.get_preimage_hash(),
                 )

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -851,7 +851,6 @@ impl Taker {
                 next_maker_refund_locktime: maker_refund_locktime,
                 next_maker_fee_rate: self.ongoing_swap_state.swap_params.fee_rate,
             };
-            // Make the function call with the updated arguments
             let (contract_sigs_as_recvr_sender, next_swap_contract_redeemscripts) =
                 send_proof_of_funding_and_init_next_hop(
                     &mut socket_reader,

--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -229,16 +229,18 @@ pub(crate) async fn req_sigs_for_recvr_once<S: SwapCoin>(
 
 // Type for information related to `this maker` consisting of:
 // `this_maker`, `funding_txs_infos`, `this_maker_contract_txs`
-pub type ThisMakerInfo<'a> = (
-    &'a OfferAndAddress,
-    &'a Vec<FundingTxInfo>,
-    &'a Vec<Transaction>,
-);
+#[derive(Clone)]
+pub struct ThisMakerInfo {
+    pub this_maker: OfferAndAddress,
+    pub funding_tx_infos: Vec<FundingTxInfo>,
+    pub this_maker_contract_txs: Vec<Transaction>,
+}
 
-// Struct for information related to the next peer
-pub struct NextPeerInfoArgs<'a> {
-    pub next_peer_multisig_pubkeys: &'a [PublicKey],
-    pub next_peer_hashlock_pubkeys: &'a [PublicKey],
+// Type for information related to the next peer
+#[derive(Clone)]
+pub struct NextPeerInfoArgs {
+    pub next_peer_multisig_pubkeys: Vec<PublicKey>,
+    pub next_peer_hashlock_pubkeys: Vec<PublicKey>,
     pub next_maker_refund_locktime: u16,
     pub next_maker_fee_rate: u64,
 }
@@ -247,8 +249,8 @@ pub struct NextPeerInfoArgs<'a> {
 pub(crate) async fn send_proof_of_funding_and_init_next_hop(
     socket_reader: &mut BufReader<ReadHalf<'_>>,
     socket_writer: &mut WriteHalf<'_>,
-    this_maker_info: ThisMakerInfo<'_>,
-    next_peer_info: NextPeerInfoArgs<'_>,
+    this_maker_info: ThisMakerInfo,
+    next_peer_info: NextPeerInfoArgs,
     hashvalue: Hash160,
 ) -> Result<(ContractSigsAsRecvrAndSender, Vec<ScriptBuf>), TakerError> {
     let NextPeerInfoArgs {
@@ -257,10 +259,16 @@ pub(crate) async fn send_proof_of_funding_and_init_next_hop(
         next_maker_refund_locktime,
         next_maker_fee_rate,
     } = next_peer_info;
+    let ThisMakerInfo {
+        this_maker: _,
+        funding_tx_infos: _,
+        this_maker_contract_txs: _,
+    } = this_maker_info;
+
     send_message(
         socket_writer,
         &TakerToMakerMessage::RespProofOfFunding(ProofOfFunding {
-            confirmed_funding_txes: this_maker_info.1.clone(),
+            confirmed_funding_txes: this_maker_info.funding_tx_infos.clone(),
             next_coinswap_info: next_peer_multisig_pubkeys
                 .iter()
                 .zip(next_peer_hashlock_pubkeys.iter())
@@ -278,9 +286,9 @@ pub(crate) async fn send_proof_of_funding_and_init_next_hop(
     .await?;
     let contract_sigs_as_recvr_and_sender = match read_message(socket_reader).await {
         Ok(MakerToTakerMessage::ReqContractSigsAsRecvrAndSender(m)) => {
-            if m.receivers_contract_txs.len() != this_maker_info.1.len() {
+            if m.receivers_contract_txs.len() != this_maker_info.funding_tx_infos.len() {
                 return Err(ProtocolError::WrongNumOfContractTxs {
-                    expected: this_maker_info.1.len(),
+                    expected: this_maker_info.funding_tx_infos.len(),
                     received: m.receivers_contract_txs.len(),
                 }
                 .into());
@@ -305,7 +313,7 @@ pub(crate) async fn send_proof_of_funding_and_init_next_hop(
     };
 
     let funding_tx_values = this_maker_info
-        .1
+        .funding_tx_infos
         .iter()
         .map(|funding_info| {
             let funding_output_index =
@@ -327,9 +335,9 @@ pub(crate) async fn send_proof_of_funding_and_init_next_hop(
         .map(|i| i.funding_amount)
         .sum::<u64>();
     let coinswap_fees = calculate_coinswap_fee(
-        this_maker_info.0.offer.absolute_fee_sat,
-        this_maker_info.0.offer.amount_relative_fee_ppb,
-        this_maker_info.0.offer.time_relative_fee_ppb,
+        this_maker_info.this_maker.offer.absolute_fee_sat,
+        this_maker_info.this_maker.offer.amount_relative_fee_ppb,
+        this_maker_info.this_maker.offer.time_relative_fee_ppb,
         this_amount,
         1, //time_in_blocks just 1 for now
     );
@@ -356,8 +364,13 @@ pub(crate) async fn send_proof_of_funding_and_init_next_hop(
         contract_sigs_as_recvr_and_sender
             .receivers_contract_txs
             .iter()
-            .zip(this_maker_info.2.iter())
-            .zip(this_maker_info.1.iter().map(|fi| &fi.contract_redeemscript))
+            .zip(this_maker_info.this_maker_contract_txs.iter())
+            .zip(
+                this_maker_info
+                    .funding_tx_infos
+                    .iter()
+                    .map(|fi| &fi.contract_redeemscript),
+            )
     {
         validate_contract_tx(
             receivers_contract_tx,


### PR DESCRIPTION
Aims to fix #45

The issue was a multi-parter:
- [X] 2 functions' return list was too complex (fixed)
- [X] 1 function's argument list was too complex (fixed)
- [X] Update that function's instance in another file (fixed)

### Result:
Respective clippy warnings gone.
![2023-11-17-01 57 18-screenshot](https://github.com/utxo-teleport/teleport-transactions/assets/38693805/4f1999a4-147a-4394-8fe4-9af688f68e7a)
