### PR TITLE
docs: file names corrections, syntax highlighting, formatting, other minor ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ src/
 tests/
 ```
 
-- `taker`: Contains Taker-related behaviors, with core logic in `src/taker/api.rs`. **Takers** manage most protocol logic, while **Makers** play a relatively passive role.
+- `taker`: Contains Taker-related behaviors, with core logic in `src/taker/api.rs`. Takers manage most protocol logic, while Makers play a relatively passive role.
 - `maker`: Encompasses Maker-specific logic.
 - `wallet`: Manages wallet-related operations, including storage and blockchain interaction.
 - `market`: Handles market-related logic, where Makers post their offers.

--- a/README.md
+++ b/README.md
@@ -15,20 +15,18 @@
 
 ## About
 
-Teleport Transactions is a rust implementation of a variant of atomic-swap protocol, using HTLCs on Bitcoin.
+Teleport Transactions is a rust implementation of a variant of atomic-swap protocol, using HTLCs on Bitcoin. Read more at:
 
-Mailing list post: [here](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-October/018221.html)
-
-Detailed design, [here](https://gist.github.com/chris-belcher/9144bd57a91c194e332fb5ca371d0964)
-
-Developer's Doc: [here](/docs/developer_resources.md)
-
-Run Demo: [here](/docs/run_teleport.md)
+* [Mailing list post](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-October/018221.html)
+* [Detailed design](https://gist.github.com/chris-belcher/9144bd57a91c194e332fb5ca371d0964)
+* [Developer's resources](/docs/developer_resources.md)
+* [Run demo](/docs/run_teleport.md)
 
 ## Architecture
 
-The project is divided into distinct modules, each focused on specific functionalities: Below is the folder structure:
-```bash
+The project is divided into distinct modules, each focused on specific functionalities. The project directory-tree is given below:
+
+```console
 docs/
 src/
 ├─ bin/
@@ -41,7 +39,8 @@ src/
 ├─ watchtower/
 tests/
 ```
-- `taker`: Contains Taker-related behaviors, with core logic in `src/taker/taker.rs`. Takers manage most protocol logic, while Makers play a relatively passive role.
+
+- `taker`: Contains Taker-related behaviors, with core logic in `src/taker/api.rs`. **Takers** manage most protocol logic, while **Makers** play a relatively passive role.
 - `maker`: Encompasses Maker-specific logic.
 - `wallet`: Manages wallet-related operations, including storage and blockchain interaction.
 - `market`: Handles market-related logic, where Makers post their offers.
@@ -53,27 +52,29 @@ tests/
 
 The project follows the standard Rust build workflow and generates a CLI app named `teleport`.
 
-```sh
-cargo build
+```console
+$ cargo build
 ```
 
 The project includes both unit and integration tests. The integration tests simulates various edge cases of the coinswap protocol.
 
 To run the unit tests:
-```sh
-cargo test
+
+```console
+$ cargo test
 ```
 
-To run the integration tests, `--features integration-test` must be enabled. Run integration tests with:
+To run the integration tests, `--features integration-test` flag must be enabled. Run integration tests with:
 
-```sh
-cargo test --features integration-test
+```console
+$ cargo test --features integration-test
 ```
-To print out logs on the tests, set the `RUST_LOG` env variable to either `info`, `warn`, `error`
 
-For manual swaps using the `teleport` app, follow the instructions in [run_coinswap](./docs/run_teleport.md).
+To print out logs on the tests, set the `RUST_LOG` env variable to either `info`, `warn` or `error`.
 
-For in-depth developer documentation on protocol workflow and implementation, consult [developer_resources](./docs/developer_resources.md).
+For manual swaps using the `teleport` app, follow the instructions in [Run Teleport](./docs/run_teleport.md).
+
+For in-depth developer documentation on protocol workflow and implementation, consult [Developer's Resources](./docs/developer_resources.md).
 
 ## Project Status
 
@@ -84,29 +85,30 @@ If you're interested in contributing to the project, explore the [open issues](h
 ## Roadmap
 
 ### V 0.1.0
-- [x] Basic protocol workflow with integration tests.
-- [x] Modularize protocol components.
-- [x] Refine logging information.
-- [x] Abort 1: Taker aborts after setup. Makers identify this, and gets their fund back via contract tx.
-- [x] Abort 2: One Maker aborts **before setup**. Taker retaliates by banning the maker, moving on with other makers, if it can't find enough makers, then recovering via contract transactions.
-  - [x] Case 1: Maker drops **before** sending sender's signature. Taker tries with another Maker and moves on.
-  - [x] Case 2: Maker drops **before** sending sender's signature. Taker doesn't have any new Maker. Recovers from swap.
-  - [x] Case 3: Maker drops **after** sending sender's signatures. Taker doesn't have any new Maker. Recovers from swap.
-- [x] Build a flexible Test-Framework with `bitcoind` backend.
-- [x] Abort 3: Maker aborts **after setup**. Taker and other Makers identify this and recovers back via contract tx. Taker bans the aborting Maker's fidelity bond.
-  - [x] Case1: Maker Drops at `ContractSigsForRecvrAndSender`. Does not broadcasts the funding txs. Taker and Other Maker recovers. Maker gets banned.
-  - [x] Case2: Maker drops at `ContractSigsForRecvr` after broadcasting funding txs. Taker and other Makers recover. Maker gets banned.
-  - [x] Case3L Maker Drops at `HashPreimage` message and doesn't respond back with privkeys. Taker and other Maker recovers. Maker gets banned.
-- [x] Malice 1: Taker broadcasts contract immaturely. Other Makers identify this, get their funds back via contract tx.
-- [x] Malice 2: One of the Makers broadcast contract immaturely. The Taker identify this, bans the Maker's fidelity bond, other Makers get back funds via contract tx.
-- [x] Fix all clippy warnings.
-- [x] Implement configuration file i/o support for Takers and Makers.
+
+- [X] Basic protocol workflow with integration tests.
+- [X] Modularize protocol components.
+- [X] Refine logging information.
+- [X] Abort 1: Taker aborts after setup. Makers identify this, and gets their fund back via contract tx.
+- [X] Abort 2: One Maker aborts **before setup**. Taker retaliates by banning the maker, moving on with other makers, if it can't find enough makers, then recovering via contract transactions.
+  - [X] Case 1: Maker drops **before** sending sender's signature. Taker tries with another Maker and moves on.
+  - [X] Case 2: Maker drops **before** sending sender's signature. Taker doesn't have any new Maker. Recovers from swap.
+  - [X] Case 3: Maker drops **after** sending sender's signatures. Taker doesn't have any new Maker. Recovers from swap.
+- [X] Build a flexible Test-Framework with `bitcoind` backend.
+- [X] Abort 3: Maker aborts **after setup**. Taker and other Makers identify this and recovers back via contract tx. Taker bans the aborting Maker's fidelity bond.
+  - [X] Case 1: Maker Drops at `ContractSigsForRecvrAndSender`. Does not broadcasts the funding txs. Taker and Other Maker recovers. Maker gets banned.
+  - [X] Case 2: Maker drops at `ContractSigsForRecvr` after broadcasting funding txs. Taker and other Makers recover. Maker gets banned.
+  - [X] Case 3: Maker Drops at `HashPreimage` message and doesn't respond back with privkeys. Taker and other Maker recovers. Maker gets banned.
+- [X] Malice 1: Taker broadcasts contract immaturely. Other Makers identify this, get their funds back via contract tx.
+- [X] Malice 2: One of the Makers broadcast contract immaturely. The Taker identify this, bans the Maker's fidelity bond, other Makers get back funds via contract tx.
+- [X] Fix all clippy warnings.
 - [ ] Complete all unit tests in modules.
-- [ ] Achieve >80% crate level test coverage ratio. (including integration tests)
+- [ ] Achieve >80% crate level test coverage ratio (including integration tests).
+- [ ] Implement configuration file i/o support for Takers and Makers.
 - [ ] Clean up and integrate fidelity bonds with maker banning.
 - [ ] Switch to binary encoding for wallet data storage and network messages.
 - [ ] Make tor detectable and connectable by default for Maker and Taker. And Tor configs to their config lists.
-- [ ] Sketch a simple `AddressBook` server. Tor must. This is  for MVP. Later on we will move to more decentralized address server architecture.
+- [ ] Sketch a simple `AddressBook` server. Tor must. This is for MVP. Later on we will move to more decentralized address server architecture.
 - [ ] Turn maker server into a `makerd` binary, and a `maker-cli` rpc controller app, with MVP API.
 - [ ] Finalize the Taker API for downstream wallet integration.
 - [ ] Develop an example web Taker client, with a downstream wallet.
@@ -114,11 +116,12 @@ If you're interested in contributing to the project, explore the [open issues](h
 - [ ] Release V 0.1.0 in Signet for beta testing.
 
 ### V 0.1.*
+
 - [ ] Implement UTXO merging and branch-out via swap for improved UTXO management.
 - [ ] Describe contract and funding transactions via miniscript, using BDK for wallet management.
 - [ ] Enable wallet syncing via CBF (BIP157/158).
 - [ ] Transition to taproot outputs for the entire protocol, enhancing anonymity and obfuscating contract transactions.
-- [ ] Optional Payjoin integration via coinswap.
+- [ ] Optional: Payjoin integration via coinswap.
 - [ ] Implement customizable wallet data storage (SQLite, Postgres).
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ tests/
 - `watchtower`: Provides a Taker-offloadable watchtower implementation for monitoring contract transactions.
 - `scripts`: Offers simple scripts to utilize library APIs in the `teleport` app.
 - `bin`: Houses deployed project binaries.
+- `protocol`: Contains utility functions, error handling, and messages for protocol communication.
 
 ## Build and Run
 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ If you're interested in contributing to the project, explore the [open issues](h
 - [X] Malice 1: Taker broadcasts contract immaturely. Other Makers identify this, get their funds back via contract tx.
 - [X] Malice 2: One of the Makers broadcast contract immaturely. The Taker identify this, bans the Maker's fidelity bond, other Makers get back funds via contract tx.
 - [X] Fix all clippy warnings.
+- [x] Implement configuration file i/o support for Takers and Makers.
 - [ ] Complete all unit tests in modules.
 - [ ] Achieve >80% crate level test coverage ratio (including integration tests).
-- [ ] Implement configuration file i/o support for Takers and Makers.
 - [ ] Clean up and integrate fidelity bonds with maker banning.
 - [ ] Switch to binary encoding for wallet data storage and network messages.
 - [ ] Make tor detectable and connectable by default for Maker and Taker. And Tor configs to their config lists.

--- a/docs/developer_resources.md
+++ b/docs/developer_resources.md
@@ -1,7 +1,6 @@
 # Developer resources
 
 <!-- TOC -->
-- [Developer resources](#developer-resources)
   - [What it is](#what-it-is)
   - [How CoinSwap works](#how-coinswap-works)
   - [Notes on architecture](#notes-on-architecture)
@@ -257,9 +256,9 @@ A step-by-step communication sequence for a typical 3-hop-swap with the above me
 
 The `Taker` carries out all the heavy lifting of the protocol. `Maker`s work like simple state-machine responding to `TakerToMakerMessage`s.
 
-`src/taker.rs` : describes the Taker protocol, which is the workflow defined in the [section above](#protocol-between-takers-and-makers). This is the core of the protocol implementation and the most security-critical section of the library.
+`src/taker/api.rs` : describes the Taker protocol, which is the workflow defined in the [section above](#protocol-between-takers-and-makers). This is the core of the protocol implementation and the most security-critical section of the library.
 
-`src/maker.rs` : describes the Maker state-machine. This is a simple server responding to various `TakerToMakerMessage`s depending on a `ConnectionState`. Each `ConnectionState` will have specific messages as "allowed". The Maker will terminate the protocol if a received message doesn't match the allowed messages of a specific state.
+`src/maker/api.rs` : describes the Maker state-machine. This is a simple server responding to various `TakerToMakerMessage`s depending on a `ConnectionState`. Each `ConnectionState` will have specific messages as "allowed". The Maker will terminate the protocol if a received message doesn't match the allowed messages of a specific state.
 
 ## Further reading
 

--- a/docs/run_teleport.md
+++ b/docs/run_teleport.md
@@ -12,11 +12,11 @@
 
 * Create three teleport wallets by running `cargo run -- --wallet-file-name=<wallet-name> generate-wallet` thrice. Instead of `<wallet-name>`, use something like `maker1.teleport`, `maker2.teleport` and `taker.teleport`.
 
-* Use `cargo run -- --wallet-file-name=maker1.teleport get-receive-invoice` to obtain 3 addresses of the maker1 wallet, and send `regtest` bitcoin to each of them (amount 5000000 satoshi or 0.05 BTC in this example). Also do this for the `maker2.teleport` and `taker.teleport` wallets. Get the transactions confirmed.
+* Use `cargo run -- --wallet-file-name=maker1.teleport get-receive-invoice` to obtain 3 addresses of the `maker1` wallet, and send `regtest` bitcoin to each of them (amount 5000000 satoshi or 0.05 BTC in this example). Also do this for the `maker2.teleport` and `taker.teleport` wallets. Get the transactions confirmed.
 
 * Check the wallet balances with `cargo run -- --wallet-file-name=maker1.teleport wallet-balance`. Example:
 
-```
+```console
 $ cargo run -- --wallet-file-name=maker1.teleport wallet-balance
 coin             address                    type   conf    value
 8f6ee5..74e813:0 bcrt1q0vn5....nrjdqljtaq   seed   1       0.05000000 BTC
@@ -26,7 +26,7 @@ coin count = 3
 total balance = 0.15000000 BTC
 ```
 
-```
+```console
 $ cargo run -- --wallet-file-name=maker2.teleport wallet-balance
 coin             address                    type   conf    value
 d33f06..30dd07:0 bcrt1qh6kq....e0tlfrzgxa   seed   1       0.05000000 BTC
@@ -36,7 +36,7 @@ coin count = 3
 total balance = 0.15000000 BTC
 ```
 
-```
+```console
 $ cargo run -- --wallet-file-name=taker.teleport wallet-balance
 coin             address                    type   conf    value
 5f4331..d53f14:0 bcrt1qmflt....q2ucgf2teu   seed   1       0.05000000 BTC
@@ -46,17 +46,17 @@ coin count = 3
 total balance = 0.15000000 BTC
 ```
 
-* On another terminal run a watchtower with `cargo run -- run-watchtower`. You should see the message `Starting teleport watchtower`. In the teleport project, contracts are enforced with one or more watchtowers which are required for the coinswap protocol to be secure against the maker's coins being stolen.
+* On another terminal, run a watchtower with `cargo run -- run-watchtower`. You should see the message `Starting teleport watchtower`. In the teleport project, contracts are enforced with one or more watchtowers which are required for the coinswap protocol to be secured against the maker's coins being stolen.
 
-* On one terminal run a maker server with `cargo run -- --wallet-file-name=maker1.teleport run-yield-generator 6102`. You should see the message `Listening on port 6102`.
+* On one terminal, run a maker server with `cargo run -- --wallet-file-name=maker1.teleport run-yield-generator 6102`. You should see the message `Listening on port 6102`.
 
-* On another terminal run another maker server with `cargo run -- --wallet-file-name=maker2.teleport run-yield-generator 16102`. You should see the message `Listening on port 16102`.
+* On another terminal, run another maker server with `cargo run -- --wallet-file-name=maker2.teleport run-yield-generator 16102`. You should see the message `Listening on port 16102`.
 
 * On another terminal start a coinswap with `cargo run -- --wallet-file-name=taker.teleport do-coinswap 500000`. When you see the terminal messages `waiting for funding transaction to confirm` and `waiting for maker's funding transaction to confirm` then tell `regtest` to generate another block (or just wait if you're using testnet).
 
 * Once you see the message `successfully completed coinswap` on all terminals then check the wallet balance again to see the result of the coinswap. Example:
 
-```
+```console
 $ cargo run -- --wallet-file-name=maker1.teleport wallet-balance
 coin             address                    type   conf    value
 9bfeec..0cc468:0 bcrt1qx49k....9cqqrp3kt0 swapcoin 2       0.00134344 BTC
@@ -69,7 +69,7 @@ coin count = 6
 total balance = 0.15004828 BTC
 ```
 
-```
+```console
 $ cargo run -- --wallet-file-name=maker2.teleport wallet-balance
 coin             address                    type   conf    value
 9d8895..e32645:1 bcrt1qm73u....3h6swyege3 swapcoin 3       0.00046942 BTC
@@ -82,7 +82,7 @@ coin count = 6
 total balance = 0.15004828 BTC
 ```
 
-```
+```console
 $ cargo run -- --wallet-file-name=taker.teleport wallet-balance
 coin             address                    type   conf    value
 9d8895..e32645:0 bcrt1qevgn....6nhl2yswa7   seed   3       0.04951334 BTC
@@ -103,9 +103,9 @@ total balance = 0.14974828 BTC
 
 * You will need Tor running on the same machine, then open the file `src/directory_servers.rs` and make sure the const `TOR_ADDR` has the correct Tor port.
 
-* To see all the advertised offers out there, use the `download-offers` subroutine: `cargo run -- download-offers`:
+* To see all the advertised offers out there, use the `download-offers` subroutine like `cargo run -- download-offers`:
 
-```
+```console
 $ cargo run -- download-offers
 n   maker address                                                          max size     min size     abs fee      amt rel fee  time rel fee minlocktime
 0   5wlgs4tmkc7vmzsqetpjyuz2qbhzydq6d7dotuvbven2cuqjbd2e2oyd.onion:6102    348541       10000        1000         10000000     100000       48
@@ -118,13 +118,14 @@ n   maker address                                                          max s
 
 ## How to recover from a failed coinswap
 
-* CoinSwaps can sometimes fail. Nobody will lose their funds, but they can have their time wasted and have spent miner fees without achieving any privacy gain (or even making their privacy worse, at least until scriptless script contracts are implemented). Everybody is incentivized so that this doesnt happen, and takers are coded to be very persistent in reestablishing a connection with makers before giving up, but sometimes failures will still happen.
+* CoinSwaps can sometimes fail. Nobody will lose their funds, but they can have their time wasted and have spent miner fees without achieving any privacy gain (or even making their privacy worse, at least until scriptless script contracts are implemented). Everybody is incentivized so that this doesn't happen, and takers are coded to be very persistent in re-establishing a connection with makers before giving up, but sometimes failures will still happen.
 
 * The major way that CoinSwaps can fail is if a taker locks up funds in a 2-of-2 multisig with a maker, but then that maker becomes non-responsive and so the CoinSwap doesn't complete. The taker is left with their money in a multisig and has to use their pre-signed contract transaction to get their money back after a timeout. This section explains how to do that.
 
 * Failed or incomplete coinswaps will show up in wallet display in another section: `cargo run -- --wallet-file-name=taker.teleport wallet-balance`. Example:
 
-```
+```console
+$ cargo run -- --wallet-file-name=taker.teleport wallet-balance
 = spendable wallet balance =
 coin             address                    type   conf    value
 9cd867..f80d57:1 bcrt1qgscq....xkxg68mq02   seed   212     0.11103591 BTC
@@ -144,9 +145,10 @@ hashvalue = a4c2fe816bf18afb8b1861138e57a51bd70e29d4
 
 * In this example there is an incomplete coinswap involving three funding transactions, we must take the hashvalue `a4c2fe816bf18afb8b1861138e57a51bd70e29d4` and pass it to the main subroutine: `cargo run -- --wallet-file-name=taker.teleport recover-from-incomplete-coinswap a4c2fe816bf18afb8b1861138e57a51bd70e29d4`.
 
-* Displaying the wallet balance again (`cargo run -- --wallet-file-name=taker.teleport wallet-balance`) after the transactions are broadcast will show the coins in the timelocked contracts section:
+* Displaying the wallet balance again (`cargo run -- --wallet-file-name=taker.teleport wallet-balance`) after the transactions are broadcast will show the coins in the timelocked contracts section. Example:
 
-```
+```console
+$ cargo run -- --wallet-file-name=taker.teleport wallet-balance
 = spendable wallet balance =
 coin             address                    type   conf    value
 9cd867..f80d57:1 bcrt1qgscq....xkxg68mq02   seed   212     0.11103591 BTC


### PR DESCRIPTION
**Summary:**

- [x] `developer_resources.md`:
`src/taker.rs` and `src/maker.rs` doesn't exist. Corrected with `src/taker/api.rs` and `src/maker/api.rs`
- [x] `README.md`:
`src/taker/taker.rs` -> `src/taker/api.rs`
- [x] Syntax highlighting enabled in `run_teleport.md` examples
- [x] Used `console` as it's [better](https://stackoverflow.com/a/49817279/9691448) than using `sh` or `shell` or `bash`
- [x] Other: formatting, typos, grammar fixes

To get a preview of the changes, check [Readme.md](https://github.com/wthrajat/teleport-transactions/blob/readme/README.md) and [run_teleport](https://github.com/wthrajat/teleport-transactions/blob/readme/docs/run_teleport.md) of my fork.