### PR TITLE
[feature] Add default data-dir support

### DIFF
--- a/src/bin/teleport.rs
+++ b/src/bin/teleport.rs
@@ -11,7 +11,7 @@ use coinswap::{
         },
     },
     taker::{SwapParams, Taker, TakerBehavior},
-    utill::setup_logger,
+    utill::{get_data_dir, setup_logger},
     wallet::{
         fidelity::YearAndMonth, CoinToSpend, Destination, DisplayAddressType, SendAmount,
         WalletError,
@@ -161,18 +161,17 @@ fn main() -> Result<(), WalletError> {
                 _ => MakerBehavior::Normal,
             };
             let maker_id = args.wallet_file_name.to_str().expect("bad file name");
-            let maker_path = dirs::home_dir()
-                .expect("expect home dir")
-                .join(".teleport")
-                .join(maker_id); // ex: tests/temp-files/ghytredi/maker6102
+            let data_dir = get_data_dir();
+
             let maker_rpc_config = coinswap::wallet::RPCConfig {
                 wallet_name: maker_id.to_string(),
                 ..Default::default()
             };
             let maker = Arc::new(
                 Maker::init(
-                    &maker_path,
-                    &maker_rpc_config,
+                    Some(&data_dir),
+                    Some(maker_id.into()),
+                    Some(maker_rpc_config),
                     Some(port),
                     maker_special_behavior,
                 )
@@ -189,13 +188,18 @@ fn main() -> Result<(), WalletError> {
             maker_count,
             tx_count,
         } => {
-            let taker_path = dirs::home_dir().expect("home dir expected").join("taker");
+            let data_dir = get_data_dir();
             let taker_rpc_config = coinswap::wallet::RPCConfig {
                 wallet_name: "taker".to_string(),
                 ..Default::default()
             };
-            let mut taker =
-                Taker::init(&taker_path, Some(taker_rpc_config), TakerBehavior::Normal).unwrap();
+            let mut taker = Taker::init(
+                Some(&data_dir),
+                Some("taker".to_string()),
+                Some(taker_rpc_config),
+                TakerBehavior::Normal,
+            )
+            .unwrap();
 
             let swap_params = SwapParams {
                 send_amount,

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -16,7 +16,9 @@ use std::time::Duration;
 
 use crate::{
     protocol::{contract::check_hashvalues_are_equal, messages::ReqContractSigsForSender, Hash160},
-    utill::redeemscript_to_scriptpubkey,
+    utill::{
+        get_config_dir, get_wallet_dir, redeemscript_to_scriptpubkey, seed_phrase_to_unique_id,
+    },
     wallet::{RPCConfig, SwapCoin, WalletSwapCoin},
 };
 
@@ -86,11 +88,21 @@ pub struct Maker {
 }
 
 impl Maker {
-    /// Initialize a Maker structure, with a given wallet file path, rpc configuration,
-    /// listening ort, onion address, wallet and special maker behavior.
+    /// Initializes a Maker structure.
+    ///
+    /// The `data_dir` and `wallet_name_path` can be selectively provided to perform wallet load/creation.
+    /// data_dir: Some(value) = Create data directory at given value.
+    /// data_dir: None = Create default data directory. For linux "~/.coinswap"
+    /// wallet_file_name: Some(value) = Try loading wallet file with name "value". If doesn't exist create a new wallet with the given name.
+    /// wallet_file_name: None = Create a new default wallet file. Ex: "9d317f933-maker".
+    ///
+    /// rpc_conf: None = Use the default [RPCConfig].
+    ///
+    /// behavior: Defines special Maker behavior. Only applicable in integration-tests.
     pub fn init(
-        wallet_file: &PathBuf,
-        rpc_config: &RPCConfig,
+        data_dir: Option<&PathBuf>,
+        wallet_file_name: Option<String>,
+        rpc_config: Option<RPCConfig>,
         port: Option<u16>,
         behavior: MakerBehavior,
     ) -> Result<Self, MakerError> {
@@ -101,21 +113,59 @@ impl Maker {
             MakerBehavior::Normal
         };
 
-        // Load if exists, else create new.
-        let mut wallet = if wallet_file.exists() {
-            Wallet::load(rpc_config, wallet_file)?
+        // Get provided data directory or the default data directory.
+        let (wallets_dir, config_dir) = data_dir
+            .map_or((get_wallet_dir(), get_config_dir()), |d| {
+                (d.join("wallets"), d.join("configs"))
+            });
+
+        let mut rpc_config = rpc_config.unwrap_or_default();
+
+        // Load/Create wallet depending on if a wallet with wallet_file_name exists.
+        let mut wallet = if let Some(file_name) = wallet_file_name {
+            let wallet_path = wallets_dir.join(&file_name);
+            rpc_config.wallet_name = file_name;
+            if wallet_path.exists() {
+                // Try loading wallet
+                let wallet = Wallet::load(&rpc_config, &wallet_path)?;
+                log::info!("Wallet file at {:?} successfully loaded.", wallet_path);
+                wallet
+            } else {
+                // Create wallet with the given name.
+                let mnemonic = Mnemonic::generate(12).unwrap();
+                let seedphrase = mnemonic.to_string();
+
+                let wallet = Wallet::init(&wallet_path, &rpc_config, seedphrase, "".to_string())?;
+                log::info!("New Wallet created at : {:?}", wallet_path);
+                wallet
+            }
         } else {
+            // Create default wallet
             let mnemonic = Mnemonic::generate(12).unwrap();
             let seedphrase = mnemonic.to_string();
-            Wallet::init(wallet_file, rpc_config, seedphrase, "".to_string())?
+
+            // File names are unique for default wallets
+            let unique_id = seed_phrase_to_unique_id(&seedphrase);
+            let file_name = unique_id + "-maker";
+            let wallet_path = wallets_dir.join(&file_name);
+            rpc_config.wallet_name = file_name;
+
+            let wallet = Wallet::init(&wallet_path, &rpc_config, seedphrase, "".to_string())?;
+            log::info!("New Wallet created at : {:?}", wallet_path);
+            wallet
         };
+
+        // If config file doesn't exist, default config will be loaded.
+        let mut config = MakerConfig::new(Some(&config_dir.join("maker.toml")))?;
+
+        if let Some(port) = port {
+            config.port = port;
+        }
+
         wallet.sync()?;
         Ok(Self {
             behavior,
-            config: MakerConfig {
-                port: port.unwrap_or_default(),
-                ..MakerConfig::new(None)?
-            },
+            config,
             wallet: RwLock::new(wallet),
             shutdown: RwLock::new(false),
             connection_state: Mutex::new(HashMap::new()),

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -144,12 +144,21 @@ pub struct Taker {
 impl Taker {
     // ######## MAIN PUBLIC INTERFACE ############
 
-    /// Initialize a Taker with a wallet, optional RPC and Wallet Mode.
-    /// If RPC config isn't provide, default RPC configuration will be used.
-    /// WalletMode is used to control wallet operation mode, Normal or Testing, Defaults to Normal.
-    /// Errors if RPC connection fails.
+    /// Initializes a Taker structure.
+    ///
+    /// The `data_dir` and `wallet_name_path` can be selectively provided to perform wallet load/creation.
+    ///
+    /// data_dir: Some(value) = Create data directory at given value.
+    /// data_dir: None = Create default data directory. For linux "~/.coinswap"
+    /// wallet_file_name: Some(value) = Try loading wallet file with name "value". If doesn't exist create a new wallet with the given name.
+    /// wallet_file_name: None = Create a new default wallet file. Ex: "9d317f933-taker".
+    ///
+    /// rpc_conf: None = Use the default [RPCConfig].
+    ///
+    /// behavior: Defines special Maker behavior. Only applicable in integration-tests.
     pub fn init(
-        wallet_file: &PathBuf,
+        data_dir: Option<&PathBuf>,
+        wallet_file_name: Option<String>,
         rpc_config: Option<RPCConfig>,
         behavior: TakerBehavior,
     ) -> Result<Taker, TakerError> {
@@ -160,24 +169,56 @@ impl Taker {
             TakerBehavior::Normal
         };
 
-        let mut wallet = if wallet_file.exists() {
-            Wallet::load(&rpc_config.unwrap_or_default(), wallet_file)?
+        // Get provided data directory or the default data directory.
+        let (wallets_dir, config_dir) = data_dir
+            .map_or((get_wallet_dir(), get_config_dir()), |d| {
+                (d.join("wallets"), d.join("configs"))
+            });
+
+        let mut rpc_config = rpc_config.unwrap_or_default();
+
+        // Load/Create wallet depending on if a wallet with wallet_file_name exists.
+        let mut wallet = if let Some(file_name) = wallet_file_name {
+            let wallet_path = wallets_dir.join(&file_name);
+            rpc_config.wallet_name = file_name;
+            if wallet_path.exists() {
+                // Try loading wallet
+                let wallet = Wallet::load(&rpc_config, &wallet_path)?;
+                log::info!("Wallet file at {:?} successfully loaded.", wallet_path);
+                wallet
+            } else {
+                // Create wallet with the given name.
+                let mnemonic = Mnemonic::generate(12).unwrap();
+                let seedphrase = mnemonic.to_string();
+
+                let wallet = Wallet::init(&wallet_path, &rpc_config, seedphrase, "".to_string())?;
+                log::info!("New Wallet created at : {:?}", wallet_path);
+                wallet
+            }
         } else {
+            // Create default wallet
             let mnemonic = Mnemonic::generate(12).unwrap();
             let seedphrase = mnemonic.to_string();
-            Wallet::init(
-                wallet_file,
-                &rpc_config.unwrap_or_default(),
-                seedphrase,
-                "".to_string(),
-            )?
+
+            // File names are unique for default wallets
+            let unique_id = seed_phrase_to_unique_id(&seedphrase);
+            let file_name = unique_id + "-taker";
+            let wallet_path = wallets_dir.join(&file_name);
+            rpc_config.wallet_name = file_name;
+
+            let wallet = Wallet::init(&wallet_path, &rpc_config, seedphrase, "".to_string())?;
+            log::info!("New Wallet created at : {:?}", wallet_path);
+            wallet
         };
+
+        // If config file doesn't exist, default config will be loaded.
+        let config = TakerConfig::new(Some(&config_dir.join("taker.toml")))?;
 
         wallet.sync()?;
 
         Ok(Self {
             wallet,
-            config: TakerConfig::default(),
+            config,
             offerbook: OfferBook::default(),
             ongoing_swap_state: OngoingSwapState::default(),
             behavior,

--- a/src/test_framework.rs
+++ b/src/test_framework.rs
@@ -95,12 +95,11 @@ impl TestFramework {
         let rpc_config = RPCConfig::from(test_framework.as_ref());
 
         // Create the Taker.
-        let taker_path = temp_dir.join("taker");
-        let mut taker_rpc_config = rpc_config.clone();
-        taker_rpc_config.wallet_name = "taker".to_string();
+        let taker_rpc_config = rpc_config.clone();
         let taker = Arc::new(RwLock::new(
             Taker::init(
-                &taker_path,
+                Some(&temp_dir),
+                None,
                 Some(taker_rpc_config),
                 taker_behavior.unwrap_or_default(),
             )
@@ -112,12 +111,17 @@ impl TestFramework {
             .iter()
             .map(|(port, behavior)| {
                 let maker_id = "maker".to_string() + &port.to_string(); // ex: "maker6102"
-                let maker_path = temp_dir.join(&maker_id); // ex: tests/temp-files/ghytredi/maker6102
-                let mut maker_rpc_config = rpc_config.clone();
-                maker_rpc_config.wallet_name = maker_id;
+                let maker_rpc_config = rpc_config.clone();
                 thread::sleep(Duration::from_secs(5)); // Sleep for some time avoid resource unavailable error.
                 Arc::new(
-                    Maker::init(&maker_path, &maker_rpc_config, Some(*port), *behavior).unwrap(),
+                    Maker::init(
+                        Some(&temp_dir),
+                        Some(maker_id),
+                        Some(maker_rpc_config),
+                        Some(*port),
+                        *behavior,
+                    )
+                    .unwrap(),
                 )
             })
             .collect::<Vec<_>>();

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -4,7 +4,7 @@ use std::{io::ErrorKind, path::PathBuf, sync::Once};
 
 use bitcoin::{
     address::{WitnessProgram, WitnessVersion},
-    hashes::Hash,
+    hashes::{sha256, Hash},
     script::PushBytesBuf,
     secp256k1::{
         rand::{rngs::OsRng, RngCore},
@@ -42,6 +42,33 @@ pub fn str_to_bitcoin_network(net_str: &str) -> Network {
         "regtest" => Network::Regtest,
         _ => panic!("unknown network: {}", net_str),
     }
+}
+
+/// Get the system specific home directory.
+pub fn get_home_dir() -> PathBuf {
+    dirs::home_dir().expect("home directory expected")
+}
+
+/// Get the default data directory. `~/.coinswap`.
+pub fn get_data_dir() -> PathBuf {
+    get_home_dir().join(".coinswap")
+}
+
+/// Get the default wallets directory. `~/.coinswap/wallets`
+pub fn get_wallet_dir() -> PathBuf {
+    get_data_dir().join("wallets")
+}
+
+/// Get the default configs directory. `~/.coinswap/configs`
+pub fn get_config_dir() -> PathBuf {
+    get_data_dir().join("configs")
+}
+
+/// Generate an unique identifier from the seedphrase.
+pub fn seed_phrase_to_unique_id(seed: &str) -> String {
+    let mut hash = sha256::Hash::hash(seed.as_bytes()).to_string();
+    let _ = hash.split_off(9);
+    hash
 }
 
 /// Setup function that will only run once, even if called multiple times.

--- a/src/wallet/rpc.rs
+++ b/src/wallet/rpc.rs
@@ -28,7 +28,6 @@ pub struct RPCConfig {
     pub wallet_name: String,
 }
 
-const RPC_WALLET: &str = "teleport";
 const RPC_HOSTPORT: &str = "localhost:18443";
 
 impl Default for RPCConfig {
@@ -37,7 +36,7 @@ impl Default for RPCConfig {
             url: RPC_HOSTPORT.to_string(),
             auth: Auth::UserPass("regtestrpcuser".to_string(), "regtestrpcpass".to_string()),
             network: Network::Regtest,
-            wallet_name: RPC_WALLET.to_string(),
+            wallet_name: "random-wallet-name".to_string(),
         }
     }
 }
@@ -81,7 +80,7 @@ impl Wallet {
     /// Sync the wallet with bitcoind. Saves to disk.
     pub fn sync(&mut self) -> Result<(), WalletError> {
         // Create or load the watch-only bitcoin core wallet
-        let wallet_name = &self.store.wallet_name;
+        let wallet_name = &self.store.file_name;
         if self.rpc.list_wallets()?.contains(wallet_name) {
             log::info!("wallet already loaded: {}", wallet_name);
         } else if list_wallet_dir(&self.rpc)?.contains(wallet_name) {

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -16,7 +16,7 @@ const WALLET_FILE_VERSION: u32 = 0;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 struct FileData {
-    wallet_name: String,
+    file_name: String,
     version: u32,
     network: Network,
     seedphrase: String,
@@ -30,7 +30,7 @@ struct FileData {
 #[derive(Debug, PartialEq)]
 pub struct WalletStore {
     // Wallet store name should match the bitcoin core watch-only wallet name
-    pub(crate) wallet_name: String,
+    pub(crate) file_name: String,
     pub(crate) network: Network,
     pub(super) master_key: ExtendedPrivKey,
     pub(super) external_index: u32,
@@ -66,7 +66,7 @@ impl TryFrom<FileData> for WalletStore {
         let timelocked_script_index_map = generate_fidelity_scripts(&xprv);
 
         Ok(Self {
-            wallet_name: file_data.wallet_name,
+            file_name: file_data.file_name,
             network: file_data.network,
             master_key: xprv,
             external_index: file_data.external_index,
@@ -82,13 +82,13 @@ impl TryFrom<FileData> for WalletStore {
 impl WalletStore {
     /// Initialize a store at a path. if path already exists, it will overwrite it.
     pub fn init(
-        wallet_name: String,
+        file_name: String,
         path: &PathBuf,
         network: Network,
         seedphrase: String,
         passphrase: String,
     ) -> Result<Self, WalletError> {
-        FileData::init_new_file(path, wallet_name, network, seedphrase, passphrase)?;
+        FileData::init_new_file(path, file_name, network, seedphrase, passphrase)?;
         let store = WalletStore::read_from_disk(path)?;
         Ok(store)
     }
@@ -123,13 +123,13 @@ impl FileData {
     /// Overwrites existing file or create a new one.
     fn init_new_file(
         path: &PathBuf,
-        wallet_name: String,
+        file_name: String,
         network: Network,
         seedphrase: String,
         passphrase: String,
     ) -> Result<(), WalletError> {
         let file_data = Self {
-            wallet_name,
+            file_name,
             version: WALLET_FILE_VERSION,
             network,
             seedphrase,


### PR DESCRIPTION
Fixes #19 

The new default data directory structure is as below.

```console
~/.coinswap/
└── wallets
    ├── 3ae826ba5-taker
    ├── a0fe9813e-maker
```

Default wallet file names start with a unique id. This is derived from `sha256(passphrase)[0..9]`.

`Maker` and `Taker` init APIs are modified to handle various load/creation cases, included in the doc.

This could use a test to assert the init behaviors. But that requires a `bitcoind` backend so this needs to be done in an integration test.

Will be added in a commit later.   