### PR TITLE
rustdoc: api_docs covered

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,16 @@ src/
 ├─ watchtower/
 tests/
 ```
-
-- `taker`: Contains Taker-related behaviors, with core logic in `src/taker/api.rs`. Takers manage most protocol logic, while Makers play a relatively passive role.
-- `maker`: Encompasses Maker-specific logic.
-- `wallet`: Manages wallet-related operations, including storage and blockchain interaction.
-- `market`: Handles market-related logic, where Makers post their offers.
-- `watchtower`: Provides a Taker-offloadable watchtower implementation for monitoring contract transactions.
-- `scripts`: Offers simple scripts to utilize library APIs in the `teleport` app.
-- `bin`: Houses deployed project binaries.
-- `protocol`: Contains utility functions, error handling, and messages for protocol communication.
+| Module | Function |
+| ------ | -------- |
+| `taker` | Contains Taker-related behaviors, with core logic in `src/taker/api.rs`. Takers manage most protocol logic, while Makers play a relatively passive role.|
+| `maker` | Encompasses Maker-specific logic. |
+| `wallet` | Manages wallet-related operations, including storage and blockchain interaction. |
+| `market` | Handles market-related logic, where Makers post their offers. |
+| `watchtower` | Provides a Taker-offloadable watchtower implementation for monitoring contract transactions. |
+| `scripts` | Offers simple scripts to utilize library APIs in the `teleport` app. |
+| `bin` | Houses deployed project binaries. |
+| `protocol` | Contains utility functions, error handling, and messages for protocol communication. |
 
 ## Build and Run
 

--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ src/
 tests/
 ```
 | Module | Function |
-| ------ | -------- |
-| `taker` | Contains Taker-related behaviors, with core logic in `src/taker/api.rs`. Takers manage most protocol logic, while Makers play a relatively passive role.|
-| `maker` | Encompasses Maker-specific logic. |
-| `wallet` | Manages wallet-related operations, including storage and blockchain interaction. |
-| `market` | Handles market-related logic, where Makers post their offers. |
-| `watchtower` | Provides a Taker-offloadable watchtower implementation for monitoring contract transactions. |
-| `scripts` | Offers simple scripts to utilize library APIs in the `teleport` app. |
-| `bin` | Houses deployed project binaries. |
-| `protocol` | Contains utility functions, error handling, and messages for protocol communication. |
+| :---: | --- |
+| **`taker`** | Contains Taker-related behaviors, with core logic in `src/taker/api.rs`. Takers manage most protocol logic, while Makers play a relatively passive role.|
+| **`maker`** | Encompasses Maker-specific logic. |
+| **`wallet`** | Manages wallet-related operations, including storage and blockchain interaction. |
+| **`market`** | Handles market-related logic, where Makers post their offers. |
+| **`watchtower`** | Provides a Taker-offloadable watchtower implementation for monitoring contract transactions. |
+| **`scripts`** | Offers simple scripts to utilize library APIs in the `teleport` app. |
+| **`bin`** | Houses deployed project binaries. |
+| **`protocol`** | Contains utility functions, error handling, and messages for protocol communication. |
 
 ## Build and Run
 

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -1,6 +1,6 @@
 //! The Maker API.
 //!
-//! This module defines the core functionality of the Maker in a swap protocol implementation.
+//! Defines the core functionality of the Maker in a swap protocol implementation.
 //! It includes structures for managing maker behavior, connection states, and recovery from swap events.
 //! The module provides methods for initializing a Maker, verifying swap messages, and monitoring
 //! contract broadcasts and handle idle Taker connections. Additionally, it handles recovery by broadcasting
@@ -41,7 +41,7 @@ use crate::{
 
 use super::{config::MakerConfig, error::MakerError};
 
-// MakerBehavior enum is used to configure the maker for testing purposes.
+/// Used to configure the maker for testing purposes.
 #[derive(Debug, Clone, Copy)]
 pub enum MakerBehavior {
     Normal,
@@ -52,9 +52,9 @@ pub enum MakerBehavior {
     CloseAtHashPreimage,
     BroadcastContractAfterSetup,
 }
-/// A structure denoting expectation of type of taker message.
-/// Used in the [ConnectionState] structure.
-///
+
+/// Expected messages for the taker in the context of [ConnectionState] structure.
+/// 
 /// If the received message doesn't match expected message,
 /// a protocol error will be returned.
 #[derive(Debug, Default, PartialEq, Clone)]
@@ -70,8 +70,7 @@ pub enum ExpectedMessage {
     PrivateKeyHandover,
 }
 
-/// ConnectionState structure maintains the state of a connection,
-/// including the list of swapcoins and the next expected message.
+/// Maintains the state of a connection, including the list of swapcoins and the next expected message.
 #[derive(Debug, Default, Clone)]
 pub struct ConnectionState {
     pub allowed_message: ExpectedMessage,
@@ -80,7 +79,7 @@ pub struct ConnectionState {
     pub pending_funding_txes: Vec<Transaction>,
 }
 
-/// The Maker structure represents the maker in the swap protocol.
+/// Represents the maker in the swap protocol.
 pub struct Maker {
     /// Defines special maker behavior, only applicable for testing
     pub behavior: MakerBehavior,
@@ -289,8 +288,10 @@ impl Maker {
     }
 }
 
-/// Constantly keep checking for contract transactions in the bitcoin network for all
-/// unsettled swap. If any one of the is ever observed, run the recovery routine.
+/// Constantly checks for contract transactions in the bitcoin network for all
+/// unsettled swap.
+/// 
+/// If any one of the is ever observed, run the recovery routine.
 pub fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), MakerError> {
     let mut failed_swap_ip = Vec::new();
     loop {
@@ -403,6 +404,7 @@ pub fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), MakerErr
 }
 
 /// Check that if any Taker connection went idle.
+/// 
 /// If a connection remains idle for more than idle timeout time, thats a potential DOS attack.
 /// Broadcast the contract transactions and claim funds via timelock.
 pub fn check_for_idle_states(maker: Arc<Maker>) -> Result<(), MakerError> {

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -56,7 +56,7 @@ pub enum MakerBehavior {
 }
 
 /// Expected messages for the taker in the context of [ConnectionState] structure.
-/// 
+///
 /// If the received message doesn't match expected message,
 /// a protocol error will be returned.
 #[derive(Debug, Default, PartialEq, Clone)]
@@ -187,6 +187,7 @@ impl Maker {
         Ok(())
     }
 
+    /// Returns a reference to the Maker's wallet.
     pub fn get_wallet(&self) -> &RwLock<Wallet> {
         &self.wallet
     }
@@ -340,7 +341,7 @@ impl Maker {
 
 /// Constantly checks for contract transactions in the bitcoin network for all
 /// unsettled swap.
-/// 
+///
 /// If any one of the is ever observed, run the recovery routine.
 pub fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), MakerError> {
     let mut failed_swap_ip = Vec::new();
@@ -454,7 +455,7 @@ pub fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), MakerErr
 }
 
 /// Check that if any Taker connection went idle.
-/// 
+///
 /// If a connection remains idle for more than idle timeout time, thats a potential DOS attack.
 /// Broadcast the contract transactions and claim funds via timelock.
 pub fn check_for_idle_states(maker: Arc<Maker>) -> Result<(), MakerError> {
@@ -537,8 +538,8 @@ pub fn check_for_idle_states(maker: Arc<Maker>) -> Result<(), MakerError> {
     Ok(())
 }
 
-/// Broadcast Incoming and Outgoing Contract transactions. Broadcast timelock transactions after maturity.
-/// remove contract transactions from the wallet.
+/// Broadcast Incoming and Outgoing Contract transactions & timelock transactions after maturity.
+/// Remove contract transactions from the wallet.
 pub fn recover_from_swap(
     maker: Arc<Maker>,
     // Tuple of ((Multisig_reedemscript, Contract Tx), (Timelock, Timelock Tx))

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -162,7 +162,7 @@ mod tests {
     fn remove_temp_config(path: &PathBuf) {
         fs::remove_file(path).unwrap();
     }
-    
+
     #[test]
     fn test_valid_config() {
         let contents = r#"

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -162,7 +162,7 @@ mod tests {
     fn remove_temp_config(path: &PathBuf) {
         fs::remove_file(path).unwrap();
     }
-
+    
     #[test]
     fn test_valid_config() {
         let contents = r#"

--- a/src/maker/error.rs
+++ b/src/maker/error.rs
@@ -6,6 +6,7 @@ use bitcoin::secp256k1;
 
 use crate::{protocol::error::ContractError, wallet::WalletError};
 
+/// Enum to handle Maker related errors.
 #[derive(Debug)]
 pub enum MakerError {
     IO(std::io::Error),

--- a/src/maker/mod.rs
+++ b/src/maker/mod.rs
@@ -1,8 +1,8 @@
 //! Defines a Coinswap Maker Server.
 //!
 //! Handles connections, communication with takers, various aspects of the
-//! Maker's behavior, includes functionalities such as checking for new connections, handling messages from takers,
-//! refreshing offer caches, and interacting with the Bitcoin node.
+//! Maker's behavior, includes functionalities such as checking for new connections,
+//! handling messages from takers, refreshing offer caches, and interacting with the Bitcoin node.
 
 pub mod api;
 pub mod config;
@@ -40,9 +40,8 @@ use crate::{
 
 use crate::maker::error::MakerError;
 
-/// This function initializes and starts the Maker server, handling connections and various
+/// Initializes and starts the Maker server, handling connections and various
 /// aspects of the Maker's behavior.
-
 #[tokio::main]
 pub async fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
     log::debug!("Running maker with special behavior = {:?}", maker.behavior);

--- a/src/market/directory.rs
+++ b/src/market/directory.rs
@@ -4,7 +4,8 @@
 //! maker addresses from directory servers, post maker addresses to directory servers,
 //! and defines constants such as Tor addresses and directory server addresses.
 
-// configure this with your own TOR port
+/// Represents the Tor address and port configuration.
+// It should be set to your specific Tor address and port.
 pub const TOR_ADDR: &str = "127.0.0.1:9050";
 
 use bitcoin::Network;
@@ -15,6 +16,7 @@ use crate::taker::offers::MakerAddress;
 const DIRECTORY_SERVER_ADDR: &str =
     "zfwo4t5yfuf6epu7rhjbmkr6kiysi6v7kibta4i55zlp4y6xirpcr7qd.onion:8080";
 
+/// Represents errors that can occur during directory server operations.
 #[derive(Debug)]
 pub enum DirectoryServerError {
     Reqwest(reqwest::Error),
@@ -27,6 +29,7 @@ impl From<reqwest::Error> for DirectoryServerError {
     }
 }
 
+/// Converts a `Network` enum variant to its corresponding string representation.
 fn network_enum_to_string(network: Network) -> &'static str {
     match network {
         Network::Bitcoin => "mainnet",
@@ -36,7 +39,7 @@ fn network_enum_to_string(network: Network) -> &'static str {
         _ => todo!(),
     }
 }
-
+/// Asynchronously Synchronize Maker Addresses from Directory Servers.
 pub async fn sync_maker_addresses_from_directory_servers(
     network: Network,
 ) -> Result<Vec<MakerAddress>, DirectoryServerError> {
@@ -73,6 +76,7 @@ pub async fn sync_maker_addresses_from_directory_servers(
     Ok(maker_addresses)
 }
 
+/// Posts a maker's address to directory servers based on the specified network.
 pub async fn post_maker_address_to_directory_servers(
     network: Network,
     address: &str,

--- a/src/protocol/contract.rs
+++ b/src/protocol/contract.rs
@@ -29,19 +29,20 @@ use super::{
     messages::{FundingTxInfo, ProofOfFunding},
 };
 
-//relatively simple handling of miner fees for now, each funding transaction is considered
+// relatively simple handling of miner fees for now, each funding transaction is considered
 // to have the same size, and taker will pay all the maker's miner fees based on that
-//taker will choose what fee rate they will use, and how many funding transactions they want
+// taker will choose what fee rate they will use, and how many funding transactions they want
 // the makers to create
-//this doesnt take into account the different sizes of single-sig, 2of2 multisig or htlc contracts
+// this doesnt take into account the different sizes of single-sig, 2of2 multisig or htlc contracts
 // but all those complications will go away when we move to ecdsa2p and scriptless scripts
 // so theres no point adding complications for something that we'll hopefully get rid of soon
-//this size here is for a tx with 2 p2wpkh outputs, 3 singlesig inputs and 1 2of2 multisig input
+// this size here is for a tx with 2 p2wpkh outputs, 3 singlesig inputs and 1 2of2 multisig input
 // if the maker can get stuff confirmed cheaper than this then they can keep that money
 // if the maker ends up paying more then thats their problem
 // we could avoid this guessing by adding one more round trip to the protocol where the maker
 // calculates exactly how big the transactions will be and then taker knows exactly the miner fee
 // to pay for
+
 pub const FUNDING_TX_VBYTE_SIZE: u64 = 372;
 
 pub fn calculate_coinswap_fee(

--- a/src/protocol/contract.rs
+++ b/src/protocol/contract.rs
@@ -43,8 +43,10 @@ use super::{
 // calculates exactly how big the transactions will be and then taker knows exactly the miner fee
 // to pay for
 
+/// Constant representing the virtual byte size of a funding transaction.
 pub const FUNDING_TX_VBYTE_SIZE: u64 = 372;
 
+/// Calculate the coin swap fee based on various parameters.
 pub fn calculate_coinswap_fee(
     absolute_fee_sat: u64,
     amount_relative_fee_ppb: u64,
@@ -57,6 +59,7 @@ pub fn calculate_coinswap_fee(
         + (time_in_blocks * time_relative_fee_ppb / 1_000_000_000)
 }
 
+/// Apply two signatures to a 2-of-2 multisig spend.
 pub fn apply_two_signatures_to_2of2_multisig_spend(
     key1: &PublicKey,
     key2: &PublicKey,
@@ -83,6 +86,7 @@ pub fn apply_two_signatures_to_2of2_multisig_spend(
     input.witness.push(redeemscript.to_bytes());
 }
 
+/// Create a multisig redeem script for a 2-of-2 setup.
 pub fn create_multisig_redeemscript(key1: &PublicKey, key2: &PublicKey) -> ScriptBuf {
     let builder = Builder::new().push_opcode(all::OP_PUSHNUM_2);
     if key1.inner.serialize()[..] < key2.inner.serialize()[..] {
@@ -95,6 +99,7 @@ pub fn create_multisig_redeemscript(key1: &PublicKey, key2: &PublicKey) -> Scrip
     .into_script()
 }
 
+/// Derive the maker's public key and nonce from a tweakable point.
 pub fn derive_maker_pubkey_and_nonce(
     tweakable_point: &PublicKey,
 ) -> Result<(PublicKey, SecretKey), ContractError> {
@@ -105,6 +110,7 @@ pub fn derive_maker_pubkey_and_nonce(
     Ok((maker_pubkey, nonce))
 }
 
+/// Calculate the public key from a tweakable point and a nonce.
 pub fn calculate_pubkey_from_nonce(
     tweakable_point: &PublicKey,
     nonce: &SecretKey,
@@ -118,6 +124,7 @@ pub fn calculate_pubkey_from_nonce(
     })
 }
 
+/// Find the index of the funding output in the funding transaction.
 pub fn find_funding_output_index(funding_tx_info: &FundingTxInfo) -> Result<u32, ContractError> {
     let multisig_spk = redeemscript_to_scriptpubkey(&funding_tx_info.multisig_redeemscript);
     funding_tx_info
@@ -131,6 +138,7 @@ pub fn find_funding_output_index(funding_tx_info: &FundingTxInfo) -> Result<u32,
         ))
 }
 
+/// Check if the given redeem script is a multisig script.
 pub fn check_reedemscript_is_multisig(redeemscript: &Script) -> Result<(), ContractError> {
     //pattern match to check redeemscript is really a 2of2 multisig
     let mut ms_rs_bytes = redeemscript.to_bytes();
@@ -154,6 +162,7 @@ pub fn check_reedemscript_is_multisig(redeemscript: &Script) -> Result<(), Contr
     }
 }
 
+/// Check if the given multisig redeem script contains the provided public key.
 pub fn check_multisig_has_pubkey(
     redeemscript: &Script,
     tweakable_point: &PublicKey,
@@ -170,6 +179,7 @@ pub fn check_multisig_has_pubkey(
     }
 }
 
+/// Check if the given hashlock redeem script contains the provided public key and nonce.
 pub fn check_hashlock_has_pubkey(
     contract_redeemscript: &Script,
     tweakable_point: &PublicKey,
@@ -186,6 +196,7 @@ pub fn check_hashlock_has_pubkey(
     }
 }
 
+/// Create a contract redeem script for a coinswap transaction.
 #[rustfmt::skip]
 pub fn create_contract_redeemscript(
     pub_hashlock: &PublicKey,
@@ -265,6 +276,7 @@ pub fn create_contract_redeemscript(
 
 //TODO put all these magic numbers in a const or something
 //a better way is to use redeemscript.instructions() like read_locktime_from_contract()
+/// Read the hash value from a contract redeem script.
 pub fn read_hashvalue_from_contract(redeemscript: &Script) -> Result<Hash160, ContractError> {
     if redeemscript.to_bytes().len() < 25 {
         return Err(ContractError::Protocol("contract reedemscript too short"));
@@ -276,7 +288,7 @@ pub fn read_hashvalue_from_contract(redeemscript: &Script) -> Result<Hash160, Co
     )?)
 }
 
-//check that all the contract redeemscripts involve the same hashvalue
+/// Check that all the contract redeemscripts involve the same hashvalue.
 pub fn check_hashvalues_are_equal(message: &ProofOfFunding) -> Result<Hash160, ContractError> {
     let hashvalues = message
         .confirmed_funding_txes
@@ -293,6 +305,7 @@ pub fn check_hashvalues_are_equal(message: &ProofOfFunding) -> Result<Hash160, C
     Ok(hashvalues[0])
 }
 
+/// Read the locktime from a contract redeem script.
 pub fn read_contract_locktime(redeemscript: &Script) -> Result<u16, ContractError> {
     match redeemscript
         .instructions()
@@ -325,6 +338,7 @@ pub fn read_contract_locktime(redeemscript: &Script) -> Result<u16, ContractErro
     }
 }
 
+/// Read the hashlock pubkey from a contract redeem script.
 pub fn read_hashlock_pubkey_from_contract(
     redeemscript: &Script,
 ) -> Result<PublicKey, ContractError> {
@@ -334,6 +348,7 @@ pub fn read_hashlock_pubkey_from_contract(
     Ok(PublicKey::from_slice(&redeemscript.to_bytes()[27..60])?)
 }
 
+/// Read the timelock pubkey from a contract redeem script.
 pub fn read_timelock_pubkey_from_contract(
     redeemscript: &Script,
 ) -> Result<PublicKey, ContractError> {
@@ -343,6 +358,7 @@ pub fn read_timelock_pubkey_from_contract(
     Ok(PublicKey::from_slice(&redeemscript.to_bytes()[65..98])?)
 }
 
+/// Read the pubkeys from a multisig redeem script.
 pub fn read_pubkeys_from_multisig_redeemscript(
     redeemscript: &Script,
 ) -> Result<(PublicKey, PublicKey), ContractError> {
@@ -378,6 +394,7 @@ pub fn create_senders_contract_tx(
     }
 }
 
+/// Create the receiver's contract transaction.
 pub fn create_receivers_contract_tx(
     input: OutPoint,
     input_value: u64,
@@ -388,6 +405,7 @@ pub fn create_receivers_contract_tx(
     create_senders_contract_tx(input, input_value, contract_redeemscript)
 }
 
+/// Check if a contract output is valid.
 pub fn is_contract_out_valid(
     contract_output: &TxOut,
     hashlock_pubkey: &PublicKey,
@@ -411,6 +429,7 @@ pub fn is_contract_out_valid(
     Ok(())
 }
 
+/// Validate a contract transaction.
 pub fn validate_contract_tx(
     receivers_contract_tx: &Transaction,
     funding_outpoint: Option<&OutPoint>,
@@ -434,6 +453,7 @@ pub fn validate_contract_tx(
     Ok(())
 }
 
+/// Sign a contract transaction.
 pub fn sign_contract_tx(
     contract_tx: &Transaction,
     multisig_redeemscript: &Script,
@@ -453,6 +473,7 @@ pub fn sign_contract_tx(
     Ok(secp.sign_ecdsa(&sighash, privkey))
 }
 
+/// Verify a signature on a contract transaction.
 pub fn verify_contract_tx_sig(
     contract_tx: &Transaction,
     multisig_redeemscript: &Script,

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -2,6 +2,7 @@
 
 use bitcoin::secp256k1;
 
+/// Enum for handling contract-related errors.
 #[derive(Debug)]
 pub enum ContractError {
     Secp(secp256k1::Error),

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -75,12 +75,14 @@ use bitcoin::hashes::hash160::Hash as Hash160;
 pub const PREIMAGE_LEN: usize = 32;
 pub type Preimage = [u8; PREIMAGE_LEN];
 
+/// Represents the initial handshake message sent from Taker to Maker.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TakerHello {
     pub protocol_version_min: u32,
     pub protocol_version_max: u32,
 }
 
+/// Represents a request to give an offer.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GiveOffer;
 
@@ -160,7 +162,7 @@ pub struct ContractSigsForRecvrAndSender {
     pub senders_sigs: Vec<Signature>,
 }
 
-/// Message to Transfer `HashPreimage` from Taker to Makers.
+/// Message to Transfer [`HashPreimage`] from Taker to Makers.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct HashPreimage {
     pub senders_multisig_redeemscripts: Vec<ScriptBuf>,
@@ -220,12 +222,14 @@ impl Display for TakerToMakerMessage {
     }
 }
 
+/// Represents the initial handshake message sent from Maker to Taker.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MakerHello {
     pub protocol_version_min: u32,
     pub protocol_version_max: u32,
 }
 
+/// Contains proof data related to fidelity bond.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct FidelityBondProof {
     pub utxo: OutPoint,
@@ -237,6 +241,7 @@ pub struct FidelityBondProof {
     pub onion_sig: Signature,
 }
 
+/// Represents an offer in the context of the Coinswap protocol.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Offer {
     pub absolute_fee_sat: u64,
@@ -264,7 +269,7 @@ pub struct SenderContractTxInfo {
     pub funding_amount: u64,
 }
 
-/// This message is sent by a Maker to a Taker. Which is a request to the Taker for gathering signatures for the Maker as both Sender and Receiver of Coinswaps.
+/// This message is sent by a Maker to a Taker, which is a request to the Taker for gathering signatures for the Maker as both Sender and Receiver of Coinswaps.
 /// This message is sent by a Maker after a [`ProofOfFunding`] has been received.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ContractSigsAsRecvrAndSender {
@@ -274,12 +279,13 @@ pub struct ContractSigsAsRecvrAndSender {
     pub senders_contract_txs_info: Vec<SenderContractTxInfo>,
 }
 
-/// Contract Tx signatures a Maker sends as a Receiver of coinswap.
+/// Contract Tx signatures a Maker sends as a Receiver of CoinSwap.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ContractSigsForRecvr {
     pub sigs: Vec<Signature>,
 }
 
+/// All messages sent from Maker to Taker.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "method", rename_all = "lowercase")]
 pub enum MakerToTakerMessage {

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -72,7 +72,10 @@ use serde::{Deserialize, Serialize};
 
 use bitcoin::hashes::hash160::Hash as Hash160;
 
+/// Defines the length of the Preimage.
 pub const PREIMAGE_LEN: usize = 32;
+
+/// Type for Preimage.
 pub type Preimage = [u8; PREIMAGE_LEN];
 
 /// Represents the initial handshake message sent from Taker to Maker.

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,4 +1,4 @@
-//! Defines the Contract Transaction and Protocol Messages
+//! Defines the Contract Transaction and Protocol Messages.
 
 pub mod contract;
 pub mod error;

--- a/src/scripts/market.rs
+++ b/src/scripts/market.rs
@@ -14,7 +14,7 @@ use crate::taker::{
 };
 
 #[tokio::main]
-/// App function to download offers
+/// App function to download offers.
 pub async fn download_and_display_offers(
     _network_str: Option<String>,
     maker_address: Option<String>,

--- a/src/scripts/wallet.rs
+++ b/src/scripts/wallet.rs
@@ -341,6 +341,7 @@ pub fn display_wallet_addresses(
     Ok(())
 }
 
+/// Prints the receive invoice for the wallet.
 pub fn print_receive_invoice(wallet_file_name: &PathBuf) -> Result<(), WalletError> {
     let mut wallet = Wallet::load(&RPCConfig::default(), wallet_file_name)?;
     wallet.sync()?;

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -117,13 +117,15 @@ struct NextPeerInfo {
     contract_reedemscripts: Vec<ScriptBuf>,
 }
 
+/// Enum representing different behaviors of the Taker in a coinswap protocol.
 #[derive(Default, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TakerBehavior {
-    // No special behavior
+    /// No special behavior.
     #[default]
     Normal,
-    // This depicts the behavior when the taker drops connections after the full coinswap setup
+    /// This depicts the behavior when the taker drops connections after the full coinswap setup.
     DropConnectionAfterFullSetup,
+    /// Behavior to broadcast the contract after the full coinswap setup.
     BroadcastContractAfterFullSetup,
 }
 

--- a/src/taker/config.rs
+++ b/src/taker/config.rs
@@ -1,9 +1,13 @@
 //! Taker configuration. Controlling various behavior.
+//!
+//!  Represents the configuration options for the Taker module, controlling behaviors
+//! such as refund locktime, connection attempts, sleep delays, and timeouts.
 
 use std::{collections::HashMap, io, path::PathBuf};
 
 use crate::utill::{parse_field, parse_toml};
-/// TODO: Optionally read this from a config file.
+// TODO: Optionally read this from a config file.
+/// Taker configuration with refund, connection, and sleep settings.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TakerConfig {
     pub refund_locktime: u16,

--- a/src/taker/error.rs
+++ b/src/taker/error.rs
@@ -10,6 +10,7 @@ use crate::{
     wallet::WalletError,
 };
 
+/// Enum for handling taker-related errors.
 #[derive(Debug)]
 pub enum TakerError {
     IO(std::io::Error),

--- a/src/taker/mod.rs
+++ b/src/taker/mod.rs
@@ -1,6 +1,5 @@
 //! Defines a Coinswap Taker Client.
 //!
-//!
 //! This also contains the entire swap workflow as major decision makings are involved for the Taker. Makers are
 //! simple request-response servers. The Taker handles all the necessary communications between one or many makers to route the swap across various makers. Description of
 //! protocol workflow is described in the [protocol between takers and makers](https://github.com/utxo-teleport/teleport-transactions#protocol-between-takers-and-makers)

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -19,6 +19,7 @@ use crate::market::directory::{
 
 use super::{config::TakerConfig, error::TakerError, routines::download_maker_offer};
 
+/// Represents an offer along with the corresponding maker address.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OfferAndAddress {
     pub offer: Offer,
@@ -33,6 +34,7 @@ const REGTEST_MAKER_ADDRESSES: &[&str] = &[
     "localhost:46102",
 ];
 
+/// Enum representing maker addresses (clearnet and TOR).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum MakerAddress {
     Clearnet { address: String },
@@ -40,6 +42,7 @@ pub enum MakerAddress {
 }
 
 impl MakerAddress {
+    /// Returns the TCP stream address as a string.
     pub fn get_tcpstream_address(&self) -> String {
         match &self {
             MakerAddress::Clearnet { address } => address.to_string(),
@@ -68,6 +71,7 @@ pub struct OfferBook {
 }
 
 impl OfferBook {
+    /// Gets all untried offers.
     pub fn get_all_untried(&self) -> Vec<&OfferAndAddress> {
         self.all_makers
             .iter()
@@ -75,6 +79,7 @@ impl OfferBook {
             .collect()
     }
 
+    /// Adds a new offer to the offer book.
     pub fn add_new_offer(&mut self, offer: &OfferAndAddress) -> bool {
         if !self.all_makers.contains(offer) {
             self.all_makers.push(offer.clone());
@@ -84,6 +89,7 @@ impl OfferBook {
         }
     }
 
+    /// Adds a good maker to the offer book.
     pub fn add_good_maker(&mut self, good_maker: &OfferAndAddress) -> bool {
         if !self.good_makers.contains(good_maker) {
             self.good_makers.push(good_maker.clone());
@@ -93,6 +99,7 @@ impl OfferBook {
         }
     }
 
+    /// Adds a bad maker to the offer book.
     pub fn add_bad_maker(&mut self, bad_maker: &OfferAndAddress) -> bool {
         if !self.bad_makers.contains(bad_maker) {
             self.bad_makers.push(bad_maker.clone());
@@ -102,6 +109,7 @@ impl OfferBook {
         }
     }
 
+    /// Synchronizes the offer book with addresses obtained from directory servers and local configurations.
     pub async fn sync_offerbook(
         &mut self,
         network: Network,
@@ -123,6 +131,7 @@ impl OfferBook {
         Ok(new_offers)
     }
 
+    /// Gets the list of bad makers.
     pub fn get_bad_makers(&self) -> Vec<&OfferAndAddress> {
         self.bad_makers.iter().collect()
     }
@@ -137,6 +146,7 @@ fn get_regtest_maker_addresses() -> Vec<MakerAddress> {
         .collect::<Vec<MakerAddress>>()
 }
 
+/// Synchronizes the offer book with specific maker addresses.
 pub async fn sync_offerbook_with_addresses(
     maker_addresses: Vec<MakerAddress>,
     config: &TakerConfig,
@@ -167,6 +177,7 @@ pub async fn sync_offerbook_with_addresses(
     result
 }
 
+/// Retrieves advertised maker addresses from directory servers based on the specified network.
 pub async fn get_advertised_maker_addresses(
     network: Network,
 ) -> Result<Vec<MakerAddress>, DirectoryServerError> {

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -34,6 +34,7 @@ use crate::{
     wallet::{SwapCoin, WalletError},
 };
 
+/// Converts a string representation of a network to a `Network` enum variant.
 pub fn str_to_bitcoin_network(net_str: &str) -> Network {
     match net_str {
         "main" => Network::Bitcoin,
@@ -84,7 +85,7 @@ pub fn setup_logger() {
     });
 }
 
-/// Can send both Taker and Maker messages
+/// Can send both Taker and Maker messages.
 pub async fn send_message(
     socket_writer: &mut WriteHalf<'_>,
     message: &impl serde::Serialize,
@@ -95,7 +96,7 @@ pub async fn send_message(
     Ok(())
 }
 
-/// Read a Maker Message
+/// Read a Maker Message.
 pub async fn read_message(
     reader: &mut BufReader<ReadHalf<'_>>,
 ) -> Result<MakerToTakerMessage, NetError> {
@@ -122,7 +123,7 @@ pub fn check_and_apply_maker_private_keys<S: SwapCoin>(
 
 /// Generate The Maker's Multisig and HashLock keys and respective nonce values.
 /// Nonce values are random integers and resulting Pubkeys are derived by tweaking the
-/// Make's advertised Pubkey with these two nonces.
+/// Maker's advertised Pubkey with these two nonces.
 pub fn generate_maker_keys(
     tweakable_point: &PublicKey,
     count: u32,
@@ -146,6 +147,7 @@ pub fn generate_maker_keys(
     )
 }
 
+/// Converts a Bitcoin amount from JSON-RPC representation to satoshis.
 pub fn convert_json_rpc_bitcoin_to_satoshis(amount: &Value) -> u64 {
     //to avoid floating point arithmetic, convert the bitcoin amount to
     //string with 8 decimal places, then remove the decimal point to
@@ -157,7 +159,11 @@ pub fn convert_json_rpc_bitcoin_to_satoshis(amount: &Value) -> u64 {
         .parse::<u64>()
         .unwrap()
 }
-// returns None if not a hd descriptor (but possibly a swapcoin (multisig) descriptor instead)
+
+/// Extracts hierarchical deterministic (HD) path components from a descriptor.
+///
+/// Parses an input descriptor string and returns `Some` with a tuple containing the HD path
+/// components if it's an HD descriptor. If it's not an HD descriptor, it returns `None`.
 pub fn get_hd_path_from_descriptor(descriptor: &str) -> Option<(&str, u32, i32)> {
     //e.g
     //"desc": "wpkh([a945b5ca/1/1]029b77637989868dcd502dbc07d6304dc2150301693ae84a60b379c3b696b289ad)#aq759em9",
@@ -186,6 +192,7 @@ pub fn get_hd_path_from_descriptor(descriptor: &str) -> Option<(&str, u32, i32)>
     Some((path_chunks[0], addr_type.unwrap(), index.unwrap()))
 }
 
+/// Generates a keypair using the secp256k1 elliptic curve.
 pub fn generate_keypair() -> (PublicKey, SecretKey) {
     let mut privkey = [0u8; 32];
     OsRng.fill_bytes(&mut privkey);
@@ -209,6 +216,7 @@ pub fn redeemscript_to_scriptpubkey(redeemscript: &ScriptBuf) -> ScriptBuf {
     ScriptBuf::new_witness_program(&witness_program)
 }
 
+/// Converts a byte vector to a hexadecimal string representation.
 pub fn to_hex(bytes: &Vec<u8>) -> String {
     let hex_chars: Vec<char> = "0123456789abcdef".chars().collect();
     let mut hex_string = String::new();
@@ -223,7 +231,7 @@ pub fn to_hex(bytes: &Vec<u8>) -> String {
     hex_string
 }
 
-/// Function to parse toml file into key-value pair
+/// Parse TOML file into key-value pair.
 pub fn parse_toml(file_path: &PathBuf) -> io::Result<HashMap<String, HashMap<String, String>>> {
     let file = File::open(file_path)?;
     let reader = io::BufReader::new(file);
@@ -253,7 +261,7 @@ pub fn parse_toml(file_path: &PathBuf) -> io::Result<HashMap<String, HashMap<Str
     Ok(sections)
 }
 
-/// Function to parse and log errors for each field
+/// Parse and log errors for each field.
 pub fn parse_field<T: std::str::FromStr>(value: Option<&String>, default: T) -> io::Result<T> {
     match value {
         Some(value) => value

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -47,9 +47,9 @@ use super::{
     swapcoin::{IncomingSwapCoin, OutgoingSwapCoin, SwapCoin, WalletSwapCoin},
 };
 
-//these subroutines are coded so that as much as possible they keep all their
-//data in the bitcoin core wallet
-//for example which privkey corresponds to a scriptpubkey is stored in hd paths
+// these subroutines are coded so that as much as possible they keep all their
+// data in the bitcoin core wallet
+// for example which privkey corresponds to a scriptpubkey is stored in hd paths
 
 const HARDENDED_DERIVATION: &str = "m/84'/1'/0'";
 pub struct Wallet {

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -52,6 +52,8 @@ use super::{
 // for example which privkey corresponds to a scriptpubkey is stored in hd paths
 
 const HARDENDED_DERIVATION: &str = "m/84'/1'/0'";
+
+/// Represents a Bitcoin wallet with associated functionality and data.
 pub struct Wallet {
     pub(crate) rpc: Client,
     wallet_file_path: PathBuf,

--- a/src/wallet/direct_send.rs
+++ b/src/wallet/direct_send.rs
@@ -15,6 +15,7 @@ use crate::wallet::{api::UTXOSpendInfo, SwapCoin};
 
 use super::{error::WalletError, fidelity::get_locktime_from_index, Wallet};
 
+/// Enum representing different options for the amount to be sent in a transaction.
 #[derive(Debug, Clone, PartialEq)]
 pub enum SendAmount {
     Max,
@@ -33,6 +34,7 @@ impl FromStr for SendAmount {
     }
 }
 
+/// Enum representing different destination options for a transaction.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Destination {
     Wallet,
@@ -51,6 +53,7 @@ impl FromStr for Destination {
     }
 }
 
+/// Enum representing different ways to identify a coin to spend.
 #[derive(Debug, Clone, PartialEq)]
 pub enum CoinToSpend {
     LongForm(OutPoint),

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -2,6 +2,7 @@
 
 use crate::protocol::error::ContractError;
 
+/// Enum for handling wallet-related errors.
 #[derive(Debug)]
 pub enum WalletError {
     File(std::io::Error),

--- a/src/wallet/rpc.rs
+++ b/src/wallet/rpc.rs
@@ -18,6 +18,7 @@ use serde::Deserialize;
 
 use super::{error::WalletError, Wallet};
 
+/// Configuration parameters for connecting to a Bitcoin node via RPC.
 #[derive(Debug, Clone)]
 pub struct RPCConfig {
     /// The bitcoin node url

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -29,19 +29,26 @@ struct FileData {
     prevout_to_contract_map: HashMap<OutPoint, ScriptBuf>,
 }
 
+/// Represents the internal data store for a Bitcoin wallet.
 #[derive(Debug, PartialEq)]
 pub struct WalletStore {
-    // Wallet store name should match the bitcoin core watch-only wallet name
+    /// The file name associated with the wallet store.
     pub(crate) file_name: String,
+    /// The network the wallet operates on.
     pub(crate) network: Network,
+    /// The master key for the wallet.
     pub(super) master_key: ExtendedPrivKey,
+    /// The external index for the wallet.
     pub(super) external_index: u32,
+    /// The maximum size for an offer in the wallet.
     pub(crate) offer_maxsize: u64,
-    /// Map of multisig reedemscript to incoming swapcoins.
+    /// Map of multisig redeemscript to incoming swapcoins.
     pub(super) incoming_swapcoins: HashMap<ScriptBuf, IncomingSwapCoin>,
-    /// Map of multisig reedemscript to outgoing swapcoins.
+    /// Map of multisig redeemscript to outgoing swapcoins.
     pub(super) outgoing_swapcoins: HashMap<ScriptBuf, OutgoingSwapCoin>,
+    /// Map of prevout to contract redeemscript.
     pub(super) prevout_to_contract_map: HashMap<OutPoint, ScriptBuf>,
+    /// Map of fidelity bond scripts to index.
     pub(super) fidelity_scripts: HashMap<ScriptBuf, u32>,
     //TODO: Add last synced height and Wallet birthday.
 }

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -27,8 +27,10 @@ use crate::protocol::{
 
 use super::WalletError;
 
-//swapcoins are UTXOs + metadata which are not from the deterministic wallet
-//they are made in the process of a coinswap
+// SwapCoins are UTXOs + metadata which are not from the deterministic wallet.
+// They are made in the process of a coinswap
+
+/// Represents an incoming swapcoin.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct IncomingSwapCoin {
     pub my_privkey: SecretKey,
@@ -42,8 +44,7 @@ pub struct IncomingSwapCoin {
     pub hash_preimage: Option<Preimage>,
 }
 
-//swapcoins are UTXOs + metadata which are not from the deterministic wallet
-//they are made in the process of a coinswap
+/// Represents an outgoing swapcoin.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct OutgoingSwapCoin {
     pub my_privkey: SecretKey,
@@ -56,31 +57,50 @@ pub struct OutgoingSwapCoin {
     pub hash_preimage: Option<Preimage>,
 }
 
+/// Represents a watch-only view of a coinswap between two makers.
 //like the Incoming/OutgoingSwapCoin structs but no privkey or signature information
 //used by the taker to monitor coinswaps between two makers
 #[derive(Debug, Clone)]
 pub struct WatchOnlySwapCoin {
+    /// Public key of the sender (maker).
     pub sender_pubkey: PublicKey,
+    /// Public key of the receiver (maker).
     pub receiver_pubkey: PublicKey,
+    /// Transaction representing the coinswap contract.
     pub contract_tx: Transaction,
+    /// Redeem script associated with the coinswap contract.
     pub contract_redeemscript: ScriptBuf,
+    /// The funding amount of the coinswap.
     pub funding_amount: u64,
 }
 
+/// Trait representing common functionality for swap coins.
 pub trait SwapCoin {
+    /// Get the multisig redeem script.
     fn get_multisig_redeemscript(&self) -> ScriptBuf;
+    /// Get the contract transaction.
     fn get_contract_tx(&self) -> Transaction;
+    /// Get the contract redeem script.
     fn get_contract_redeemscript(&self) -> ScriptBuf;
+    /// Get the timelock public key.
     fn get_timelock_pubkey(&self) -> PublicKey;
+    /// Get the timelock value.
     fn get_timelock(&self) -> u16;
+    /// Get the hashlock public key.
     fn get_hashlock_pubkey(&self) -> PublicKey;
+    /// Get the hash value.
     fn get_hashvalue(&self) -> Hash160;
+    /// Get the funding amount.
     fn get_funding_amount(&self) -> u64;
+    /// Verify the receiver's signature on the contract transaction.
     fn verify_contract_tx_receiver_sig(&self, sig: &Signature) -> Result<(), WalletError>;
+    /// Verify the sender's signature on the contract transaction.
     fn verify_contract_tx_sender_sig(&self, sig: &Signature) -> Result<(), WalletError>;
+    /// Apply a private key to the swap coin.
     fn apply_privkey(&mut self, privkey: SecretKey) -> Result<(), WalletError>;
 }
 
+/// Trait representing swap coin functionality specific to a wallet.
 pub trait WalletSwapCoin: SwapCoin {
     fn get_my_pubkey(&self) -> PublicKey;
     fn get_other_pubkey(&self) -> &PublicKey;


### PR DESCRIPTION
Aims to fix #57. As of now, ~95% of api docs are documented.
Here is the status:
```sh
├── maker ✅
│   ├── api.rs ✅
│   ├── config.rs ✅
│   ├── error.rs ✅
│   ├── handlers.rs <PRIVATE>
│   └── mod.rs ✅
├── market ✅ <DUMMY>
│   ├── directory.rs ✅ <DUMMY>
│   └── mod.rs ✅ <DUMMY>
├── protocol
│   ├── contract.rs
│   ├── error.rs ✅
│   ├── messages.rs ✅
│   └── mod.rs ✅
├── scripts  ✅ <DUMMY>
│   ├── market.rs  ✅
│   ├── mod.rs  ✅
│   └── wallet.rs ✅
├── taker ✅
│   ├── api.rs ✅
│   ├── config.rs <PRIVATE>
│   ├── error.rs ✅
│   ├── mod.rs ✅
│   ├── offers.rs ✅
│   └── routines.rs <PRIVATE>
├── utill.rs ✅
├── wallet ✅
│   ├── api.rs ✅
│   ├── direct_send.rs <PRIVATE>
│   ├── error.rs <PRIVATE>
│   ├── fidelity.rs ✅
│   ├── funding.rs <PRIVATE>
│   ├── mod.rs ✅
│   ├── rpc.rs <PRIVATE>
│   ├── storage.rs <PRIVATE>
│   └── swapcoin.rs <PRIVATE>
```
> ✅ means everything is documented.
 `<PRIVATE>` means that the module isn't exposed for rustdocs.

Remaining modules, because they're huge and will take time. Will push more commits here for these whenever I'll get some time from exams:
```sh
├── protocol
│   ├── contract.rs <1300 Lines>
```
Also @rajarshimaitra, feel free to push your commits too! : )
