### PR TITLE
misc: todos, .gitignore, cleanups, broken links, readme, milestones, grammar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 *.swp
 /docs/fidelity_bonds.md
 Cargo.lock
-*/temp-files
 .vscode

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </div>
 
 > \[!WARNING\]
-> This library is currently under beta development and at an experimental stage. There are known and unknown bugs. Mainnet use is strictly not recommended.
+> This library is currently under beta development and at an experimental stage. There are known and unknown bugs. Mainnet use is strictly NOT recommended.
 
 ## Table of Contents
 
@@ -43,12 +43,12 @@ Teleport Transactions is a rust implementation of a variant of atomic-swap proto
 
 * [Mailing list post](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-October/018221.html)
 * [Detailed design](https://gist.github.com/chris-belcher/9144bd57a91c194e332fb5ca371d0964)
-* [Developer's resources](/docs/developer_resources.md)
-* [Run demo](/docs/run_teleport.md)
+* [Developer's resources](/docs/dev-book.md)
+* [Run demo](/docs/demo.md)
 
 ## Architecture
 
-The project is divided into distinct modules, each focused on specific functionalities. The project directory-tree is given below:
+The project is divided into distinct modules, each focused on specific functionalities.
 
 ```console
 docs/
@@ -65,10 +65,10 @@ tests/
 ```
 | Directory           | Description |
 |---------------------|-------------|
-| **`doc`**           | Contains all the project-related docs. The [dev-book](https://github.com/utxo-teleport/teleport-transactions/blob/master/docs/dev-book.md) includes major developer salient points. The [demo doc](https://github.com/utxo-teleport/teleport-transactions/blob/master/docs/demo.md) describes how to run the `teleport` binary and perform a swap in regtest.|
+| **`doc`**           | Contains all the project-related docs. The [dev-book](./docs/dev-book.md) includes major developer salient points and the [demo doc](./docs/demo.md) describes how to run the `teleport` binary and perform a swap in regtest.|
 | **`tests`**         | Contains integration tests. Describes behavior of various abort/malice cases.|
-| **`src/taker`**     | Contains Taker-related behaviors, with core logic in `src/taker/api.rs`. Takers manage most protocol logic, while Makers play a relatively passive role.|
-| **`src/maker`**     | Encompasses Maker-specific logic. |
+| **`src/taker`**     | Taker module houses its core logic in `src/taker/api.rs` and handles both Taker-related behaviors and most of the protocol-related logic. |
+| **`src/maker`**     | Encompasses Maker-specific logic and plays a relatively passive role compared to Taker. |
 | **`src/wallet`**    | Manages wallet-related operations, including storage and blockchain interaction. |
 | **`src/market`**    | Handles market-related logic, where Makers post their offers. |
 | **`src/watchtower`**| Provides a Taker-offloadable watchtower implementation for monitoring contract transactions. |
@@ -85,7 +85,7 @@ The project follows the standard Rust build workflow and generates a CLI app nam
 $ cargo build
 ```
 
-The project includes both unit and integration tests. The integration tests simulates various edge cases of the coinswap protocol.
+The project includes both integration and unit tests. The integration tests simulates various edge cases of the coinswap protocol.
 
 To run the tests:
 
@@ -93,9 +93,9 @@ To run the tests:
 $ cargo test -- --nocapture
 ```
 
-For manual swaps using the `teleport` app, follow the instructions in [Run Teleport](./docs/run_teleport.md).
+For manual swaps using the `teleport` app, follow the instructions in [demo](/docs/demo.md).
 
-For in-depth developer documentation on protocol workflow and implementation, consult [Developer's Resources](./docs/developer_resources.md).
+For in-depth developer documentation on protocol workflow and implementation, consult the [dev book](/docs/dev-book.md).
 
 ## Project Status
 
@@ -126,16 +126,16 @@ If you're interested in contributing to the project, explore the [open issues](h
 - [x] Implement configuration file i/o support for Takers and Makers.
 - [x] Switch to binary encoding for network messages.
 - [x] Switch to binary encoding for wallet data.
+- [ ] Make tor detectable and connectable by default for Maker and Taker. And Tor configs to their config lists.
 - [ ] Complete all unit tests in modules.
 - [ ] Achieve >80% crate level test coverage ratio (including integration tests).
 - [ ] Clean up and integrate fidelity bonds with maker banning.
-- [ ] Make tor detectable and connectable by default for Maker and Taker. And Tor configs to their config lists.
 - [ ] Sketch a simple `AddressBook` server. Tor must. This is for MVP. Later on we will move to more decentralized address server architecture.
 - [ ] Turn maker server into a `makerd` binary, and a `maker-cli` rpc controller app, with MVP API.
 - [ ] Finalize the Taker API for downstream wallet integration.
-- [ ] Develop an example web Taker client, with a downstream wallet.
+- [ ] Develop an example web Taker client with a downstream wallet.
 - [ ] Package `makerd` and `maker-cli` in a downstream node.
-- [ ] Release V 0.1.0 in Signet for beta testing.
+- [ ] Release v0.1.0 in Signet for beta testing.
 
 ### V 0.1.*
 
@@ -143,20 +143,20 @@ If you're interested in contributing to the project, explore the [open issues](h
 - [ ] Describe contract and funding transactions via miniscript, using BDK for wallet management.
 - [ ] Enable wallet syncing via CBF (BIP157/158).
 - [ ] Transition to taproot outputs for the entire protocol, enhancing anonymity and obfuscating contract transactions.
-- [ ] Optional: Payjoin integration via coinswap.
 - [ ] Implement customizable wallet data storage (SQLite, Postgres).
+- [ ] Optional: Payjoin integration via coinswap.
 
 # Contributing
 
-The project is under active development by a few motivated rusty bitcoin devs. Any contribution for features, tests, docs and other fixes/upgrades is encouraged and welcomed. The maintainers will use the PR thread to provide quick reviews and suggestions and are generally proactive at merging good contributions.
+The project is under active development by a few motivated Rusty Bitcoin devs. Any contribution for features, tests, docs and other fixes/upgrades is encouraged and welcomed. The maintainers will use the PR thread to provide quick reviews and suggestions and are generally proactive at merging good contributions.
 
 Few directions for new contributors:
 
-- The list of [issues](https://github.com/utxo-teleport/teleport-transactions/issues) are good place to look for contributable tasks and open problems.
+- The list of [issues](https://github.com/utxo-teleport/teleport-transactions/issues) is a good place to look for contributable tasks and open problems.
 
 - Issues marked with [`good first issue`](https://github.com/utxo-teleport/teleport-transactions/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) are good places to get started for newbie Rust/Bitcoin devs.
 
-- The [docs](https://github.com/utxo-teleport/teleport-transactions/tree/master/docs) are a good place to start reading up on the protocol.
+- The [docs](./docs) are a good place to start reading up on the protocol.
 
 - Reviewing [open PRs](https://github.com/utxo-teleport/teleport-transactions/pulls) are a good place to start gathering a contextual understanding of the codebase.
 

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ If you're interested in contributing to the project, explore the [open issues](h
 - [X] Malice 2: One of the Makers broadcast contract immaturely. The Taker identify this, bans the Maker's fidelity bond, other Makers get back funds via contract tx.
 - [X] Fix all clippy warnings.
 - [x] Implement configuration file i/o support for Takers and Makers.
+- [x] Switch to binary encoding for network messages.
+- [x] Switch to binary encoding for wallet data.
 - [ ] Complete all unit tests in modules.
 - [ ] Achieve >80% crate level test coverage ratio (including integration tests).
 - [ ] Clean up and integrate fidelity bonds with maker banning.
-- [x] Switch to binary encoding for network messages.
-- [ ] Switch to binary encoding for wallet data.
 - [ ] Make tor detectable and connectable by default for Maker and Taker. And Tor configs to their config lists.
 - [ ] Sketch a simple `AddressBook` server. Tor must. This is for MVP. Later on we will move to more decentralized address server architecture.
 - [ ] Turn maker server into a `makerd` binary, and a `maker-cli` rpc controller app, with MVP API.

--- a/src/protocol/contract.rs
+++ b/src/protocol/contract.rs
@@ -47,6 +47,11 @@ use super::{
 pub const FUNDING_TX_VBYTE_SIZE: u64 = 372;
 const MIN_HASHV_LEN: usize = 25;
 
+// Used in read_pubkeys_from_multisig_redeemscript() function.
+const PUBKEY_LENGTH: usize = 33;
+const PUBKEY1_OFFSET: usize = 2;
+const PUBKEY2_OFFSET: usize = PUBKEY1_OFFSET + PUBKEY_LENGTH + 1;
+
 /// Calculate the coin swap fee based on various parameters.
 pub fn calculate_coinswap_fee(
     absolute_fee_sat: u64,
@@ -367,9 +372,10 @@ pub fn read_pubkeys_from_multisig_redeemscript(
     redeemscript: &Script,
 ) -> Result<(PublicKey, PublicKey), ContractError> {
     let ms_rs_bytes = redeemscript.to_bytes();
-    //TODO put these magic numbers in consts, PUBKEY1_OFFSET maybe
-    let pubkey1 = PublicKey::from_slice(&ms_rs_bytes[2..35])?;
-    let pubkey2 = PublicKey::from_slice(&ms_rs_bytes[36..69])?;
+    let pubkey1 =
+        PublicKey::from_slice(&ms_rs_bytes[PUBKEY1_OFFSET..PUBKEY1_OFFSET + PUBKEY_LENGTH])?;
+    let pubkey2 =
+        PublicKey::from_slice(&ms_rs_bytes[PUBKEY2_OFFSET..PUBKEY2_OFFSET + PUBKEY_LENGTH])?;
     Ok((pubkey1, pubkey2))
 }
 

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -1,9 +1,3 @@
-//we make heavy use of serde_json's de/serialization for the benefits of
-//having the compiler check for us, extra type checking and readability
-
-//this works because of enum representations in serde
-//see https://serde.rs/enum-representations.html
-
 //! Coinswap Protocol Messages.
 //!
 //! Messages are communicated between one Taker and one or many Makers.

--- a/src/scripts/wallet.rs
+++ b/src/scripts/wallet.rs
@@ -40,7 +40,7 @@ pub fn generate_wallet(
 ) -> Result<(), WalletError> {
     let rpc_config = rpc_config.unwrap_or_default();
 
-    println!("input an optional passphrase (or leave blank for none): ");
+    println!("Input an optional passphrase (or leave blank for none): ");
     let mut passphrase = String::new();
     std::io::stdin().read_line(&mut passphrase)?;
     passphrase = passphrase.trim().to_string();
@@ -59,12 +59,12 @@ pub fn generate_wallet(
         return Err(e);
     }
 
-    println!("Write down this seed phrase =\n{}", mnemonic);
+    println!("Write down this seed phrase:\n{}", mnemonic);
     if !passphrase.trim().is_empty() {
-        println!("And this passphrase =\n\"{}\"", passphrase);
+        println!("And this passphrase:\n\"{}\"", passphrase);
     }
     println!(
-        "\nThis seed phrase is NOT enough to backup all coins in your wallet\n\
+        "\nThis seed phrase is NOT enough to backup all coins in your wallet.\n\
         The teleport wallet file is needed to backup swapcoins"
     );
     println!("\nSaved to file `{}`", wallet_file.to_string_lossy());
@@ -74,24 +74,24 @@ pub fn generate_wallet(
 
 /// Reset a wallet file with a given menmomic and passphrase
 pub fn recover_wallet(wallet_file: &PathBuf) -> Result<(), WalletError> {
-    println!("input seed phrase: ");
+    println!("Input seed phrase: ");
     let mut seed_phrase = String::new();
     std::io::stdin().read_line(&mut seed_phrase)?;
     seed_phrase = seed_phrase.trim().to_string();
 
     if let Err(e) = Mnemonic::parse(&seed_phrase) {
-        println!("invalid seed phrase: {:?}", e);
+        println!("Invalid seed phrase: {:?}", e);
         return Ok(());
     }
 
-    println!("input seed phrase extension (or leave blank for none): ");
+    println!("Input seed phrase extension (or leave blank for none): ");
     let mut passphrase = String::new();
     std::io::stdin().read_line(&mut passphrase)?;
     passphrase = passphrase.trim().to_string();
 
     let wallet_name = wallet_file
         .file_name()
-        .expect("filename expected")
+        .expect("Filename expected!")
         .to_str()
         .unwrap()
         .to_string();
@@ -139,7 +139,7 @@ pub fn display_wallet_balance(
     let balance: Amount = utxos
         .iter()
         .fold(Amount::ZERO, |acc, (u, _)| acc + u.amount);
-    println!("= spendable wallet balance =");
+    println!("= Spendable wallet balance =");
     println!(
         "{:16} {:24} {:^8} {:<7} value",
         "coin", "address", "type", "conf",
@@ -164,12 +164,12 @@ pub fn display_wallet_balance(
             utxo.amount
         );
     }
-    println!("coin count = {}", utxo_count);
-    println!("total balance = {}", balance);
+    println!("Coin count = {}", utxo_count);
+    println!("Total balance = {}", balance);
 
     let incomplete_coinswaps = wallet.find_incomplete_coinswaps()?;
     if !incomplete_coinswaps.is_empty() {
-        println!("= incomplete coinswaps =");
+        println!("= Incomplete coinswaps =");
         for (hashvalue, (utxo_incoming_swapcoins, utxo_outgoing_swapcoins)) in incomplete_coinswaps
         {
             let incoming_swapcoins_balance: Amount = utxo_incoming_swapcoins
@@ -212,13 +212,13 @@ pub fn display_wallet_balance(
             }
             if incoming_swapcoins_balance != Amount::ZERO {
                 println!(
-                    "amount earned if coinswap successful = {}",
+                    "Amount earned if coinswap is successful = {}",
                     (incoming_swapcoins_balance.to_signed().unwrap()
                         - outgoing_swapcoins_balance.to_signed().unwrap()),
                 );
             }
             println!(
-                "outgoing balance = {}\nhashvalue = {}",
+                "Outgoing balance = {}\nhashvalue = {}",
                 outgoing_swapcoins_balance, hashvalue
             );
         }
@@ -228,7 +228,7 @@ pub fn display_wallet_balance(
         wallet.find_live_contract_unspents()?;
     if !outgoing_contract_utxos.is_empty() {
         outgoing_contract_utxos.sort_by(|a, b| b.1.confirmations.cmp(&a.1.confirmations));
-        println!("= live timelocked contracts =");
+        println!("= Live timelocked contracts =");
         println!(
             "{:16} {:10} {:8} {:<7} {:<8} {:6}",
             "coin", "hashvalue", "timelock", "conf", "locked?", "value"
@@ -260,7 +260,7 @@ pub fn display_wallet_balance(
     let expert_mode = true;
     if expert_mode && !incoming_contract_utxos.is_empty() {
         incoming_contract_utxos.sort_by(|a, b| b.1.confirmations.cmp(&a.1.confirmations));
-        println!("= live hashlocked contracts =");
+        println!("= Live hashlocked contracts =");
         println!(
             "{:16} {:10} {:8} {:<7} {:8} {:6}",
             "coin", "hashvalue", "timelock", "conf", "preimage", "value"
@@ -287,7 +287,7 @@ pub fn display_wallet_balance(
     }
 
     if !fidelity_bond_utxos.is_empty() {
-        println!("= fidelity bond coins =");
+        println!("= Fidelity bond coins =");
         println!(
             "{:16} {:24} {:<7} {:<11} {:<8} {:6}",
             "coin", "address", "conf", "locktime", "locked?", "value"
@@ -303,7 +303,7 @@ pub fn display_wallet_balance(
             {
                 index
             } else {
-                panic!("logic error, all these utxos should be fidelity bonds");
+                panic!("Logic error, all these UTXOs should be fidelity bonds!");
             };
             let unix_locktime = get_locktime_from_index(*index);
             let txid = utxo.txid.to_string();
@@ -363,17 +363,17 @@ pub fn print_fidelity_bond_address(
     let (addr, unix_locktime) = wallet.get_timelocked_address(locktime);
     println!(concat!(
         "WARNING: You should send coins to this address only once.",
-        " Only single biggest value UTXO will be announced as a fidelity bond.",
-        " Sending coins to this address multiple times will not increase",
-        " fidelity bond value."
+        " Only single, largest value UTXO will be announced as a fidelity bond.",
+        " Sending coins to this address multiple times will NOT increase",
+        " the fidelity bond value."
     ));
     println!(concat!(
         "WARNING: Only send coins here which are from coinjoins, coinswaps or",
         " otherwise not linked to your identity. Also, use a sweep transaction when funding the",
-        " timelocked address, i.e. Don't create a change address."
+        " timelocked address, i.e., don't create a change address."
     ));
     println!(
-        "Coins sent to this address will not be spendable until {}",
+        "Coins sent to this address will NOT be spendable until {}",
         NaiveDateTime::from_timestamp_opt(unix_locktime, 0)
             .expect("expected")
             .format("%Y-%m-%d")
@@ -397,16 +397,16 @@ pub fn direct_send(
         .create_direct_send(fee_rate, send_amount, destination, coins_to_spend)
         .unwrap();
     let txhex = bitcoin::consensus::encode::serialize_hex(&tx);
-    log::debug!("fully signed tx hex = {}", txhex);
+    log::debug!("Fully signed tx hex = {}", txhex);
     let test_mempool_accept_result = &wallet.rpc.test_mempool_accept(&[txhex.clone()]).unwrap()[0];
     if !test_mempool_accept_result.allowed {
         panic!(
-            "created invalid transaction, reason = {:#?}",
+            "Created invalid transaction, reason = {:#?}",
             test_mempool_accept_result
         );
     }
     println!(
-        "actual fee rate = {:.3} sat/vb",
+        "Actual fee rate = {:.3} sat/vb",
         test_mempool_accept_result
             .fees
             .as_ref()
@@ -416,10 +416,10 @@ pub fn direct_send(
             / test_mempool_accept_result.vsize.unwrap() as f64
     );
     if dont_broadcast {
-        println!("tx = \n{}", txhex);
+        println!("Tx = \n{}", txhex);
     } else {
         let txid = wallet.rpc.send_raw_transaction(&tx).unwrap();
-        println!("broadcasted {}", txid);
+        println!("Broadcasted {}", txid);
     }
     Ok(())
 }

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -498,14 +498,8 @@ impl Wallet {
         prevout: OutPoint,
         contract: ScriptBuf,
     ) -> Result<(), WalletError> {
-        // let mut wallet_file_data = Wallet::load_wallet_file_data(&self.wallet_file_path[..])?;
-        // wallet_file_data
-        //     .prevout_to_contract_map
-        //     .insert(prevout, contract);
-        // let wallet_file = File::create(&self.wallet_file_path[..])?;
-        // serde_json::to_writer(wallet_file, &wallet_file_data).map_err(|e| io::Error::from(e))?;
         if let Some(contract) = self.store.prevout_to_contract_map.insert(prevout, contract) {
-            log::debug!(target: "Wallet:cache_prevout_to_contract", "prevout-contract map updated. existing contract: {}", contract);
+            log::debug!(target: "Wallet:cache_prevout_to_contract", "prevout-contract map updated.\nExisting contract: {}", contract);
         }
         Ok(())
     }

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -1082,12 +1082,11 @@ impl Wallet {
     }
 
     /// Signs a transaction corresponding to the provided UTXO spend information.
-    // TODO: Result the unwraps
     pub fn sign_transaction(
         &self,
         tx: &mut Transaction,
         inputs_info: &mut dyn Iterator<Item = UTXOSpendInfo>,
-    ) {
+    ) -> Result<(), WalletError> {
         let secp = Secp256k1::new();
         let master_private_key = self
             .store
@@ -1173,6 +1172,7 @@ impl Wallet {
                 }
             }
         }
+        Ok(())
     }
 
     /// Converts a PSBT (Partially Signed Bitcoin Transaction) created by the wallet
@@ -1248,7 +1248,7 @@ impl Wallet {
                 }
             });
         log::debug!(target: "wallet", "inputs_info = {:?}", inputs_info);
-        self.sign_transaction(&mut tx, &mut inputs_info);
+        self.sign_transaction(&mut tx, &mut inputs_info)?;
 
         log::debug!(target: "wallet",
             "txhex = {}",

--- a/src/wallet/direct_send.rs
+++ b/src/wallet/direct_send.rs
@@ -243,7 +243,7 @@ impl Wallet {
         self.sign_transaction(
             &mut tx,
             &mut unspent_inputs.iter().map(|(_u, usi)| usi.clone()),
-        );
+        )?;
         Ok(tx)
     }
 }

--- a/src/wallet/funding.rs
+++ b/src/wallet/funding.rs
@@ -90,7 +90,7 @@ impl Wallet {
             }
         }
         Err(WalletError::Protocol(
-            "unable to generate amount fractions, probably amount too small".to_string(),
+            "Unable to generate amount fractions, probably amount too small".to_string(),
         ))
     }
 
@@ -460,8 +460,8 @@ impl Wallet {
 
             //not implemented yet!
             log::debug!(target: "wallet",
-                concat!("failed to create funding txes with the biggest-utxos method, this ",
-                    "branch not implemented"));
+                concat!("Failed to create funding txes with the biggest-utxos method, this ",
+                    "branch not implemented yet!"));
             Ok(None)
         } else {
             //at most one utxo bigger than the coinswap amount

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -93,7 +93,7 @@ impl TryFrom<FileData> for WalletStore {
 }
 
 impl WalletStore {
-    /// Initialize a store at a path. if path already exists, it will overwrite it.
+    /// Initialize a store at a path (if path already exists, it will overwrite it).
     pub fn init(
         file_name: String,
         path: &PathBuf,
@@ -106,8 +106,7 @@ impl WalletStore {
         Ok(store)
     }
 
-    /// Load existing file, updates it, writes it back.
-    /// errors if path does not exist.
+    /// Load existing file, updates it, writes it back (errors if path doesn't exist).
     pub fn write_to_disk(&self, path: &PathBuf) -> Result<(), WalletError> {
         let mut file_data = FileData::load_from_file(path)?;
         file_data.incoming_swapcoins = self
@@ -125,7 +124,7 @@ impl WalletStore {
         file_data.save_to_file(path)
     }
 
-    /// Reads from a path. Errors if path doesn't exist.
+    /// Reads from a path (errors if path doesn't exist).
     pub fn read_from_disk(path: &PathBuf) -> Result<Self, WalletError> {
         let file_data = FileData::load_from_file(path)?;
         Self::try_from(file_data)

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -1,4 +1,6 @@
 //! SwapCoins are structures defining an ongoing swap operations.
+//! They are UTXOs + metadata which are not from the deterministic wallet
+//! and made in the process of a CoinSwap.
 //!
 //! There are three types of SwapCoins:
 //! [IncomingSwapCoin]: The contract data defining an **incoming** swap.
@@ -26,9 +28,6 @@ use crate::protocol::{
 };
 
 use super::WalletError;
-
-// SwapCoins are UTXOs + metadata which are not from the deterministic wallet.
-// They are made in the process of a coinswap
 
 /// Represents an incoming swapcoin.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -238,7 +237,7 @@ impl IncomingSwapCoin {
     ) -> Result<(), WalletError> {
         if self.other_privkey.is_none() {
             return Err(WalletError::Protocol(
-                "unable to sign: incomplete coinswap for this input".to_string(),
+                "Unable to sign: incomplete coinswap for this input".to_string(),
             ));
         }
         let secp = Secp256k1::new();
@@ -603,9 +602,11 @@ impl SwapCoin for WatchOnlySwapCoin {
         create_multisig_redeemscript(&self.sender_pubkey, &self.receiver_pubkey)
     }
 
-    //potential confusion here:
-    //verify sender sig uses the receiver_pubkey
-    //verify receiver sig uses the sender_pubkey
+    /*
+    Potential confusion here:
+        verify sender sig uses the receiver_pubkey
+        verify receiver sig uses the sender_pubkey
+    */
     fn verify_contract_tx_sender_sig(&self, sig: &Signature) -> Result<(), WalletError> {
         Ok(verify_contract_tx_sig(
             &self.contract_tx,


### PR DESCRIPTION
Making a PR only for updating the milestone would be an overkill so I made some quick fixes alongside.
1. Fix todo: `publickeys` magic numbers are now not hardcoded.
2. Fix todo: `unwrap` to `Result` for better error handling.
3. We now don't need `*/temp-files` in `.gitignore`.
4. Docs `run_teleport.md` and `developer_resources.md` have been renamed, but not at all places. Also we should use relative URLs instead of hardcoded. They work bad when in branch other than `master` and in forks.
5. Remove old information in `src/protocol/messages.rs`
6. Milestone and readme.