### PR TITLE
[feature] Fidelity Bonds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ futures = "0.3"
 dirs = "3.0.1"
 tokio-socks = "0.5"
 reqwest = { version = "0.11", default-features = false, features = ["socks"] }
-chrono = "0.4"
 clap = { version = "4.3.19", features = ["derive"] }
 bitcoind = {version = "0.32", features = ["25_0"] }
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ If you're interested in contributing to the project, explore the [open issues](h
 - [ ] Make tor detectable and connectable by default for Maker and Taker. And Tor configs to their config lists.
 - [ ] Complete all unit tests in modules.
 - [ ] Achieve >80% crate level test coverage ratio (including integration tests).
-- [ ] Clean up and integrate fidelity bonds with maker banning.
+- [x] Clean up and integrate fidelity bonds with maker banning.
 - [ ] Sketch a simple `AddressBook` server. Tor must. This is for MVP. Later on we will move to more decentralized address server architecture.
 - [ ] Turn maker server into a `makerd` binary, and a `maker-cli` rpc controller app, with MVP API.
 - [ ] Finalize the Taker API for downstream wallet integration.

--- a/src/bin/teleport.rs
+++ b/src/bin/teleport.rs
@@ -15,15 +15,12 @@ use coinswap::{
         market::download_and_display_offers,
         wallet::{
             direct_send, display_wallet_addresses, display_wallet_balance, generate_wallet,
-            print_fidelity_bond_address, print_receive_invoice, recover_wallet,
+            print_receive_invoice, recover_wallet,
         },
     },
     taker::{SwapParams, Taker, TakerBehavior},
     utill::{get_data_dir, setup_logger},
-    wallet::{
-        fidelity::YearAndMonth, CoinToSpend, Destination, DisplayAddressType, SendAmount,
-        WalletError,
-    },
+    wallet::{CoinToSpend, Destination, DisplayAddressType, SendAmount, WalletError},
 };
 
 #[derive(Parser, Debug)]
@@ -84,14 +81,6 @@ enum WalletArgsSubcommand {
         /// TODO more information on usefulness
         #[arg(long, short)]
         special_behavior: Option<String>,
-    },
-
-    /// Prints a fidelity bond timelocked address
-    GetFidelityBondAddress {
-        /// Locktime value of timelocked address as yyyy-mm year and month, for example "2025-03"
-        #[arg( long, short, value_parser = clap::value_parser!(YearAndMonth),
-    )]
-        year_and_month: YearAndMonth,
     },
 
     /// Runs Taker.
@@ -187,9 +176,6 @@ fn main() -> Result<(), WalletError> {
             );
 
             start_maker_server(maker).unwrap();
-        }
-        WalletArgsSubcommand::GetFidelityBondAddress { year_and_month } => {
-            print_fidelity_bond_address(&args.wallet_file_name, &year_and_month)?;
         }
         WalletArgsSubcommand::DoCoinswap {
             send_amount,

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -52,7 +52,7 @@ impl Default for MakerConfig {
             required_confirms: 1,
             min_contract_reaction_time: 48,
             min_size: 10_000,
-            fidelity_value: 5_000_000, // 50 million  sats
+            fidelity_value: 5_000_000, // 5 million  sats
             fidelity_timelock: 26_000, // Approx 6 months of blocks
         }
     }

--- a/src/maker/config.rs
+++ b/src/maker/config.rs
@@ -31,6 +31,10 @@ pub struct MakerConfig {
     pub min_contract_reaction_time: u16,
     /// Minimum coinswap amount size in sats
     pub min_size: u64,
+    /// Fidelity Bond Value
+    pub fidelity_value: u64,
+    /// Fidelity Bond timelock in Block heights.
+    pub fidelity_timelock: u32,
 }
 
 impl Default for MakerConfig {
@@ -48,6 +52,8 @@ impl Default for MakerConfig {
             required_confirms: 1,
             min_contract_reaction_time: 48,
             min_size: 10_000,
+            fidelity_value: 5_000_000, // 50 million  sats
+            fidelity_timelock: 26_000, // Approx 6 months of blocks
         }
     }
 }
@@ -142,6 +148,16 @@ impl MakerConfig {
                 default_config.min_size,
             )
             .unwrap_or(default_config.min_size),
+            fidelity_value: parse_field(
+                maker_config_section.get("fidelity_value"),
+                default_config.fidelity_value,
+            )
+            .unwrap_or(default_config.fidelity_value),
+            fidelity_timelock: parse_field(
+                maker_config_section.get("fidelity_timelock"),
+                default_config.fidelity_timelock,
+            )
+            .unwrap_or(default_config.fidelity_timelock),
         })
     }
 }

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -75,7 +75,9 @@ pub async fn handle_message(
                     (tweakable_point, max_size)
                 };
                 connection_state.allowed_message = ExpectedMessage::ReqContractSigsForSender;
-                Some(MakerToTakerMessage::RespOffer(Offer {
+                let fidelity = maker.highest_fidelity_proof.read()?;
+                let fidelity = fidelity.as_ref().expect("proof expected");
+                Some(MakerToTakerMessage::RespOffer(Box::new(Offer {
                     absolute_fee_sat: maker.config.absolute_fee_sats,
                     amount_relative_fee_ppb: maker.config.amount_relative_fee_ppb,
                     time_relative_fee_ppb: maker.config.time_relative_fee_ppb,
@@ -84,7 +86,8 @@ pub async fn handle_message(
                     max_size,
                     min_size: maker.config.min_size,
                     tweakable_point,
-                }))
+                    fidelity: fidelity.clone(),
+                })))
             }
             TakerToMakerMessage::ReqContractSigsForSender(message) => {
                 connection_state.allowed_message = ExpectedMessage::ProofOfFunding;

--- a/src/maker/mod.rs
+++ b/src/maker/mod.rs
@@ -15,7 +15,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use bitcoin::Network;
+use bitcoin::{absolute::LockTime, Amount, Network};
 use bitcoind::bitcoincore_rpc::RpcApi;
 use tokio::{
     io::{AsyncReadExt, BufReader},
@@ -60,6 +60,51 @@ pub async fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
         post_maker_address_to_directory_servers(network, &maker.config.onion_addrs)
             .await
             .expect("unable to add my address to the directory servers, is tor reachable?");
+    }
+
+    // Get the highest value fidelity bond from the wallet.
+    {
+        let mut wallet = maker.wallet.write()?;
+        if let Some(i) = wallet.get_highest_fidelity_index()? {
+            let highest_proof = wallet.generate_fidelity_proof(i, maker.config.port.to_string())?;
+            let mut proof = maker.highest_fidelity_proof.write()?;
+            *proof = Some(highest_proof);
+        } else {
+            // No bond in the wallet. Lets attempt to create one.
+            let amount = Amount::from_sat(maker.config.fidelity_value);
+            let current_height = wallet
+                .rpc
+                .get_block_count()
+                .map_err(WalletError::Rpc)? as u32;
+
+            // Set 100 blocks locktime for test
+            let locktime = if cfg!(feature = "integration-test") {
+                LockTime::from_height(current_height + 100).unwrap()
+            } else {
+                LockTime::from_height(maker.config.fidelity_timelock + current_height).unwrap()
+            };
+
+            match wallet.create_fidelity(amount, locktime) {
+                // Hard error if we cant create fidelity. As without this Maker can't send a valid
+                // Offer to taker.
+                Err(e) => {
+                    log::error!(
+                        "[{}] Fidelity Bond Creation failed: {:?}. Shutting Down Maker server",
+                        maker.config.port,
+                        e
+                    );
+                    return Err(e.into());
+                }
+                Ok(i) => {
+                    log::info!("[{}] Successfully created fidelity bond", maker.config.port);
+                    // FIXME: Hack to get the tests running. This should be the actual onion address.
+                    let onion_string = "localhost:".to_string() + &maker.config.port.to_string();
+                    let highest_proof = wallet.generate_fidelity_proof(i, onion_string)?;
+                    let mut proof = maker.highest_fidelity_proof.write()?;
+                    *proof = Some(highest_proof);
+                }
+            }
+        }
     }
 
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, maker.config.port)).await?;

--- a/src/maker/mod.rs
+++ b/src/maker/mod.rs
@@ -72,10 +72,7 @@ pub async fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
         } else {
             // No bond in the wallet. Lets attempt to create one.
             let amount = Amount::from_sat(maker.config.fidelity_value);
-            let current_height = wallet
-                .rpc
-                .get_block_count()
-                .map_err(WalletError::Rpc)? as u32;
+            let current_height = wallet.rpc.get_block_count().map_err(WalletError::Rpc)? as u32;
 
             // Set 100 blocks locktime for test
             let locktime = if cfg!(feature = "integration-test") {

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -66,6 +66,8 @@ use serde::{Deserialize, Serialize};
 
 use bitcoin::hashes::hash160::Hash as Hash160;
 
+use crate::wallet::FidelityBond;
+
 /// Defines the length of the Preimage.
 pub const PREIMAGE_LEN: usize = 32;
 
@@ -226,19 +228,15 @@ pub struct MakerHello {
 }
 
 /// Contains proof data related to fidelity bond.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct FidelityBondProof {
-    pub utxo: OutPoint,
-    pub utxo_key: PublicKey,
-    pub locktime: i64,
-    pub cert_sig: Signature,
-    pub cert_expiry: u16,
-    pub cert_pubkey: PublicKey,
-    pub onion_sig: Signature,
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Hash)]
+pub struct FidelityProof {
+    pub bond: FidelityBond,
+    pub cert_hash: Hash,
+    pub cert_sig: bitcoin::secp256k1::ecdsa::Signature,
 }
 
 /// Represents an offer in the context of the Coinswap protocol.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Hash)]
 pub struct Offer {
     pub absolute_fee_sat: u64,
     pub amount_relative_fee_ppb: u64,
@@ -248,6 +246,7 @@ pub struct Offer {
     pub max_size: u64,
     pub min_size: u64,
     pub tweakable_point: PublicKey,
+    pub fidelity: FidelityProof,
 }
 
 /// Contract Tx signatures provided by a Sender of a Coinswap.
@@ -287,7 +286,7 @@ pub enum MakerToTakerMessage {
     /// Protocol Handshake.
     MakerHello(MakerHello),
     /// Send the Maker's offer advertisement.
-    RespOffer(Offer),
+    RespOffer(Box<Offer>), // Add box as Offer has large size due to fidelity bond
     /// Send Contract Sigs **for** the Sender side of the hop. The Maker sending this message is the Receiver of the hop.
     RespContractSigsForSender(ContractSigsForSender),
     /// Request Contract Sigs, **as** both the Sending and Receiving side of the hop.

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -58,8 +58,8 @@
 use std::fmt::Display;
 
 use bitcoin::{
-    secp256k1::{ecdsa::Signature, SecretKey},
-    OutPoint, PublicKey, ScriptBuf, Transaction,
+    ecdsa::Signature, hashes::sha256d::Hash, secp256k1::SecretKey, PublicKey, ScriptBuf,
+    Transaction,
 };
 
 use serde::{Deserialize, Serialize};

--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -464,7 +464,7 @@ async fn download_maker_offer_attempt_once(addr: &MakerAddress) -> Result<Offer,
     };
 
     log::debug!(target: "offerbook", "Obtained offer from {}", addr);
-    Ok(offer)
+    Ok(*offer)
 }
 
 pub async fn download_maker_offer(

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -215,7 +215,7 @@ pub fn redeemscript_to_scriptpubkey(redeemscript: &ScriptBuf) -> ScriptBuf {
 }
 
 /// Converts a byte vector to a hexadecimal string representation.
-pub fn to_hex(bytes: &Vec<u8>) -> String {
+pub fn to_hex(bytes: &[u8]) -> String {
     let hex_chars: Vec<char> = "0123456789abcdef".chars().collect();
     let mut hex_string = String::new();
 

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -1,5 +1,6 @@
 //! All Wallet-related errors.
 
+use super::fidelity::FidelityError;
 use crate::protocol::error::ContractError;
 
 /// Enum for handling wallet-related errors.
@@ -12,6 +13,10 @@ pub enum WalletError {
     BIP32(bitcoin::bip32::Error),
     BIP39(bip39::Error),
     Contract(ContractError),
+    Fidelity(FidelityError),
+    Locktime(bitcoin::blockdata::locktime::absolute::Error),
+    Secp(bitcoin::secp256k1::Error),
+    Address(bitcoin::address::Error),
 }
 
 impl From<std::io::Error> for WalletError {
@@ -47,5 +52,29 @@ impl From<ContractError> for WalletError {
 impl From<serde_cbor::Error> for WalletError {
     fn from(value: serde_cbor::Error) -> Self {
         Self::Cbor(value)
+    }
+}
+
+impl From<FidelityError> for WalletError {
+    fn from(value: FidelityError) -> Self {
+        Self::Fidelity(value)
+    }
+}
+
+impl From<bitcoin::blockdata::locktime::absolute::Error> for WalletError {
+    fn from(value: bitcoin::blockdata::locktime::absolute::Error) -> Self {
+        Self::Locktime(value)
+    }
+}
+
+impl From<bitcoin::secp256k1::Error> for WalletError {
+    fn from(value: bitcoin::secp256k1::Error) -> Self {
+        Self::Secp(value)
+    }
+}
+
+impl From<bitcoin::address::Error> for WalletError {
+    fn from(value: bitcoin::address::Error) -> Self {
+        Self::Address(value)
     }
 }

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -329,7 +329,6 @@ impl Wallet {
             } else {
                 remaining -= unspent.0.amount;
                 selected_utxo.push(unspent);
-                continue;
             }
         }
 

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -1,9 +1,32 @@
-//! Defines Fidelity Bonds.
-//!
-//! Fidelity bonds are used in Coinswap as a sybil-resistance mechanism to protect against cheap DOS attacks.
-//! Mostly made by malicious Makers on other Takers and Makers.
+use std::{
+    collections::HashMap,
+    str::FromStr,
+    thread,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
-// To (strongly) disincentivize Sybil behaviour, the value assessment of the bond
+use bitcoin::{
+    absolute::LockTime,
+    bip32::{ChildNumber, DerivationPath},
+    hashes::{sha256d, Hash},
+    opcodes,
+    script::{Builder, Instruction},
+    secp256k1::{KeyPair, Message, Secp256k1},
+    Address, Amount, OutPoint, PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid,
+    Witness,
+};
+use bitcoind::bitcoincore_rpc::RpcApi;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    protocol::messages::FidelityProof,
+    utill::redeemscript_to_scriptpubkey,
+    wallet::{UTXOSpendInfo, Wallet},
+};
+
+use super::WalletError;
+
+// To (strongly) disincentivize Sybil behavior, the value assessment of the bond
 // is based on the (time value of the bond)^x here x is the bond_value_exponent,
 // where x > 1.
 const BOND_VALUE_EXPONENT: f64 = 1.3;
@@ -15,305 +38,50 @@ const BOND_VALUE_EXPONENT: f64 = 1.3;
 // Set as a real number, i.e. 1 = 100% and 0.01 = 1%
 const BOND_VALUE_INTEREST_RATE: f64 = 0.015;
 
-use std::{collections::HashMap, fmt::Display, num::ParseIntError, str::FromStr};
+/// Constant representing the derivation path for fidelity addresses.
+const FIDELITY_DERIVATION_PATH: &str = "m/84'/0'/0'/2";
 
-use chrono::NaiveDate;
-
-use bitcoin::{
-    bip32::{ChildNumber, DerivationPath, ExtendedPrivKey},
-    blockdata::{
-        opcodes,
-        script::{Builder, Instruction, Script},
-    },
-    hashes::{sha256d, Hash},
-    secp256k1::{Context, Message, Secp256k1, SecretKey, Signing},
-    Address, OutPoint, PublicKey, ScriptBuf,
-};
-
-use bitcoind::bitcoincore_rpc::{
-    json::{GetTxOutResult, ListUnspentResultEntry},
-    Client, RpcApi,
-};
-
-use crate::{
-    protocol::messages::FidelityBondProof,
-    utill::{generate_keypair, redeemscript_to_scriptpubkey},
-    wallet::{UTXOSpendInfo, Wallet},
-};
-
-/// Constant representing the derivation path for timelocked addresses.
-pub const TIMELOCKED_MPK_PATH: &str = "m/84'/0'/0'/2";
-
-/// Constant representing the number of timelocked addresses.
-pub const TIMELOCKED_ADDRESS_COUNT: u32 = 960;
-
-/// Constant representing a dummy Onion hostname for regtest.
-pub const REGTEST_DUMMY_ONION_HOSTNAME: &str = "regtest-dummy-onion-hostname.onion";
-
-/// Represents the year & month for the Fidelity Bonds.
-#[derive(Debug, Clone)]
-pub struct YearAndMonth {
-    year: u32,
-    month: u32,
-}
-
-impl YearAndMonth {
-    /// Creates a new `YearAndMonth` instance.
-    pub fn new(year: u32, month: u32) -> YearAndMonth {
-        YearAndMonth { year, month }
-    }
-
-    /// Converts the `YearAndMonth` to an index.
-    pub fn to_index(&self) -> u32 {
-        (self.year - 2020) * 12 + (self.month - 1)
-    }
-}
-
-impl FromStr for YearAndMonth {
-    type Err = YearAndMonthError;
-
-    /// Parses a string into a `YearAndMonth` in yyyy-mm format.
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() != 7 {
-            return Err(YearAndMonthError::WrongLength);
-        }
-        let year = String::from(&s[..4]).parse::<u32>()?;
-        let month = String::from(&s[5..]).parse::<u32>()?;
-        if (2020..=2079).contains(&year) && (1..=12).contains(&month) {
-            Ok(YearAndMonth { year, month })
-        } else {
-            Err(YearAndMonthError::OutOfRange)
-        }
-    }
-}
-
-impl From<std::ffi::OsString> for YearAndMonth {
-    /// Converts an `OsString` into a `YearAndMonth`.
-    fn from(value: std::ffi::OsString) -> Self {
-        YearAndMonth::from_str(&value.into_string().unwrap()).unwrap()
-    }
-}
-
-/// Possible errors when parsing `YearAndMonth`.
+/// Error structure defining possible fidelity related errors
 #[derive(Debug)]
-pub enum YearAndMonthError {
-    WrongLength,
-    ParseIntError(ParseIntError),
-    OutOfRange,
+pub enum FidelityError {
+    WrongScriptType,
+    BondAlreadyExists(u32),
+    BondDoesNotExist,
+    BondAlreadySpent,
+    CertExpired,
+    InsufficientFund { available: u64, required: u64 },
 }
 
-impl From<ParseIntError> for YearAndMonthError {
-    fn from(p: ParseIntError) -> YearAndMonthError {
-        YearAndMonthError::ParseIntError(p)
-    }
-}
+// impl From<bitcoin::secp256k1::Error> for FidelityError {
+//     fn from(value: bitcoin::secp256k1::Error) -> Self {
+//         Self::Secp(value)
+//     }
+// }
 
-impl Display for YearAndMonthError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            YearAndMonthError::WrongLength => write!(f, "WrongLength, should be yyyy-mm"),
-            YearAndMonthError::ParseIntError(p) => p.fmt(f),
-            YearAndMonthError::OutOfRange => {
-                write!(f, "Out of range, must be between 2020-01 and 2079-12")
-            }
-        }
-    }
-}
+// impl From<bitcoin::bip32::Error> for FidelityError {
+//     fn from(value: bitcoin::bip32::Error) -> Self {
+//         Self::Bip32(value)
+//     }
+// }
 
-/// Creates a hash for the fidelity bond certificate message.
-fn create_cert_msg_hash(cert_pubkey: &PublicKey, cert_expiry: u16) -> Message {
-    let cert_msg_str = format!("fidelity-bond-cert|{}|{}", cert_pubkey, cert_expiry);
-    let cert_msg = cert_msg_str.as_bytes();
-    let mut btc_signed_msg = Vec::<u8>::new();
-    btc_signed_msg.extend("\x18Bitcoin Signed Message:\n".as_bytes());
-    btc_signed_msg.push(cert_msg.len() as u8);
-    btc_signed_msg.extend(cert_msg);
-    Message::from_slice(sha256d::Hash::hash(&btc_signed_msg).as_byte_array()).unwrap()
-}
+// impl From<bitcoin::consensus::encode::Error> for FidelityError {
+//     fn from(value: bitcoin::consensus::encode::Error) -> Self {
+//         Self::Encoding(value)
+//     }
+// }
 
-/// Represents a hot wallet fidelity bond.
-pub struct HotWalletFidelityBond {
-    pub utxo: OutPoint,
-    utxo_key: PublicKey,
-    locktime: i64,
-    utxo_privkey: SecretKey,
-}
+// impl From<bitcoin::key::Error> for FidelityError {
+//     fn from(value: bitcoin::key::Error) -> Self {
+//         Self::WrongPubKeyFormat(value.to_string())
+//     }
+// }
 
-impl HotWalletFidelityBond {
-    /// Creates a new `HotWalletFidelityBond`.
-    pub fn new(wallet: &Wallet, utxo: &ListUnspentResultEntry, spend_info: &UTXOSpendInfo) -> Self {
-        let index = if let UTXOSpendInfo::FidelityBondCoin {
-            index,
-            input_value: _,
-        } = spend_info
-        {
-            *index
-        } else {
-            panic!("bug, should be fidelity bond coin")
-        };
-        let redeemscript = wallet.get_timelocked_redeemscript_from_index(index);
-        Self {
-            utxo: OutPoint {
-                txid: utxo.txid,
-                vout: utxo.vout,
-            },
-            utxo_key: read_pubkey_from_timelocked_redeemscript(&redeemscript).unwrap(),
-            locktime: read_locktime_from_timelocked_redeemscript(&redeemscript).unwrap(),
-            utxo_privkey: wallet.get_timelocked_privkey_from_index(index),
-        }
-    }
+// ------- Fidelity Helper Scripts -------------
 
-    /// Creates a fidelity bond proof.
-    pub fn create_proof(&self, rpc: &Client, onion_hostname: &str) -> FidelityBondProof {
-        const BLOCK_COUNT_SAFETY: u64 = 2;
-        const RETARGET_INTERVAL: u64 = 2016;
-        const CERT_MAX_VALIDITY_TIME: u64 = 1;
-
-        let blocks = rpc.get_block_count().unwrap();
-        let cert_expiry =
-            ((blocks + BLOCK_COUNT_SAFETY) / RETARGET_INTERVAL) + CERT_MAX_VALIDITY_TIME;
-        let cert_expiry = cert_expiry as u16;
-
-        let (cert_pubkey, cert_privkey) = generate_keypair();
-        let secp = Secp256k1::new();
-
-        let cert_msg_hash = create_cert_msg_hash(&cert_pubkey, cert_expiry);
-        let cert_sig = secp.sign_ecdsa(&cert_msg_hash, &self.utxo_privkey);
-
-        let onion_msg_hash =
-            Message::from_slice(sha256d::Hash::hash(onion_hostname.as_bytes()).as_byte_array())
-                .unwrap();
-        let onion_sig = secp.sign_ecdsa(&onion_msg_hash, &cert_privkey);
-
-        FidelityBondProof {
-            utxo: self.utxo,
-            utxo_key: self.utxo_key,
-            locktime: self.locktime,
-            cert_sig,
-            cert_expiry,
-            cert_pubkey,
-            onion_sig,
-        }
-    }
-}
-
-impl FidelityBondProof {
-    /// Verifies the fidelity bond proof and gets the transaction output.
-    pub fn verify_and_get_txo(
-        &self,
-        rpc: &Client,
-        block_count: u64,
-        onion_hostname: &str,
-    ) -> GetTxOutResult {
-        let secp = Secp256k1::new();
-
-        let onion_msg_hash =
-            Message::from_slice(sha256d::Hash::hash(onion_hostname.as_bytes()).as_byte_array())
-                .unwrap();
-        secp.verify_ecdsa(&onion_msg_hash, &self.onion_sig, &self.cert_pubkey.inner)
-            .unwrap();
-        let cert_msg_hash = create_cert_msg_hash(&self.cert_pubkey, self.cert_expiry);
-        secp.verify_ecdsa(&cert_msg_hash, &self.cert_sig, &self.utxo_key.inner)
-            .unwrap();
-
-        let txo_data = rpc
-            .get_tx_out(&self.utxo.txid, self.utxo.vout, None)
-            .unwrap()
-            .unwrap();
-
-        const RETARGET_INTERVAL: u64 = 2016;
-        if block_count > self.cert_expiry as u64 * RETARGET_INTERVAL {
-            panic!("cert has expired");
-        }
-
-        let implied_spk = redeemscript_to_scriptpubkey(&create_timelocked_redeemscript(
-            self.locktime,
-            &self.utxo_key,
-        ));
-        if txo_data.script_pub_key.hex != implied_spk.into_bytes() {
-            panic!("UTXO script doesnt match given script",);
-        }
-
-        // an important thing we cant verify in this function
-        // is that a given fidelity bond UTXO was only used once in the offer book
-        // that has to be checked elsewhere
-
-        txo_data
-    }
-
-    /// Calculates the fidelity bond value.
-    pub fn calculate_fidelity_bond_value(
-        &self,
-        rpc: &Client,
-        block_count: u64,
-        txo_data: &GetTxOutResult,
-        mediantime: u64,
-    ) -> f64 {
-        let blockhash = rpc
-            .get_block_hash(block_count - txo_data.confirmations as u64 + 1)
-            .unwrap();
-        calculate_timelocked_fidelity_bond_value(
-            txo_data.value.to_sat(),
-            self.locktime,
-            rpc.get_block_header_info(&blockhash).unwrap().time as i64,
-            mediantime,
-        )
-    }
-}
-
-/// Calculates the timelocked fidelity bond value from UTXO information.
-#[allow(non_snake_case)]
-fn calculate_timelocked_fidelity_bond_value(
-    value_sats: u64,
-    locktime: i64,
-    confirmation_time: i64,
-    current_time: u64,
-) -> f64 {
-    const YEAR: f64 = 60.0 * 60.0 * 24.0 * 365.2425; // Gregorian calender year length
-
-    let r = BOND_VALUE_INTEREST_RATE;
-    let T = (locktime - confirmation_time) as f64 / YEAR;
-    let L = locktime as f64 / YEAR;
-    let t = current_time as f64 / YEAR;
-
-    let exp_rT_m1 = f64::exp_m1(r * T);
-    let exp_rtL_m1 = f64::exp_m1(r * f64::max(0.0, t - L));
-
-    let timevalue = f64::max(0.0, f64::min(1.0, exp_rT_m1) - f64::min(1.0, exp_rtL_m1));
-
-    (value_sats as f64 * timevalue).powf(BOND_VALUE_EXPONENT)
-}
-
-fn calculate_timelocked_fidelity_bond_value_from_utxo(
-    utxo: &ListUnspentResultEntry,
-    usi: &UTXOSpendInfo,
-    rpc: &Client,
-) -> f64 {
-    calculate_timelocked_fidelity_bond_value(
-        utxo.amount.to_sat(),
-        get_locktime_from_index(
-            if let UTXOSpendInfo::FidelityBondCoin {
-                index,
-                input_value: _,
-            } = usi
-            {
-                *index
-            } else {
-                panic!("bug, should be fidelity bond coin")
-            },
-        ),
-        rpc.get_transaction(&utxo.txid, Some(true))
-            .unwrap()
-            .info
-            .blocktime
-            .unwrap() as i64,
-        rpc.get_blockchain_info().unwrap().median_time,
-    )
-}
-
-fn create_timelocked_redeemscript(locktime: i64, pubkey: &PublicKey) -> ScriptBuf {
+/// Create a Fidelity Timelocked redeemscript.
+pub fn fidelity_redeemscript(lock_time: &LockTime, pubkey: &PublicKey) -> ScriptBuf {
     Builder::new()
-        .push_int(locktime)
+        .push_lock_time(*lock_time)
         .push_opcode(opcodes::all::OP_CLTV)
         .push_opcode(opcodes::all::OP_DROP)
         .push_key(pubkey)
@@ -321,150 +89,531 @@ fn create_timelocked_redeemscript(locktime: i64, pubkey: &PublicKey) -> ScriptBu
         .into_script()
 }
 
-/// Reads the locktime from a timelocked redeem script.
-pub fn read_locktime_from_timelocked_redeemscript(redeemscript: &Script) -> Option<i64> {
-    if let Instruction::PushBytes(locktime_bytes) = redeemscript.instructions().next()?.ok()? {
-        let mut u8slice: [u8; 8] = [0; 8];
-        u8slice[..locktime_bytes.len()].copy_from_slice(locktime_bytes.as_bytes());
-        Some(i64::from_le_bytes(u8slice))
+#[allow(unused)]
+/// Reads the locktime from a fidelity redeemscript.
+pub fn read_locktime_from_fidelity_script(
+    redeemscript: &ScriptBuf,
+) -> Result<LockTime, FidelityError> {
+    if let Some(Ok(Instruction::PushBytes(locktime_bytes))) = redeemscript.instructions().next() {
+        let mut u4slice: [u8; 4] = [0; 4];
+        u4slice[..locktime_bytes.len()].copy_from_slice(locktime_bytes.as_bytes());
+        Ok(LockTime::from_consensus(u32::from_le_bytes(u4slice)))
     } else {
-        None
+        Err(FidelityError::WrongScriptType)
     }
 }
 
-/// Reads the public key from a timelocked redeem script.
-fn read_pubkey_from_timelocked_redeemscript(redeemscript: &Script) -> Option<PublicKey> {
-    if let Instruction::PushBytes(pubkey_bytes) = redeemscript.instructions().nth(3)?.ok()? {
-        PublicKey::from_slice(pubkey_bytes.as_bytes()).ok()
+#[allow(unused)]
+/// Reads the public key from a fidelity redeemscript.
+fn read_pubkey_from_fidelity_script(redeemscript: &ScriptBuf) -> Result<PublicKey, FidelityError> {
+    if let Some(Ok(Instruction::PushBytes(pubkey_bytes))) = redeemscript.instructions().nth(3) {
+        Ok(PublicKey::from_slice(pubkey_bytes.as_bytes()).unwrap())
     } else {
-        None
+        Err(FidelityError::WrongScriptType)
     }
 }
 
-/// Gets the timelocked master key from the root master key.
-fn get_timelocked_master_key_from_root_master_key(master_key: &ExtendedPrivKey) -> ExtendedPrivKey {
-    let secp = Secp256k1::new();
+/// Calculates the theoretical fidelity bond value. Bond value calculation is described in the doc below.
+/// https://gist.github.com/chris-belcher/87ebbcbb639686057a389acb9ab3e25b#financial-mathematics-of-joinmarket-fidelity-bonds
+pub fn calculate_fidelity_value(
+    value: Amount,          // Bond amount in sats
+    locktime: u64,          // Bond locktime timestamp
+    confirmation_time: u64, // Confirmation timestamp
+    current_time: u64,      // Current timestamp
+) -> Amount {
+    let sec_in_a_year: f64 = 60.0 * 60.0 * 24.0 * 365.2425; // Gregorian calender year length
 
-    master_key
-        .derive_priv(
-            &secp,
-            &DerivationPath::from_str(TIMELOCKED_MPK_PATH).unwrap(),
-        )
-        .unwrap()
+    let interest_rate = BOND_VALUE_INTEREST_RATE;
+    let lock_period_yr = (locktime - confirmation_time) as f64 / sec_in_a_year;
+    let locktime_yr = locktime as f64 / sec_in_a_year;
+    let currenttime_yr = current_time as f64 / sec_in_a_year;
+
+    // TODO: This calculation can be simplified
+    let exp_rt_m1 = f64::exp_m1(interest_rate * lock_period_yr);
+    let exp_rtl_m1 = f64::exp_m1(interest_rate * f64::max(0.0, currenttime_yr - locktime_yr));
+
+    let timevalue = f64::max(0.0, f64::min(1.0, exp_rt_m1) - f64::min(1.0, exp_rtl_m1));
+
+    Amount::from_sat((value.to_sat() as f64 * timevalue).powf(BOND_VALUE_EXPONENT) as u64)
 }
 
-/// Gets the locktime from an index.
-pub fn get_locktime_from_index(index: u32) -> i64 {
-    let year_off = index as i32 / 12;
-    let month = index % 12;
-    NaiveDate::from_ymd_opt(2020 + year_off, 1 + month, 1)
-        .expect("expected")
-        .and_hms_opt(0, 0, 0)
-        .expect("expected")
-        .timestamp()
+/// Structure describing a Fidelity Bond.
+/// Fidelity Bonds are described in https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/fidelity-bonds.md
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Hash)]
+pub struct FidelityBond {
+    pub outpoint: OutPoint,
+    pub amount: u64,
+    pub lock_time: LockTime,
+    pub pubkey: PublicKey,
+    // Height at which the bond was confirmed.
+    pub conf_height: u32,
+    // Cert expiry denoted in multiple of difficulty adjustment period (2016 blocks)
+    pub cert_expiry: u64,
 }
 
-/// Gets the timelocked redeem script from an index.
-fn get_timelocked_redeemscript_from_index<C: Context + Signing>(
-    secp: &Secp256k1<C>,
-    timelocked_master_private_key: &ExtendedPrivKey,
-    index: u32,
-) -> ScriptBuf {
-    let privkey = timelocked_master_private_key
-        .ckd_priv(secp, ChildNumber::Normal { index })
-        .unwrap()
-        .private_key;
-    let pubkey = PublicKey {
-        compressed: true,
-        inner: privkey.public_key(secp),
-    };
-    let locktime = get_locktime_from_index(index);
-    create_timelocked_redeemscript(locktime, &pubkey)
-}
-
-/// Generates fidelity scripts for a master key.
-pub fn generate_fidelity_scripts(master_key: &ExtendedPrivKey) -> HashMap<ScriptBuf, u32> {
-    let timelocked_master_private_key = get_timelocked_master_key_from_root_master_key(master_key);
-    let mut timelocked_script_index_map = HashMap::new();
-
-    let secp = Secp256k1::new();
-    //all these magic numbers and constants are explained in the fidelity bonds bip
-    // https://gist.github.com/chris-belcher/7257763cedcc014de2cd4239857cd36e
-    for index in 0..TIMELOCKED_ADDRESS_COUNT {
-        let redeemscript =
-            get_timelocked_redeemscript_from_index(&secp, &timelocked_master_private_key, index);
-        let spk = redeemscript_to_scriptpubkey(&redeemscript);
-        timelocked_script_index_map.insert(spk, index);
+impl FidelityBond {
+    /// get the reedemscript for this bond
+    pub fn redeem_script(&self) -> ScriptBuf {
+        fidelity_redeemscript(&self.lock_time, &self.pubkey)
     }
-    timelocked_script_index_map
+
+    /// Get the script_pubkey for this bond.
+    pub fn script_pub_key(&self) -> ScriptBuf {
+        redeemscript_to_scriptpubkey(&self.redeem_script())
+    }
+
+    /// Generate the bond's certificate hash.
+    pub fn generate_cert_hash(&self, onion_addr: String) -> sha256d::Hash {
+        let cert_msg_str = format!(
+            "fidelity-bond-cert|{}|{}|{}|{}|{}|{}",
+            self.outpoint, self.pubkey, self.cert_expiry, self.lock_time, self.amount, onion_addr
+        );
+        let cert_msg = cert_msg_str.as_bytes();
+        let mut btc_signed_msg = Vec::<u8>::new();
+        btc_signed_msg.extend("\x18Bitcoin Signed Message:\n".as_bytes());
+        btc_signed_msg.push(cert_msg.len() as u8);
+        btc_signed_msg.extend(cert_msg);
+        sha256d::Hash::hash(&btc_signed_msg)
+    }
 }
 
+// Wallet APIs related to fidelity bonds.
 impl Wallet {
-    /// Gets the timelocked redeem script from an index.
-    pub fn get_timelocked_redeemscript_from_index(&self, index: u32) -> ScriptBuf {
-        get_timelocked_redeemscript_from_index(
-            &Secp256k1::new(),
-            &get_timelocked_master_key_from_root_master_key(&self.store.master_key),
-            index,
-        )
+    /// Get a reference to the fidelity bond store
+    pub fn get_fidelity_bonds(&self) -> &HashMap<u32, (FidelityBond, ScriptBuf, bool)> {
+        &self.store.fidelity_bond
     }
 
-    /// Gets the timelocked private key from an index.
-    pub fn get_timelocked_privkey_from_index(&self, index: u32) -> SecretKey {
-        get_timelocked_master_key_from_root_master_key(&self.store.master_key)
-            .ckd_priv(&Secp256k1::new(), ChildNumber::Normal { index })
-            .unwrap()
-            .private_key
-    }
-
-    /// Gets the timelocked address and locktime for a given YearAndMonth.
-    pub fn get_timelocked_address(&self, locktime: &YearAndMonth) -> (Address, i64) {
-        let redeemscript = self.get_timelocked_redeemscript_from_index(locktime.to_index());
-        let addr = Address::p2wsh(&redeemscript, self.store.network);
-        let unix_locktime = read_locktime_from_timelocked_redeemscript(&redeemscript)
-            .expect("bug: unable to read locktime");
-        (addr, unix_locktime)
-    }
-
-    /// Finds the most valuable fidelity bond in the wallet.
-    // Returns Ok(None) if no fidelity bonds in wallet.
-    pub fn find_most_valuable_fidelity_bond(&self, rpc: &Client) -> Option<HotWalletFidelityBond> {
-        let list_unspent_result = self.list_unspent_from_wallet(false, true).unwrap();
-        let fidelity_bond_utxos = list_unspent_result
+    /// Get the highest value fidelity bond. Returns None, if no bond exists.
+    pub fn get_highest_fidelity_index(&self) -> Result<Option<u32>, WalletError> {
+        Ok(self
+            .store
+            .fidelity_bond
             .iter()
-            .filter(|(utxo, _)| utxo.confirmations > 0)
-            .filter(|(_, usi)| {
-                matches!(
-                    usi,
-                    UTXOSpendInfo::FidelityBondCoin {
-                        index: _,
-                        input_value: _,
+            .filter_map(|(i, (_, _, is_spent))| {
+                if !is_spent {
+                    let value = self.calculate_bond_value(*i).unwrap();
+                    Some((i, value))
+                } else {
+                    None
+                }
+            })
+            .max_by(|a, b| a.1.cmp(&b.1))
+            .map(|(i, _)| *i))
+    }
+    /// Get the [KeyPair] for the fidelity bond at given index.
+    pub fn get_fidelity_keypair(&self, index: u32) -> Result<KeyPair, WalletError> {
+        let secp = Secp256k1::new();
+
+        let derivation_path = DerivationPath::from_str(FIDELITY_DERIVATION_PATH)?;
+
+        let child_index = ChildNumber::Normal { index };
+
+        Ok(self
+            .store
+            .master_key
+            .derive_priv(&secp, &derivation_path)?
+            .ckd_priv(&secp, child_index)?
+            .to_keypair(&secp))
+    }
+
+    /// Derives the fidelity redeemscript from bond values at given index.
+    pub fn get_fidelity_reedemscript(&self, index: u32) -> Result<ScriptBuf, WalletError> {
+        let (bond, _, _) = self
+            .store
+            .fidelity_bond
+            .get(&index)
+            .ok_or(FidelityError::BondDoesNotExist)?;
+        Ok(bond.redeem_script())
+    }
+
+    /// Get the next fidelity bond address. If no fidelity bond is created
+    /// returned address will be derived from index 0, of the [FIDELITY_DERIVATION_PATH]
+    pub fn get_next_fidelity_address(
+        &self,
+        locktime: LockTime,
+    ) -> Result<(u32, Address, PublicKey), WalletError> {
+        // Check what was the last fidelity address index.
+        // Derive a fidelity address
+        let next_index = self
+            .store
+            .fidelity_bond
+            .keys()
+            .map(|i| *i + 1)
+            .last()
+            .unwrap_or(0);
+
+        let fidelity_pubkey = PublicKey {
+            compressed: true,
+            inner: self.get_fidelity_keypair(next_index)?.public_key(),
+        };
+
+        Ok((
+            next_index,
+            Address::p2wsh(
+                fidelity_redeemscript(&locktime, &fidelity_pubkey).as_script(),
+                self.store.network,
+            ),
+            fidelity_pubkey,
+        ))
+    }
+
+    /// Calculate the theoretical fidelity bond value.
+    /// Bond value calculation is described in the document below.
+    /// https://gist.github.com/chris-belcher/87ebbcbb639686057a389acb9ab3e25b#financial-mathematics-of-joinmarket-fidelity-bonds
+    pub fn calculate_bond_value(&self, index: u32) -> Result<Amount, WalletError> {
+        let (bond, _, _) = self
+            .store
+            .fidelity_bond
+            .get(&index)
+            .ok_or(FidelityError::BondDoesNotExist)?;
+        let current_time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("This can't error")
+            .as_secs();
+
+        let hash = self.rpc.get_block_hash(bond.conf_height as u64)?;
+
+        let confirmation_time = self.rpc.get_block_header_info(&hash)?.time as u64;
+
+        let locktime = match bond.lock_time {
+            LockTime::Blocks(blocks) => {
+                let tip_hash = self.rpc.get_blockchain_info()?.best_block_hash;
+                let (tip_height, tip_time) = {
+                    let info = self.rpc.get_block_header_info(&tip_hash)?;
+                    (info.height, info.time as u64)
+                };
+                // Estimated locktime from block height = [current-time + (maturity-height - block-count) * 10 * 60] sec
+                tip_time + ((blocks.to_consensus_u32() - tip_height as u32) * 10 * 60) as u64
+            }
+            LockTime::Seconds(sec) => sec.to_consensus_u32() as u64,
+        };
+
+        let bond_value = calculate_fidelity_value(
+            Amount::from_sat(bond.amount),
+            locktime,
+            confirmation_time,
+            current_time,
+        );
+
+        Ok(bond_value)
+    }
+
+    /// Create a new fidelity bond with given amount and locktime.
+    /// This functions creates the fidelity transaction, signs and broadcast it.
+    /// Upon confirmation it stores the fidelity information in the wallet data.
+    pub fn create_fidelity(
+        &mut self,
+        amount: Amount,
+        locktime: LockTime, // The final locktime in blockheight or timestamp
+    ) -> Result<u32, WalletError> {
+        let (index, fidelity_addr, fidelity_pubkey) = self.get_next_fidelity_address(locktime)?;
+
+        // Fetch utxos, filter out existing fidelity coins
+        let mut unspents = self
+            .list_unspent_from_wallet(false, false)?
+            .into_iter()
+            .filter(|(_, spend_info)| !matches!(spend_info, UTXOSpendInfo::FidelityBondCoin { .. }))
+            .collect::<Vec<_>>();
+
+        unspents.sort_by(|a, b| b.0.amount.cmp(&a.0.amount));
+
+        let mut selected_utxo = Vec::new();
+        let mut remaining = amount;
+
+        // the simplest largest first coinselection.
+        for unspent in unspents {
+            if remaining.checked_sub(unspent.0.amount).is_none() {
+                selected_utxo.push(unspent);
+                break;
+            } else {
+                remaining -= unspent.0.amount;
+                selected_utxo.push(unspent);
+                continue;
+            }
+        }
+
+        let fee = Amount::from_sat(1000); // TODO: Update this with the feerate
+
+        let total_input_amount = selected_utxo.iter().fold(Amount::ZERO, |acc, (unspet, _)| {
+            acc.checked_add(unspet.amount)
+                .expect("Amount sum overflowed")
+        });
+
+        if total_input_amount < amount {
+            return Err(FidelityError::InsufficientFund {
+                available: total_input_amount.to_sat(),
+                required: amount.to_sat(),
+            }
+            .into());
+        }
+
+        let change_amount = total_input_amount.checked_sub(amount + fee);
+        let tx_inputs = selected_utxo
+            .iter()
+            .map(|(unspent, _)| TxIn {
+                previous_output: OutPoint::new(unspent.txid, unspent.vout),
+                sequence: Sequence(0),
+                witness: Witness::new(),
+                script_sig: ScriptBuf::new(),
+            })
+            .collect::<Vec<_>>();
+
+        let mut tx_outs = vec![TxOut {
+            value: amount.to_sat(),
+            script_pubkey: fidelity_addr.script_pubkey(),
+        }];
+
+        if change_amount.is_some() {
+            let change_addrs = self.get_next_internal_addresses(1)?[0].script_pubkey();
+            tx_outs.push(TxOut {
+                value: change_amount.expect("expected").to_sat(),
+                script_pubkey: change_addrs,
+            })
+        }
+        let current_height = self.rpc.get_block_count()?;
+        let anti_fee_snipping_locktime = LockTime::from_height(current_height as u32)?;
+
+        let mut tx = Transaction {
+            input: tx_inputs,
+            output: tx_outs,
+            lock_time: anti_fee_snipping_locktime,
+            version: 2, // anti-fee-snipping
+        };
+
+        let mut input_info = selected_utxo
+            .iter()
+            .map(|(_, spend_info)| spend_info.clone());
+        self.sign_transaction(&mut tx, &mut input_info)?;
+
+        let txid = self.rpc.send_raw_transaction(&tx)?;
+
+        let conf_height = loop {
+            if let Ok(get_tx_result) = self.rpc.get_transaction(&txid, None) {
+                if let Some(ht) = get_tx_result.info.blockheight {
+                    log::info!("Fidelity Bond confirmed at blockheight: {}", ht);
+                    break ht;
+                } else {
+                    log::info!(
+                        "Fildelity Transaction {} seen in mempool, waiting for confirmation.",
+                        txid
+                    );
+                    if cfg!(feature = "integration-test") {
+                        thread::sleep(Duration::from_secs(1)); // wait for 1 sec in tests
+                    } else {
+                        thread::sleep(Duration::from_secs(60 * 10)); // wait for 10 mins in prod
                     }
-                )
-            })
-            .collect::<Vec<&(ListUnspentResultEntry, UTXOSpendInfo)>>();
-        let fidelity_bond_values = fidelity_bond_utxos
-            .iter()
-            .map(|(utxo, usi)| calculate_timelocked_fidelity_bond_value_from_utxo(utxo, usi, rpc))
-            .collect::<Vec<f64>>();
-        fidelity_bond_utxos
-            .iter()
-            .zip(fidelity_bond_values.iter())
-            //partial_cmp fails if NaN value involved, which wont happen, so unwrap() is acceptable
-            .max_by(|(_, x), (_, y)| x.partial_cmp(y).unwrap())
-            .map(|most_valuable_fidelity_bond| {
-                HotWalletFidelityBond::new(
-                    self,
-                    &most_valuable_fidelity_bond.0 .0,
-                    &most_valuable_fidelity_bond.0 .1,
-                )
-            })
+
+                    continue;
+                }
+            } else {
+                log::info!("Waiting for {} in mempool", txid);
+                continue;
+            }
+        };
+
+        let cert_expiry = self.get_fidelity_expriy()?;
+
+        let bond = FidelityBond {
+            outpoint: OutPoint::new(txid, 0),
+            amount: amount.to_sat(),
+            lock_time: locktime,
+            pubkey: fidelity_pubkey,
+            conf_height,
+            cert_expiry,
+        };
+
+        let bond_spk = bond.script_pub_key();
+
+        self.store
+            .fidelity_bond
+            .insert(index, (bond, bond_spk, false));
+
+        Ok(index)
+    }
+
+    /// Redeem a Fidelity Bond.
+    /// This functions creates a spending transaction, signs and broadcasts it.
+    /// Upon confirmation it marks the bond as `spent` in the wallet data.
+    pub fn redeem_fidelity(&mut self, index: u32) -> Result<Txid, WalletError> {
+        let (bond, _, is_spent) = self
+            .store
+            .fidelity_bond
+            .get(&index)
+            .ok_or(FidelityError::BondDoesNotExist)?;
+
+        if *is_spent {
+            return Err(FidelityError::BondAlreadySpent.into());
+        }
+
+        // create a spending transaction.
+        let txin = TxIn {
+            previous_output: bond.outpoint,
+            sequence: Sequence(0),
+            script_sig: ScriptBuf::new(),
+            witness: Witness::new(),
+        };
+
+        // TODO take feerate as user input
+        let fee = 1000;
+
+        let change_addr = &self.get_next_internal_addresses(1)?[0];
+
+        let txout = TxOut {
+            script_pubkey: change_addr.script_pubkey(),
+            value: bond.amount - fee,
+        };
+
+        let mut tx = Transaction {
+            input: vec![txin],
+            output: vec![txout],
+            lock_time: bond.lock_time,
+            version: 2,
+        };
+
+        let utxo_spend_info = UTXOSpendInfo::FidelityBondCoin {
+            index,
+            input_value: bond.amount,
+        };
+
+        self.sign_transaction(&mut tx, vec![utxo_spend_info].into_iter())?;
+
+        let txid = self.rpc.send_raw_transaction(&tx)?;
+
+        let conf_height = loop {
+            if let Ok(get_tx_result) = self.rpc.get_transaction(&txid, None) {
+                if let Some(ht) = get_tx_result.info.blockheight {
+                    log::info!("Fidelity Bond confirmed at blockheight: {}", ht);
+                    break ht;
+                } else {
+                    log::info!(
+                        "Fildelity Transaction {} seen in mempool, waiting for confirmation.",
+                        txid
+                    );
+
+                    if cfg!(feature = "integration-test") {
+                        thread::sleep(Duration::from_secs(1)); // wait for 1 sec in tests
+                    } else {
+                        thread::sleep(Duration::from_secs(60 * 10)); // wait for 10 mins in prod
+                    }
+
+                    continue;
+                }
+            } else {
+                log::info!("Waiting for {} in mempool", txid);
+                continue;
+            }
+        };
+
+        log::info!(
+            "Fidleity spend txid: {}, confirmed at height : {}",
+            txid,
+            conf_height
+        );
+
+        // mark is_spent
+        {
+            let (_, _, is_spent) = self
+                .store
+                .fidelity_bond
+                .get_mut(&index)
+                .ok_or(FidelityError::BondDoesNotExist)?;
+
+            *is_spent = true;
+        }
+
+        Ok(txid)
+    }
+
+    /// Generate a [FidelityProof] for bond at a given index and a specific onion address.
+    pub fn generate_fidelity_proof(
+        &self,
+        index: u32,
+        onion_addr: String,
+    ) -> Result<FidelityProof, WalletError> {
+        // Generate a fidelity bond proof from the fidelity data.
+        let (bond, _, is_spent) = self
+            .store
+            .fidelity_bond
+            .get(&index)
+            .ok_or(FidelityError::BondDoesNotExist)?;
+
+        if *is_spent {
+            return Err(FidelityError::BondAlreadySpent.into());
+        }
+
+        let fidelity_privkey = self.get_fidelity_keypair(index)?.secret_key();
+
+        let cert_hash = bond.generate_cert_hash(onion_addr);
+
+        let secp = Secp256k1::new();
+        let cert_sig = secp.sign_ecdsa(
+            &Message::from_slice(cert_hash.as_byte_array())?,
+            &fidelity_privkey,
+        );
+
+        Ok(FidelityProof {
+            bond: bond.clone(),
+            cert_hash,
+            cert_sig,
+        })
+    }
+
+    /// Verify a [FidelityProof] received from the directory servers.
+    pub fn verify_fidelity_proof(
+        &self,
+        proof: &FidelityProof,
+        onion_addr: String,
+    ) -> Result<(), WalletError> {
+        if self.is_fidelity_expired(&proof.bond)? {
+            return Err(FidelityError::CertExpired.into());
+        }
+
+        let cert_message =
+            Message::from_slice(proof.bond.generate_cert_hash(onion_addr).as_byte_array())?;
+
+        let secp = Secp256k1::new();
+
+        Ok(secp.verify_ecdsa(&cert_message, &proof.cert_sig, &proof.bond.pubkey.inner)?)
+    }
+
+    /// Calculate the expiry value. This depends on the current block height.
+    pub fn get_fidelity_expriy(&self) -> Result<u64, WalletError> {
+        let current_height = self.rpc.get_block_count()?;
+        Ok(((current_height + 2/* safety buffer */) / 2016) + 5)
+    }
+
+    /// Extend the expiry of a fidelity bond. This is useful for bonds which are close to their expiry.
+    pub fn extend_fidelity_expiry(&mut self, index: u32) -> Result<(), WalletError> {
+        let cert_expiry = self.get_fidelity_expriy()?;
+        let (bond, _, _) = self
+            .store
+            .fidelity_bond
+            .get_mut(&index)
+            .ok_or(FidelityError::BondDoesNotExist)?;
+
+        bond.cert_expiry = cert_expiry;
+
+        Ok(())
+    }
+
+    /// Checks if the bond has expired.
+    pub fn is_fidelity_expired(&self, bond: &FidelityBond) -> Result<bool, WalletError> {
+        // Certificate has expired if current height more than the expiry difficulty period target
+        // 1 difficulty period = 2016 blocks
+        let current_height = self.rpc.get_block_count()?;
+        if current_height > bond.cert_expiry * 2016 {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn test_fidelity_bond_value_function_behavior() {
@@ -474,12 +623,13 @@ mod test {
         //the function should be flat anywhere before the locktime ends
         let values = (0..4)
             .map(|y| {
-                calculate_timelocked_fidelity_bond_value(
-                    100000000,
-                    (6.0 * YEAR) as i64,
+                calculate_fidelity_value(
+                    Amount::from_sat(100000000),
+                    (6.0 * YEAR) as u64,
                     0,
                     y * YEAR as u64,
                 )
+                .to_sat() as f64
             })
             .collect::<Vec<f64>>();
         let value_diff = (0..values.len() - 1)
@@ -492,12 +642,13 @@ mod test {
         //after locktime, the value should go down
         let values = (0..5)
             .map(|y| {
-                calculate_timelocked_fidelity_bond_value(
-                    100000000,
-                    (6.0 * YEAR) as i64,
+                calculate_fidelity_value(
+                    Amount::from_sat(100000000),
+                    (6.0 * YEAR) as u64,
                     0,
                     (6 + y) * YEAR as u64,
                 )
+                .to_sat() as f64
             })
             .collect::<Vec<f64>>();
         let value_diff = (0..values.len() - 1)
@@ -510,7 +661,13 @@ mod test {
         //value of a bond goes up as the locktime goes up
         let values = (0..5)
             .map(|y| {
-                calculate_timelocked_fidelity_bond_value(100000000, (y as f64 * YEAR) as i64, 0, 0)
+                calculate_fidelity_value(
+                    Amount::from_sat(100000000),
+                    (y as f64 * YEAR) as u64,
+                    0,
+                    0,
+                )
+                .to_sat() as f64
             })
             .collect::<Vec<f64>>();
         let value_ratio = (0..values.len() - 1)
@@ -526,12 +683,13 @@ mod test {
         //value of a bond locked into the far future is constant, clamped at the value of burned coins
         let values = (0..5)
             .map(|y| {
-                calculate_timelocked_fidelity_bond_value(
-                    100000000,
-                    ((200 + y) as f64 * YEAR) as i64,
+                calculate_fidelity_value(
+                    Amount::from_sat(100000000),
+                    ((200 + y) as f64 * YEAR) as u64,
                     0,
                     0,
                 )
+                .to_sat() as f64
             })
             .collect::<Vec<f64>>();
         let value_diff = (0..values.len() - 1)
@@ -539,6 +697,59 @@ mod test {
             .collect::<Vec<f64>>();
         for v in &value_diff {
             assert!(v.abs() < EPSILON);
+        }
+    }
+
+    #[test]
+    fn test_fidelity_bond_values() {
+        let value = Amount::from_btc(1.0).unwrap();
+        let confirmation_time = 50_000;
+        let current_time = 60_000;
+
+        // Following is a (locktime, fidelity_value) tupple series to show how fidelity_value increases with locktimes
+        let test_vectors = [
+            (55000, 0), // Value is zero for expired timelocks
+            (60000, 3020),
+            (65000, 5117),
+            (70000, 7437),
+            (75000, 9940),
+            (80000, 12599),
+            (85000, 15395),
+            (90000, 18313),
+            (95000, 21344),
+            (100000, 24477),
+            (105000, 27706),
+            (110000, 31024),
+            (115000, 34426),
+            (120000, 37908),
+            (125000, 41465),
+            (130000, 45094),
+            (135000, 48792),
+            (140000, 52556),
+            (145000, 56383),
+        ]
+        .map(|(lt, val)| (lt as u64, Amount::from_sat(val)));
+
+        for (locktime, fidelity_value) in test_vectors {
+            assert_eq!(
+                fidelity_value,
+                calculate_fidelity_value(value, locktime, confirmation_time, current_time)
+            )
+        }
+    }
+
+    #[test]
+    fn test_fidleity_redeemscripts() {
+        let test_data = [(("03ffe2b8b46eb21eadc3b535e9f57054213a1775b035faba6c5b3368b3a0ab5a5c", 15000), "02983ab1752103ffe2b8b46eb21eadc3b535e9f57054213a1775b035faba6c5b3368b3a0ab5a5cac"),
+        (("031499764842691088897cff51efd85347dd3215912cbb8fb9b121b1da3b15bec8", 30000), "023075b17521031499764842691088897cff51efd85347dd3215912cbb8fb9b121b1da3b15bec8ac"),
+        (("022714334f189db14fabd3dd893bbb913b8c3ddff245f7094cdc0b24c2fabb3570", 45000), "03c8af00b17521022714334f189db14fabd3dd893bbb913b8c3ddff245f7094cdc0b24c2fabb3570ac"),
+        (("02145a1d2bd118edcb3fe85495192d44e1d09f75ab4f0fe98269f61ff672860dae", 60000), "0360ea00b1752102145a1d2bd118edcb3fe85495192d44e1d09f75ab4f0fe98269f61ff672860daeac"),]
+        .map(|((pk, lt), script)| ((PublicKey::from_str(pk).unwrap(), LockTime::from_height(lt).unwrap()), ScriptBuf::from_hex(script).unwrap()));
+
+        for ((pk, lt), script) in test_data {
+            assert_eq!(script, fidelity_redeemscript(&lt, &pk));
+            assert_eq!(pk, read_pubkey_from_fidelity_script(&script).unwrap());
+            assert_eq!(lt, read_locktime_from_fidelity_script(&script).unwrap());
         }
     }
 }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -3,7 +3,7 @@
 mod api;
 mod direct_send;
 mod error;
-pub mod fidelity;
+mod fidelity;
 mod funding;
 mod rpc;
 mod storage;
@@ -12,6 +12,7 @@ mod swapcoin;
 pub use api::{DisplayAddressType, UTXOSpendInfo, Wallet};
 pub use direct_send::{CoinToSpend, Destination, SendAmount};
 pub use error::WalletError;
+pub use fidelity::{FidelityBond, FidelityError};
 pub use rpc::RPCConfig;
 pub use storage::WalletStore;
 pub use swapcoin::{

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -50,7 +50,7 @@ impl WalletStore {
         seedphrase: String,
         passphrase: String,
     ) -> Result<Self, WalletError> {
-        let mnemonic = Mnemonic::parse(&seedphrase)?;
+        let mnemonic = Mnemonic::parse(seedphrase)?;
         let seed = mnemonic.to_seed(passphrase);
         let master_key = ExtendedPrivKey::new_master(network, &seed)?;
 

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -2,39 +2,23 @@
 //!
 //! Wallet data is currently written in unencrypted CBOR files which are not directly human readable.
 
-use std::{collections::HashMap, convert::TryFrom, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf};
 
 use bip39::Mnemonic;
 use bitcoin::{bip32::ExtendedPrivKey, Network, OutPoint, ScriptBuf};
 use serde::{Deserialize, Serialize};
 use std::{
-    fs::{File, OpenOptions},
+    fs::OpenOptions,
     io::{BufReader, BufWriter},
 };
 
-use super::{error::WalletError, SwapCoin};
+use super::{error::WalletError, fidelity::FidelityBond};
 
 use super::swapcoin::{IncomingSwapCoin, OutgoingSwapCoin};
 
-use super::fidelity::generate_fidelity_scripts;
-
-const WALLET_FILE_VERSION: u32 = 0;
-
-#[derive(Serialize, Deserialize)]
-struct FileData {
-    file_name: String,
-    version: u32,
-    network: Network,
-    seedphrase: String,
-    passphrase: String,
-    external_index: u32,
-    incoming_swapcoins: Vec<IncomingSwapCoin>,
-    outgoing_swapcoins: Vec<OutgoingSwapCoin>,
-    prevout_to_contract_map: HashMap<OutPoint, ScriptBuf>,
-}
-
 /// Represents the internal data store for a Bitcoin wallet.
-#[derive(Debug, PartialEq)]
+// TODO: Derive Serialize/Deserialize for this structure, and remove FileData
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct WalletStore {
     /// The file name associated with the wallet store.
     pub(crate) file_name: String,
@@ -52,44 +36,9 @@ pub struct WalletStore {
     pub(super) outgoing_swapcoins: HashMap<ScriptBuf, OutgoingSwapCoin>,
     /// Map of prevout to contract redeemscript.
     pub(super) prevout_to_contract_map: HashMap<OutPoint, ScriptBuf>,
-    /// Map of fidelity bond scripts to index.
-    pub(super) fidelity_scripts: HashMap<ScriptBuf, u32>,
+    /// Map for all the fidelity bond information. (index, (Bond, script_pubkey, is_spent)).
+    pub(super) fidelity_bond: HashMap<u32, (FidelityBond, ScriptBuf, bool)>,
     //TODO: Add last synced height and Wallet birthday.
-}
-
-impl TryFrom<FileData> for WalletStore {
-    type Error = WalletError;
-    fn try_from(file_data: FileData) -> Result<Self, WalletError> {
-        let mnemonic = Mnemonic::parse(&file_data.seedphrase)?;
-        let seed = mnemonic.to_seed(file_data.passphrase);
-        let xprv = ExtendedPrivKey::new_master(file_data.network, &seed)?;
-
-        let incoming_swapcoins = file_data
-            .incoming_swapcoins
-            .iter()
-            .map(|sc| (sc.get_multisig_redeemscript(), sc.clone()))
-            .collect::<HashMap<_, _>>();
-
-        let outgoing_swapcoins = file_data
-            .outgoing_swapcoins
-            .iter()
-            .map(|sc| (sc.get_multisig_redeemscript(), sc.clone()))
-            .collect::<HashMap<_, _>>();
-
-        let timelocked_script_index_map = generate_fidelity_scripts(&xprv);
-
-        Ok(Self {
-            file_name: file_data.file_name,
-            network: file_data.network,
-            master_key: xprv,
-            external_index: file_data.external_index,
-            incoming_swapcoins,
-            outgoing_swapcoins,
-            prevout_to_contract_map: file_data.prevout_to_contract_map,
-            fidelity_scripts: timelocked_script_index_map,
-            offer_maxsize: 0,
-        })
-    }
 }
 
 impl WalletStore {
@@ -101,76 +50,48 @@ impl WalletStore {
         seedphrase: String,
         passphrase: String,
     ) -> Result<Self, WalletError> {
-        FileData::init_new_file(path, file_name, network, seedphrase, passphrase)?;
-        let store = WalletStore::read_from_disk(path)?;
+        let mnemonic = Mnemonic::parse(&seedphrase)?;
+        let seed = mnemonic.to_seed(passphrase);
+        let master_key = ExtendedPrivKey::new_master(network, &seed)?;
+
+        let store = Self {
+            file_name,
+            network,
+            master_key,
+            external_index: 0,
+            offer_maxsize: 0,
+            incoming_swapcoins: HashMap::new(),
+            outgoing_swapcoins: HashMap::new(),
+            prevout_to_contract_map: HashMap::new(),
+            fidelity_bond: HashMap::new(),
+        };
+
+        std::fs::create_dir_all(path.parent().expect("Path should NOT be root!"))?;
+        // write: overwrites existing file.
+        // create: creates new file if doesn't exist.
+        let file = OpenOptions::new().write(true).create(true).open(path)?;
+        let writer = BufWriter::new(file);
+        serde_cbor::to_writer(writer, &store)?;
+        // let store_read = WalletStore::read_from_disk(path)?;
+        // assert_eq!(store_read, store);
         Ok(store)
     }
 
     /// Load existing file, updates it, writes it back (errors if path doesn't exist).
     pub fn write_to_disk(&self, path: &PathBuf) -> Result<(), WalletError> {
-        let mut file_data = FileData::load_from_file(path)?;
-        file_data.incoming_swapcoins = self
-            .incoming_swapcoins
-            .iter()
-            .map(|is| is.1)
-            .cloned()
-            .collect();
-        file_data.outgoing_swapcoins = self
-            .outgoing_swapcoins
-            .iter()
-            .map(|os| os.1)
-            .cloned()
-            .collect();
-        file_data.save_to_file(path)
+        let wallet_file = OpenOptions::new().write(true).open(path)?;
+        let writer = BufWriter::new(wallet_file);
+        Ok(serde_cbor::to_writer(writer, &self)?)
     }
 
     /// Reads from a path (errors if path doesn't exist).
     pub fn read_from_disk(path: &PathBuf) -> Result<Self, WalletError> {
-        let file_data = FileData::load_from_file(path)?;
-        Self::try_from(file_data)
-    }
-}
-
-impl FileData {
-    /// Overwrites existing file or create a new one.
-    fn init_new_file(
-        path: &PathBuf,
-        file_name: String,
-        network: Network,
-        seedphrase: String,
-        passphrase: String,
-    ) -> Result<(), WalletError> {
-        let file_data = Self {
-            file_name,
-            version: WALLET_FILE_VERSION,
-            network,
-            seedphrase,
-            passphrase,
-            external_index: 0,
-            incoming_swapcoins: Vec::new(),
-            outgoing_swapcoins: Vec::new(),
-            prevout_to_contract_map: HashMap::new(),
-        };
-        file_data.save_to_file(path)
-    }
-
-    /// File path should exist.
-    fn load_from_file(path: &PathBuf) -> Result<Self, WalletError> {
-        let wallet_file = File::open(path)?;
+        let wallet_file = OpenOptions::new().read(true).open(path)?;
         let reader = BufReader::new(wallet_file);
-        Ok(serde_cbor::from_reader(reader)?)
-    }
-
-    // Overwrite existing file or create a new one.
-    fn save_to_file(&self, path: &PathBuf) -> Result<(), WalletError> {
-        std::fs::create_dir_all(path.parent().expect("Path should NOT be root!"))?;
-        let file = OpenOptions::new().write(true).create(true).open(path)?;
-        let writer = BufWriter::new(file);
-        serde_cbor::to_writer(writer, &self)?;
-        Ok(())
+        let store: Self = serde_cbor::from_reader(reader)?;
+        Ok(store)
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -69,7 +69,11 @@ impl WalletStore {
         std::fs::create_dir_all(path.parent().expect("Path should NOT be root!"))?;
         // write: overwrites existing file.
         // create: creates new file if doesn't exist.
-        let file = OpenOptions::new().write(true).create(true).open(path)?;
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
         let writer = BufWriter::new(file);
         serde_cbor::to_writer(writer, &store)?;
         // let store_read = WalletStore::read_from_disk(path)?;

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -145,14 +145,17 @@ macro_rules! impl_walletswapcoin {
                         .map_err(ContractError::Sighash)?[..],
                 )
                 .map_err(ContractError::Secp)?;
-                let sig_mine = secp.sign_ecdsa(&sighash, &self.my_privkey);
+                let sig_mine = Signature {
+                    sig: secp.sign_ecdsa(&sighash, &self.my_privkey),
+                    hash_ty: EcdsaSighashType::All,
+                };
 
                 let mut signed_contract_tx = self.contract_tx.clone();
                 apply_two_signatures_to_2of2_multisig_spend(
                     &my_pubkey,
                     &self.other_pubkey,
                     &sig_mine,
-                    &self.others_contract_sig.unwrap().sig,
+                    &self.others_contract_sig.unwrap(),
                     &mut signed_contract_tx.input[index],
                     &multisig_redeemscript,
                 );
@@ -256,8 +259,14 @@ impl IncomingSwapCoin {
         )
         .map_err(ContractError::Secp)?;
 
-        let sig_mine = secp.sign_ecdsa(&sighash, &self.my_privkey);
-        let sig_other = secp.sign_ecdsa(&sighash, &self.other_privkey.unwrap());
+        let sig_mine = Signature {
+            sig: secp.sign_ecdsa(&sighash, &self.my_privkey),
+            hash_ty: EcdsaSighashType::All,
+        };
+        let sig_other = Signature {
+            sig: secp.sign_ecdsa(&sighash, &self.other_privkey.unwrap()),
+            hash_ty: EcdsaSighashType::All,
+        };
 
         apply_two_signatures_to_2of2_multisig_spend(
             &my_pubkey,

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -10,7 +10,8 @@
 
 use bitcoin::{
     absolute::LockTime,
-    secp256k1::{self, ecdsa::Signature, Secp256k1, SecretKey},
+    ecdsa::Signature,
+    secp256k1::{self, Secp256k1, SecretKey},
     sighash::{EcdsaSighashType, SighashCache},
     Address, OutPoint, PublicKey, Script, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
 };
@@ -151,7 +152,7 @@ macro_rules! impl_walletswapcoin {
                     &my_pubkey,
                     &self.other_pubkey,
                     &sig_mine,
-                    &self.others_contract_sig.unwrap(),
+                    &self.others_contract_sig.unwrap().sig,
                     &mut signed_contract_tx.input[index],
                     &multisig_redeemscript,
                 );
@@ -359,7 +360,7 @@ impl IncomingSwapCoin {
             &self.get_multisig_redeemscript(),
             self.funding_amount,
             &self.other_pubkey,
-            sig,
+            &sig.sig,
         )?)
     }
 }
@@ -473,7 +474,7 @@ impl OutgoingSwapCoin {
             &self.get_multisig_redeemscript(),
             self.funding_amount,
             &self.other_pubkey,
-            sig,
+            &sig.sig,
         )?)
     }
 }
@@ -613,7 +614,7 @@ impl SwapCoin for WatchOnlySwapCoin {
             &self.get_multisig_redeemscript(),
             self.funding_amount,
             &self.receiver_pubkey,
-            sig,
+            &sig.sig,
         )?)
     }
 
@@ -623,7 +624,7 @@ impl SwapCoin for WatchOnlySwapCoin {
             &self.get_multisig_redeemscript(),
             self.funding_amount,
             &self.sender_pubkey,
-            sig,
+            &sig.sig,
         )?)
     }
 }

--- a/tests/abort2_case1.rs
+++ b/tests/abort2_case1.rs
@@ -54,6 +54,17 @@ async fn test_abort_case_2_move_on_with_other_makers() {
         })
     }
 
+    // Coins for fidelity creation
+    makers.iter().for_each(|maker| {
+        let maker_addrs = maker
+            .get_wallet()
+            .write()
+            .unwrap()
+            .get_next_external_address()
+            .unwrap();
+        test_framework.send_to_address(&maker_addrs, Amount::from_btc(0.05).unwrap());
+    });
+
     // confirm balances
     test_framework.generate_1_block();
 

--- a/tests/abort2_case2.rs
+++ b/tests/abort2_case2.rs
@@ -52,6 +52,17 @@ async fn test_abort_case_2_recover_if_no_makers_found() {
         })
     }
 
+    // Coins for fidelity creation
+    makers.iter().for_each(|maker| {
+        let maker_addrs = maker
+            .get_wallet()
+            .write()
+            .unwrap()
+            .get_next_external_address()
+            .unwrap();
+        test_framework.send_to_address(&maker_addrs, Amount::from_btc(0.05).unwrap());
+    });
+
     // confirm balances
     test_framework.generate_1_block();
 
@@ -62,17 +73,6 @@ async fn test_abort_case_2_recover_if_no_makers_found() {
         .get_wallet()
         .balance(false, false)
         .unwrap();
-    let org_maker_balances = makers
-        .iter()
-        .map(|maker| {
-            maker
-                .get_wallet()
-                .read()
-                .unwrap()
-                .balance(false, false)
-                .unwrap()
-        })
-        .collect::<Vec<_>>();
 
     // ---- Start Servers and attempt Swap ----
 
@@ -96,6 +96,20 @@ async fn test_abort_case_2_recover_if_no_makers_found() {
         required_confirms: 1,
         fee_rate: 1000,
     };
+
+    // Calculate Original balance excluding fidelity bonds.
+    // Bonds are created automatically after spawning the maker server.
+    let org_maker_balances = makers
+        .iter()
+        .map(|maker| {
+            maker
+                .get_wallet()
+                .read()
+                .unwrap()
+                .balance(false, false)
+                .unwrap()
+        })
+        .collect::<Vec<_>>();
 
     // Spawn a Taker coinswap thread.
     let taker_clone = taker.clone();

--- a/tests/abort2_case3.rs
+++ b/tests/abort2_case3.rs
@@ -53,6 +53,17 @@ async fn maker_drops_after_sending_senders_sigs() {
         })
     }
 
+    // Coins for fidelity creation
+    makers.iter().for_each(|maker| {
+        let maker_addrs = maker
+            .get_wallet()
+            .write()
+            .unwrap()
+            .get_next_external_address()
+            .unwrap();
+        test_framework.send_to_address(&maker_addrs, Amount::from_btc(0.05).unwrap());
+    });
+
     // confirm balances
     test_framework.generate_1_block();
 

--- a/tests/abort3_case1.rs
+++ b/tests/abort3_case1.rs
@@ -52,6 +52,17 @@ async fn abort3_case1_close_at_contract_sigs_for_recvr_and_sender() {
         })
     }
 
+    // Coins for fidelity creation
+    makers.iter().for_each(|maker| {
+        let maker_addrs = maker
+            .get_wallet()
+            .write()
+            .unwrap()
+            .get_next_external_address()
+            .unwrap();
+        test_framework.send_to_address(&maker_addrs, Amount::from_btc(0.05).unwrap());
+    });
+
     // confirm balances
     test_framework.generate_1_block();
 

--- a/tests/abort3_case2.rs
+++ b/tests/abort3_case2.rs
@@ -52,6 +52,17 @@ async fn abort3_case2_close_at_contract_sigs_for_recvr() {
         })
     }
 
+    // Coins for fidelity creation
+    makers.iter().for_each(|maker| {
+        let maker_addrs = maker
+            .get_wallet()
+            .write()
+            .unwrap()
+            .get_next_external_address()
+            .unwrap();
+        test_framework.send_to_address(&maker_addrs, Amount::from_btc(0.05).unwrap());
+    });
+
     // confirm balances
     test_framework.generate_1_block();
 

--- a/tests/abort3_case3.rs
+++ b/tests/abort3_case3.rs
@@ -52,6 +52,17 @@ async fn abort3_case2_close_at_contract_sigs_for_recvr() {
         })
     }
 
+    // Coins for fidelity creation
+    makers.iter().for_each(|maker| {
+        let maker_addrs = maker
+            .get_wallet()
+            .write()
+            .unwrap()
+            .get_next_external_address()
+            .unwrap();
+        test_framework.send_to_address(&maker_addrs, Amount::from_btc(0.05).unwrap());
+    });
+
     // confirm balances
     test_framework.generate_1_block();
 

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -29,7 +29,7 @@ async fn test_fidelity() {
     let (test_framework, _, makers) =
         TestFramework::init(None, makers_config_map.into(), None).await;
 
-    let maker = makers.iter().next().unwrap();
+    let maker = makers.first().unwrap();
 
     // ----- Test -----
 

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -1,0 +1,158 @@
+#![cfg(feature = "integration-test")]
+use bitcoin::{absolute::LockTime, Amount};
+use coinswap::{
+    maker::{error::MakerError, start_maker_server, MakerBehavior},
+    test_framework::TestFramework,
+    wallet::{FidelityError, WalletError},
+};
+use std::{thread, time::Duration};
+
+/// Test Fidelity Transactions
+///
+/// These tests covers
+///  - Creation
+///  - Redemption
+///  - Valuations of Fidelity Bonds.
+///
+/// Fidelity Bonds can be created either via running the maker server or by calling the `create_fidelity()` API
+/// on the wallet. Both of them are performed here. At the start of the maker server it will try to create a fidelity
+/// bond with value and timelock provided in the configuration (default: value = 5_000_000 sats, locktime = 100 block).
+///
+/// Maker server will error if not enough balance is present to create fidelity bond.
+/// A custom fidelity bond can be create using the `create_fidelity()` API.
+#[tokio::test]
+async fn test_fidelity() {
+    // ---- Setup ----
+
+    let makers_config_map = [(6102, MakerBehavior::Normal)];
+
+    let (test_framework, _, makers) =
+        TestFramework::init(None, makers_config_map.into(), None).await;
+
+    let maker = makers.iter().next().unwrap();
+
+    // ----- Test -----
+
+    // Give insufficient fund to maker and start the server.
+    // This should return Error of Insufficient fund.
+    let maker_addrs = maker
+        .get_wallet()
+        .write()
+        .unwrap()
+        .get_next_external_address()
+        .unwrap();
+    test_framework.send_to_address(&maker_addrs, Amount::from_btc(0.04).unwrap());
+    test_framework.generate_1_block();
+
+    let maker_clone = maker.clone();
+    let maker_thread = thread::spawn(move || start_maker_server(maker_clone));
+
+    thread::sleep(Duration::from_secs(5));
+    maker.shutdown().unwrap();
+    let expected_error = maker_thread.join().unwrap();
+
+    matches!(
+        expected_error.err().unwrap(),
+        MakerError::Wallet(WalletError::Fidelity(FidelityError::InsufficientFund {
+            available: 4000000,
+            required: 5000000
+        }))
+    );
+
+    // Give Maker more funds and check fidelity bond is created at the restart of server.
+    test_framework.send_to_address(&maker_addrs, Amount::from_btc(0.04).unwrap());
+    test_framework.generate_1_block();
+
+    let maker_clone = maker.clone();
+    let maker_thread = thread::spawn(move || start_maker_server(maker_clone));
+
+    thread::sleep(Duration::from_secs(5));
+    maker.shutdown().unwrap();
+
+    let success = maker_thread.join().unwrap();
+
+    assert!(success.is_ok());
+
+    // Check fidelity bond created correctly
+    let first_conf_height = {
+        let wallet_read = maker.get_wallet().read().unwrap();
+        let (index, bond, is_spent) = wallet_read
+            .get_fidelity_bonds()
+            .iter()
+            .map(|(i, (b, _, is_spent))| (i, b, is_spent))
+            .next()
+            .unwrap();
+        assert_eq!(*index, 0);
+        assert_eq!(bond.amount, 5000000);
+        assert!(!is_spent);
+        bond.conf_height
+    };
+
+    // Create another fidelity bond of 1000000 sats
+    let second_conf_height = {
+        let mut wallet_write = maker.get_wallet().write().unwrap();
+        let index = wallet_write
+            .create_fidelity(
+                Amount::from_sat(1000000),
+                LockTime::from_height(test_framework.get_block_count() as u32 + 100).unwrap(),
+            )
+            .unwrap();
+        assert_eq!(index, 1);
+        let (bond, _, is_spent) = wallet_write
+            .get_fidelity_bonds()
+            .get(&index)
+            .expect("bond expected");
+        assert_eq!(bond.amount, 1000000);
+        assert!(!is_spent);
+        bond.conf_height
+    };
+
+    // Check the balances
+    {
+        let wallet = maker.get_wallet().read().unwrap();
+        let normal_balance = wallet.balance(false, false).unwrap();
+        assert_eq!(normal_balance.to_sat(), 1998000);
+    }
+
+    let (first_maturity_heigh, second_maturity_height) =
+        (first_conf_height + 100, second_conf_height + 100);
+
+    // Wait for maturity and then redeem the bonds
+    loop {
+        let current_height = test_framework.get_block_count() as u32;
+        let required_height = first_maturity_heigh.max(second_maturity_height);
+        if current_height < required_height {
+            log::info!(
+                "Waiting for maturity. Current height {}, required height: {}",
+                current_height,
+                required_height
+            );
+            thread::sleep(Duration::from_secs(10));
+            continue;
+        } else {
+            log::info!("Fidelity is matured. sending redemption transactions");
+            let mut wallet_write = maker.get_wallet().write().unwrap();
+            let indexes = wallet_write
+                .get_fidelity_bonds()
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>();
+            for i in indexes {
+                wallet_write.redeem_fidelity(i).unwrap();
+            }
+            break;
+        }
+    }
+
+    // Check the balances again
+    {
+        let wallet = maker.get_wallet().read().unwrap();
+        let normal_balance = wallet.balance(false, false).unwrap();
+        assert_eq!(normal_balance.to_sat(), 7996000);
+    }
+
+    // Stop test and clean everything.
+    // comment this line if you want the wallet directory and bitcoind to live. Can be useful for
+    // after test debugging.
+    test_framework.stop();
+}

--- a/tests/standard_swap.rs
+++ b/tests/standard_swap.rs
@@ -48,16 +48,27 @@ async fn test_standard_coinswap() {
         })
     }
 
+    // Coins for fidelity creation
+    makers.iter().for_each(|maker| {
+        let maker_addrs = maker
+            .get_wallet()
+            .write()
+            .unwrap()
+            .get_next_external_address()
+            .unwrap();
+        test_framework.send_to_address(&maker_addrs, Amount::from_btc(0.05).unwrap());
+    });
+
     // confirm balances
     test_framework.generate_1_block();
 
     // --- Basic Checks ----
 
-    // Assert external address index reached to 3.
+    // Assert external address index reached to 4.
     assert_eq!(taker.read().unwrap().get_wallet().get_external_index(), &3);
     makers.iter().for_each(|maker| {
         let next_external_index = *maker.get_wallet().read().unwrap().get_external_index();
-        assert_eq!(next_external_index, 3);
+        assert_eq!(next_external_index, 4);
     });
 
     // Check if utxo list looks good.
@@ -80,7 +91,7 @@ async fn test_standard_coinswap() {
             .list_unspent_from_wallet(false, false)
             .unwrap();
 
-        assert_eq!(utxo_count.len(), 3);
+        assert_eq!(utxo_count.len(), 4);
     });
 
     // Check locking non-wallet utxos worked.


### PR DESCRIPTION
This PR adds the Fidelity Bond API, protocol, and tests. 

The previous fidelity bond codes are mostly removed. 

The Wallet now has a new fidelity-related API.

The Makers by default attempt to create a fidelity bond and startup with default config options. If failed, then the server stops with a hard error.

Takers now validate fidelity bonds at the offer downloading time. If an invalid bond is present, that offer is rejected.

Unit and functional tests were added to test fidelity bond behavior.

Reviewer's note:
Commits are broken into modular chunks. Check out each commit message to get the change summary.