### PR TITLE
`test:` unit tests for `wallet/swapcoin.rs`

### DIFF
--- a/src/wallet/storage.rs
+++ b/src/wallet/storage.rs
@@ -164,7 +164,11 @@ impl FileData {
     // Overwrite existing file or create a new one.
     fn save_to_file(&self, path: &PathBuf) -> Result<(), WalletError> {
         std::fs::create_dir_all(path.parent().expect("Path should NOT be root!"))?;
-        let file = OpenOptions::new().write(true).create(true).open(path)?;
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
         let writer = BufWriter::new(file);
         serde_cbor::to_writer(writer, &self)?;
         Ok(())

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -637,3 +637,396 @@ impl SwapCoin for WatchOnlySwapCoin {
         )?)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use bitcoin::PrivateKey;
+    use secp256k1::Secp256k1;
+
+    #[test]
+    fn test_apply_privkey_watchonly_swapcoin() {
+        let secp = Secp256k1::new();
+
+        let privkey_sender = bitcoin::PrivateKey {
+            compressed: true,
+            network: bitcoin::Network::Testnet,
+            inner: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000001",
+            )
+            .unwrap(),
+        };
+
+        let privkey_receiver = bitcoin::PrivateKey {
+            compressed: true,
+            network: bitcoin::Network::Testnet,
+            inner: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000002",
+            )
+            .unwrap(),
+        };
+
+        let mut swapcoin = WatchOnlySwapCoin {
+            sender_pubkey: PublicKey::from_private_key(&secp, &privkey_sender),
+            receiver_pubkey: PublicKey::from_private_key(&secp, &privkey_receiver),
+            funding_amount: 100,
+            contract_tx: Transaction {
+                input: vec![],
+                output: vec![],
+                lock_time: LockTime::ZERO,
+                version: 2,
+            },
+            contract_redeemscript: ScriptBuf::default(),
+        };
+
+        let secret_key_1 =
+            SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000002")
+                .unwrap();
+        let secret_key_2 =
+            SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000069")
+                .unwrap();
+        // Test for applying the correct privkey
+        assert!(swapcoin.apply_privkey(secret_key_1).is_ok());
+        // Test for applying the incorrect privkey
+        assert!(swapcoin.apply_privkey(secret_key_2).is_err());
+    }
+
+    #[test]
+    fn test_apply_privkey_incoming_swapcoin() {
+        let secp = Secp256k1::new();
+        let other_privkey = bitcoin::PrivateKey {
+            compressed: true,
+            network: bitcoin::Network::Testnet,
+            inner: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000002",
+            )
+            .unwrap(),
+        };
+
+        let mut incoming_swapcoin = IncomingSwapCoin {
+            my_privkey: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000003",
+            )
+            .unwrap(),
+            other_privkey: Some(
+                secp256k1::SecretKey::from_str(
+                    "0000000000000000000000000000000000000000000000000000000000000005",
+                )
+                .unwrap(),
+            ),
+            other_pubkey: PublicKey::from_private_key(&secp, &other_privkey),
+            contract_tx: Transaction {
+                input: vec![],
+                output: vec![],
+                lock_time: LockTime::ZERO,
+                version: 2,
+            },
+            contract_redeemscript: ScriptBuf::default(),
+            hashlock_privkey: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000004",
+            )
+            .unwrap(),
+            funding_amount: 0,
+            others_contract_sig: None,
+            hash_preimage: None,
+        };
+
+        let secret_key_1 =
+            SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000002")
+                .unwrap();
+        let secret_key_2 =
+            SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000069")
+                .unwrap();
+        // Test for applying the correct privkey
+        assert!(incoming_swapcoin.apply_privkey(secret_key_1).is_ok());
+        // Test for applying the incorrect privkey
+        assert!(incoming_swapcoin.apply_privkey(secret_key_2).is_err());
+        // Test get_other_pubkey
+        let other_pubkey_from_method = incoming_swapcoin.get_other_pubkey();
+        assert_eq!(other_pubkey_from_method, &incoming_swapcoin.other_pubkey);
+        // Test is_hash_preimage_known for empty hash_preimage
+        assert!(!incoming_swapcoin.is_hash_preimage_known());
+    }
+
+    #[test]
+
+    fn test_apply_privkey_outgoing_swapcoin() {
+        let secp = Secp256k1::new();
+        let other_privkey = bitcoin::PrivateKey {
+            compressed: true,
+            network: bitcoin::Network::Testnet,
+            inner: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000001",
+            )
+            .unwrap(),
+        };
+        let mut outgoing_swapcoin = OutgoingSwapCoin {
+            my_privkey: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000002",
+            )
+            .unwrap(),
+            other_pubkey: PublicKey::from_private_key(&secp, &other_privkey),
+            contract_tx: Transaction {
+                input: vec![],
+                output: vec![],
+                lock_time: LockTime::ZERO,
+                version: 2,
+            },
+            contract_redeemscript: ScriptBuf::default(),
+            timelock_privkey: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000003",
+            )
+            .unwrap(),
+            funding_amount: 0,
+            others_contract_sig: None,
+            hash_preimage: None,
+        };
+        let secret_key_1 =
+            SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000001")
+                .unwrap();
+        let secret_key_2 =
+            SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000069")
+                .unwrap();
+
+        // Test for applying the correct privkey
+        assert!(outgoing_swapcoin.apply_privkey(secret_key_1).is_ok());
+        // Test for applying the incorrect privkey
+        assert!(outgoing_swapcoin.apply_privkey(secret_key_2).is_err());
+        // Test get_other_pubkey
+        assert_eq!(
+            outgoing_swapcoin.get_other_pubkey(),
+            &outgoing_swapcoin.other_pubkey
+        );
+        // Test is_hash_preimage_known
+        assert!(!outgoing_swapcoin.is_hash_preimage_known());
+    }
+
+    #[test]
+    fn test_sign_transaction_input_fail() {
+        let secp = Secp256k1::new();
+        let other_privkey = bitcoin::PrivateKey {
+            compressed: true,
+            network: bitcoin::Network::Testnet,
+            inner: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000002",
+            )
+            .unwrap(),
+        };
+        let index: usize = 10;
+        let mut input = TxIn::default();
+        let tx = Transaction {
+            input: vec![input.clone()],
+            output: vec![],
+            lock_time: LockTime::ZERO,
+            version: 2,
+        };
+
+        let contract_redeemscript = ScriptBuf::default(); // Example redeem script
+
+        let incoming_swapcoin = IncomingSwapCoin {
+            my_privkey: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000003",
+            )
+            .unwrap(),
+            other_privkey: Some(
+                secp256k1::SecretKey::from_str(
+                    "0000000000000000000000000000000000000000000000000000000000000005",
+                )
+                .unwrap(),
+            ),
+            other_pubkey: PublicKey::from_private_key(&secp, &other_privkey),
+            contract_tx: Transaction {
+                input: vec![],
+                output: vec![],
+                lock_time: LockTime::ZERO,
+                version: 2,
+            },
+            contract_redeemscript: ScriptBuf::default(),
+            hashlock_privkey: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000004",
+            )
+            .unwrap(),
+            funding_amount: 100_000,
+            others_contract_sig: None,
+            hash_preimage: None,
+        };
+        // Intentionally failing to sign with incomplete swapcoin
+        assert!(incoming_swapcoin
+            .sign_transaction_input(index, &tx, &mut input, &contract_redeemscript,)
+            .is_err());
+        let sign = bitcoin::ecdsa::Signature {
+            sig: secp256k1::ecdsa::Signature::from_compact(&[0; 64]).unwrap(),
+            hash_ty: bitcoin::sighash::EcdsaSighashType::All,
+        };
+        // Intentionally failing to verify with incomplete swapcoin
+        assert!(incoming_swapcoin
+            .verify_contract_tx_sender_sig(&sign)
+            .is_err());
+    }
+
+    #[test]
+
+    fn test_create_hashlock_spend_without_preimage() {
+        let secp = Secp256k1::new();
+        let other_privkey = PrivateKey {
+            compressed: true,
+            network: bitcoin::Network::Bitcoin,
+            inner: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000001",
+            )
+            .unwrap(),
+        };
+        let input = TxIn::default();
+        let output = TxOut::default();
+        let incoming_swapcoin = IncomingSwapCoin {
+            my_privkey: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000003",
+            )
+            .unwrap(),
+            other_privkey: Some(
+                secp256k1::SecretKey::from_str(
+                    "0000000000000000000000000000000000000000000000000000000000000005",
+                )
+                .unwrap(),
+            ),
+            other_pubkey: PublicKey::from_private_key(&secp, &other_privkey),
+            contract_tx: Transaction {
+                input: vec![input.clone()],
+                output: vec![output.clone()],
+                lock_time: LockTime::ZERO,
+                version: 2,
+            },
+            contract_redeemscript: ScriptBuf::default(),
+            hashlock_privkey: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000004",
+            )
+            .unwrap(),
+            funding_amount: 100_000,
+            others_contract_sig: None,
+            hash_preimage: Some(Preimage::from([0; 32])),
+        };
+        let destination_address: Address = Address::from_str("32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf")
+            .unwrap()
+            .require_network(bitcoin::Network::Bitcoin)
+            .unwrap();
+
+        let miner_fee = 136 * 10; //126 vbytes x 10 sat/vb, size calculated using testmempoolaccept
+        let mut tx = Transaction {
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: incoming_swapcoin.contract_tx.txid(),
+                    vout: 0, //contract_tx is one-input-one-output
+                },
+                sequence: Sequence(1), //hashlock spends must have 1 because of the `OP_CSV 1`
+                witness: Witness::new(),
+                script_sig: ScriptBuf::new(),
+            }],
+            output: vec![TxOut {
+                script_pubkey: destination_address.script_pubkey(),
+                value: incoming_swapcoin.contract_tx.output[0].value - miner_fee,
+            }],
+            lock_time: LockTime::ZERO,
+            version: 2,
+        };
+        let index = 0;
+        let preimage = Vec::new();
+        incoming_swapcoin
+            .sign_hashlocked_transaction_input_given_preimage(
+                index,
+                &tx.clone(),
+                &mut tx.input[0],
+                incoming_swapcoin.contract_tx.output[0].value,
+                &preimage,
+            )
+            .unwrap();
+        // If the tx is succesful, check some field like:
+        assert!(tx.input[0].witness.len() == 3);
+    }
+
+    #[test]
+    fn test_sign_hashlocked_transaction_input() {
+        let secp = Secp256k1::new();
+        let other_privkey = PrivateKey {
+            compressed: true,
+            network: bitcoin::Network::Bitcoin,
+            inner: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000001",
+            )
+            .unwrap(),
+        };
+        let mut input = TxIn::default();
+        let output = TxOut::default();
+        let incoming_swapcoin = IncomingSwapCoin {
+            my_privkey: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000003",
+            )
+            .unwrap(),
+            other_privkey: Some(
+                secp256k1::SecretKey::from_str(
+                    "0000000000000000000000000000000000000000000000000000000000000005",
+                )
+                .unwrap(),
+            ),
+            other_pubkey: PublicKey::from_private_key(&secp, &other_privkey),
+            contract_tx: Transaction {
+                input: vec![input.clone()],
+                output: vec![output.clone()],
+                lock_time: LockTime::ZERO,
+                version: 2,
+            },
+            contract_redeemscript: ScriptBuf::default(),
+            hashlock_privkey: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000004",
+            )
+            .unwrap(),
+            funding_amount: 100_000,
+            others_contract_sig: None,
+            hash_preimage: Some(Preimage::from([0; 32])),
+        };
+        let destination_address: Address = Address::from_str("32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf")
+            .unwrap()
+            .require_network(bitcoin::Network::Bitcoin)
+            .unwrap();
+
+        let miner_fee = 136 * 10;
+        let mut tx = Transaction {
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: incoming_swapcoin.contract_tx.txid(),
+                    vout: 0, //contract_tx is one-input-one-output
+                },
+                sequence: Sequence(1), //hashlock spends must have 1 because of the `OP_CSV 1`
+                witness: Witness::new(),
+                script_sig: ScriptBuf::new(),
+            }],
+            output: vec![TxOut {
+                script_pubkey: destination_address.script_pubkey(),
+                value: incoming_swapcoin.contract_tx.output[0].value - miner_fee,
+            }],
+            lock_time: LockTime::ZERO,
+            version: 2,
+        };
+        let index = 0;
+        let input_value = 100;
+        let preimage = Vec::new();
+        incoming_swapcoin
+            .sign_hashlocked_transaction_input_given_preimage(
+                index,
+                &tx.clone(),
+                &mut tx.input[0],
+                incoming_swapcoin.contract_tx.output[0].value,
+                &preimage,
+            )
+            .unwrap();
+        // Check if the hashlocked transaction input is successful
+        let final_return = incoming_swapcoin.sign_hashlocked_transaction_input(
+            index,
+            &tx,
+            &mut input,
+            input_value,
+        );
+        assert!(final_return.is_ok());
+    }
+}

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -644,7 +644,6 @@ mod tests {
 
     use super::*;
     use bitcoin::PrivateKey;
-    use secp256k1::Secp256k1;
 
     #[test]
     fn test_apply_privkey_watchonly_swapcoin() {

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -673,7 +673,9 @@ mod tests {
         let secret_key_1 =
             SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000002")
                 .unwrap();
-        let secret_key_2 = SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000069").unwrap();
+        let secret_key_2 =
+            SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000069")
+                .unwrap();
         assert!(swapcoin.apply_privkey(secret_key_1).is_ok());
         assert!(swapcoin.apply_privkey(secret_key_2).is_err());
     }
@@ -721,7 +723,9 @@ mod tests {
         let secret_key_1 =
             SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000002")
                 .unwrap();
-        let secret_key_2 = SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000069").unwrap();
+        let secret_key_2 =
+            SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000069")
+                .unwrap();
         assert!(incoming_swapcoin.apply_privkey(secret_key_1).is_ok());
         assert!(incoming_swapcoin.apply_privkey(secret_key_2).is_err());
     }
@@ -762,182 +766,65 @@ mod tests {
         let secret_key_1 =
             SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000001")
                 .unwrap();
-        let secret_key_2 = SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000069").unwrap();
+        let secret_key_2 =
+            SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000069")
+                .unwrap();
         assert!(outgoing_swapcoin.apply_privkey(secret_key_1).is_ok());
         assert!(outgoing_swapcoin.apply_privkey(secret_key_2).is_err());
     }
-}
-/*
-#[cfg(test)]
-mod tests {
-    use std::str::FromStr;
-
-    use super::*;
-    use secp256k1::SecretKey;
-
-    // Mock implementation of WatchOnlySwapCoin for testing
-    struct MockWatchOnlySwapCoin {
-        sender_pubkey: PublicKey,
-        receiver_pubkey: PublicKey,
-        funding_amount: u64,
-        contract_tx: Transaction,
-    }
-
-    impl SwapCoin for MockWatchOnlySwapCoin {
-        fn apply_privkey(&mut self, privkey: SecretKey) -> Result<(), WalletError> {
-            // Implement logic to test apply_privkey function
-            // For example, you can check if the privkey matches sender_pubkey or receiver_pubkey
-            Ok(())
-        }
-
-        fn get_multisig_redeemscript(&self) -> ScriptBuf {
-            // Implement logic to test get_multisig_redeemscript function
-            // Return a dummy ScriptBuf for testing purposes
-            ScriptBuf::new()
-        }
-
-        fn verify_contract_tx_sender_sig(&self, sig: &Signature) -> Result<(), WalletError> {
-            // Implement logic to test verify_contract_tx_sender_sig function
-            // Return Ok(()) if the signature is valid; otherwise, return an error
-            Ok(())
-        }
-
-        fn verify_contract_tx_receiver_sig(&self, sig: &Signature) -> Result<(), WalletError> {
-            // Implement logic to test verify_contract_tx_receiver_sig function
-            // Return Ok(()) if the signature is valid; otherwise, return an error
-            Ok(())
-        }
-    }
 
     #[test]
-    fn test_get_multisig_redeemscript() {
-        // Create a MockWatchOnlySwapCoin instance for testing
-        let swapcoin = MockWatchOnlySwapCoin {
-            sender_pubkey: PublicKey::default(),
-            receiver_pubkey: PublicKey::default(),
-            funding_amount: 0,
-            contract_tx: Transaction::default(),
-        };
-
-        // Call get_multisig_redeemscript function
-        let redeem_script = swapcoin.get_multisig_redeemscript();
-
-        // Assert that the redeem_script is valid
-        // Add assertions here to validate the redeem_script
-    }
-
-    #[test]
-    fn test_verify_contract_tx_sender_sig() {
-        // Create a MockWatchOnlySwapCoin instance for testing
-        let swapcoin = MockWatchOnlySwapCoin {
-            sender_pubkey: PublicKey::default(),
-            receiver_pubkey: PublicKey::default(),
-            funding_amount: 0,
-            contract_tx: Transaction::default(),
-        };
-
-        // Call verify_contract_tx_sender_sig function with a valid signature
-        let result = swapcoin.verify_contract_tx_sender_sig(&Signature::default());
-
-        // Assert that the function returns Ok(())
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_verify_contract_tx_receiver_sig() {
-        // Create a MockWatchOnlySwapCoin instance for testing
-        let swapcoin = MockWatchOnlySwapCoin {
-            sender_pubkey: PublicKey::default(),
-            receiver_pubkey: PublicKey::default(),
-            funding_amount: 0,
-            contract_tx: Transaction::default(),
-        };
-
-        // Call verify_contract_tx_receiver_sig function with a valid signature
-        let result = swapcoin.verify_contract_tx_receiver_sig(&Signature::default());
-
-        // Assert that the function returns Ok(())
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_sign_transaction_input() {
+    fn test_sign_transaction_input_fail() {
         let secp = Secp256k1::new();
-        // using testnet keys
-        let my_privkey = bitcoin::PrivateKey::from_str("5032554e9d661af4e3fe58ef485231358925d39996830dac9eace8cadfbea9cd").unwrap();
-        let my_pubkey = bitcoin::PublicKey::from_private_key(&secp, &my_privkey);
-        let other_privkey = bitcoin::PrivateKey::from_str("5032554e9d661af4e3fe58ef485231358925d39996830dac9eace8cadfbea9ce").unwrap();
-        let other_pubkey = bitcoin::PublicKey::from_private_key(&secp, &other_privkey);
-        let funding_amount = 100_000;
-        let index : usize = 0;
+        let other_privkey = bitcoin::PrivateKey {
+            compressed: true,
+            network: bitcoin::Network::Testnet,
+            inner: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000002",
+            )
+            .unwrap(),
+        };
+        let index: usize = 10;
+        let mut input = TxIn::default();
         let tx = Transaction {
-            input: vec![],
+            input: vec![input.clone()],
             output: vec![],
             lock_time: LockTime::ZERO,
             version: 2,
-
         };
-        // let redeemscript : &Script = bitcoin::blockdata::script::Builder::new().as_script();
-        let redeemscript = ScriptBuf::default().as_script();
-        let sighash = secp256k1::Message::from_slice(
-            &SighashCache::new(tx)
-                .segwit_signature_hash(
-                    index,
-                    redeemscript,
-                    funding_amount,
-                    EcdsaSighashType::All,
-                )
-                .map_err(ContractError::Sighash)[..],
-        )
-        .map_err(ContractError::Secp)?;
+
         let contract_redeemscript = ScriptBuf::default(); // Example redeem script
-        let mut input = TxIn::default();
 
-        let assert = sign_transaction_input();
-
-        // Create an instance of IncomingSwapCoin
-        let mut incoming_swap_coin = IncomingSwapCoin {
-            my_privkey,
-            other_pubkey,
-            other_privkey: Some(other_privkey),
-            contract_tx,
-            contract_redeemscript,
-            hashlock_privkey: SecretKey::default(), // Example hashlock private key
-            funding_amount,
+        let incoming_swapcoin = IncomingSwapCoin {
+            my_privkey: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000003",
+            )
+            .unwrap(),
+            other_privkey: Some(
+                secp256k1::SecretKey::from_str(
+                    "0000000000000000000000000000000000000000000000000000000000000005",
+                )
+                .unwrap(),
+            ),
+            other_pubkey: PublicKey::from_private_key(&secp, &other_privkey),
+            contract_tx: Transaction {
+                input: vec![],
+                output: vec![],
+                lock_time: LockTime::ZERO,
+                version: 2,
+            },
+            contract_redeemscript: ScriptBuf::default(),
+            hashlock_privkey: secp256k1::SecretKey::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000004",
+            )
+            .unwrap(),
+            funding_amount: 100_000,
             others_contract_sig: None,
             hash_preimage: None,
         };
-
-        // Perform signing
-        let result = incoming_swap_coin.sign_transaction_input(
-            index,
-            &contract_tx,
-            &mut input,
-            &redeemscript,
-        );
-
-        // Check if signing is successful
-        assert!(result.is_ok());
-
-    // Verify the resulting transaction input contains the expected signatures
-    let expected_my_pubkey = incoming_swap_coin.get_my_pubkey();
-    let expected_other_pubkey = incoming_swap_coin.other_pubkey;
-    let expected_sig_mine = Secp256k1::new().sign_ecdsa(&secp256k1::Message::from_slice(&[0; 32]).unwrap(), &my_privkey);
-    let expected_sig_other = Secp256k1::new().sign_ecdsa(&secp256k1::Message::from_slice(&[0; 32]).unwrap(), &other_privkey);
-
-    // Assuming apply_two_signatures_to_2of2_multisig_spend modifies the input in place
-    let expected_input = TxIn {
-        witness: vec![
-            expected_sig_mine.serialize_der().to_vec(),
-            expected_sig_other.serialize_der().to_vec(),
-            vec![EcdsaSighashType::All as u8],
-            redeemscript.to_bytes(),
-        ],
-        ..Default::default()
-    };
-
-    assert_eq!(input, expected_input);
+        // Intentionally failing to sign with incomplete swapcoin
+        assert!(incoming_swapcoin
+            .sign_transaction_input(index, &tx, &mut input, &contract_redeemscript,)
+            .is_err());
     }
-
 }
-*/

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -863,7 +863,7 @@ mod tests {
             )
             .unwrap(),
         };
-        let mut input = TxIn::default();
+        let input = TxIn::default();
         let output = TxOut::default();
         let incoming_swapcoin = IncomingSwapCoin {
             my_privkey: secp256k1::SecretKey::from_str(
@@ -916,7 +916,6 @@ mod tests {
             version: 2,
         };
         let index = 0;
-        let input_value = 100;
         let preimage = Vec::new();
         incoming_swapcoin
             .sign_hashlocked_transaction_input_given_preimage(
@@ -929,13 +928,6 @@ mod tests {
             .unwrap();
         // If the tx is succesful, check some field like:
         assert!(tx.input[0].witness.len() == 3);
-        let test2 = incoming_swapcoin.sign_hashlocked_transaction_input(
-            index,
-            &tx,
-            &mut input,
-            input_value,
-        );
-        println!(" test 2 {:?}", test2);
     }
 
     #[test]

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -670,10 +670,12 @@ mod tests {
             contract_redeemscript: ScriptBuf::default(),
         };
 
-        let secret_key =
+        let secret_key_1 =
             SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000002")
                 .unwrap();
-        assert!(swapcoin.apply_privkey(secret_key).is_ok());
+        let secret_key_2 = SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000069").unwrap();
+        assert!(swapcoin.apply_privkey(secret_key_1).is_ok());
+        assert!(swapcoin.apply_privkey(secret_key_2).is_err());
     }
 
     #[test]
@@ -716,10 +718,12 @@ mod tests {
             hash_preimage: None,
         };
 
-        let secret_key =
+        let secret_key_1 =
             SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000002")
                 .unwrap();
-        assert!(incoming_swapcoin.apply_privkey(secret_key).is_ok());
+        let secret_key_2 = SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000069").unwrap();
+        assert!(incoming_swapcoin.apply_privkey(secret_key_1).is_ok());
+        assert!(incoming_swapcoin.apply_privkey(secret_key_2).is_err());
     }
 
     #[test]
@@ -755,10 +759,12 @@ mod tests {
             others_contract_sig: None,
             hash_preimage: None,
         };
-        let secret_key =
+        let secret_key_1 =
             SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000001")
                 .unwrap();
-        assert!(outgoing_swapcoin.apply_privkey(secret_key).is_ok());
+        let secret_key_2 = SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000069").unwrap();
+        assert!(outgoing_swapcoin.apply_privkey(secret_key_1).is_ok());
+        assert!(outgoing_swapcoin.apply_privkey(secret_key_2).is_err());
     }
 }
 /*
@@ -801,23 +807,6 @@ mod tests {
             // Return Ok(()) if the signature is valid; otherwise, return an error
             Ok(())
         }
-    }
-
-    #[test]
-    fn test_apply_privkey() {
-        // Create a MockWatchOnlySwapCoin instance for testing
-        let mut swapcoin = MockWatchOnlySwapCoin {
-            sender_pubkey: PublicKey::default(),
-            receiver_pubkey: PublicKey::default(),
-            funding_amount: 0,
-            contract_tx: Transaction::default(),
-        };
-
-        // Call apply_privkey function with a valid privkey
-        let result = swapcoin.apply_privkey(SecretKey::default());
-
-        // Assert that the function returns Ok(())
-        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/wallet/swapcoin.rs
+++ b/src/wallet/swapcoin.rs
@@ -735,7 +735,7 @@ mod tests {
         let other_pubkey_from_method = incoming_swapcoin.get_other_pubkey();
         assert_eq!(other_pubkey_from_method, &incoming_swapcoin.other_pubkey);
         // Test is_hash_preimage_known for empty hash_preimage
-        assert_eq!(incoming_swapcoin.is_hash_preimage_known(), false);
+        assert!(!incoming_swapcoin.is_hash_preimage_known());
     }
 
     #[test]
@@ -788,7 +788,7 @@ mod tests {
             &outgoing_swapcoin.other_pubkey
         );
         // Test is_hash_preimage_known
-        assert_eq!(outgoing_swapcoin.is_hash_preimage_known(), false);
+        assert!(!outgoing_swapcoin.is_hash_preimage_known());
     }
 
     #[test]
@@ -917,15 +917,16 @@ mod tests {
         };
         let index = 0;
         let preimage = Vec::new();
-        incoming_swapcoin.sign_hashlocked_transaction_input_given_preimage(
-            index,
-            &tx.clone(),
-            &mut tx.input[0],
-            incoming_swapcoin.contract_tx.output[0].value,
-            &preimage,
-        )
-        .unwrap();
-    // If the tx is succesful, check some field like:
-    assert!(tx.input[0].witness.len() == 3);
+        incoming_swapcoin
+            .sign_hashlocked_transaction_input_given_preimage(
+                index,
+                &tx.clone(),
+                &mut tx.input[0],
+                incoming_swapcoin.contract_tx.output[0].value,
+                &preimage,
+            )
+            .unwrap();
+        // If the tx is succesful, check some field like:
+        assert!(tx.input[0].witness.len() == 3);
     }
 }


### PR DESCRIPTION
Aims to fix #81.
Added unit tests for various methods like:

```rust
fn sign_transaction_input()
fn sign_hashlocked_transaction_input()
fn create_hashlock_spend_without_preimage()
fn apply_privkey_watchonly_swapcoin()
fn apply_privkey_incoming_swapcoin()
fn apply_privkey_outgoing_swapcoin()
```
Keeping our `codecov` in mind, various fail/error cases have also been covered to get the coverage higher. Also some tests are implemented for all three structs like `IncomingSwapcoin`, `OutgoingSwapcoin`, `WatchonlySwapcoin` to get more codecov coverage.

PS: After merging, we will go from `65%` to `85%` in this `swapcoin.rs`. Also these tests indirectly increased the coverage in several other files as well. We'll analyze the overall codecov once this is merged.