### PR TITLE
Added pre-commit to .git

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ tests/
 | **`src/bin`**       | Houses deployed project binaries. |
 | **`src/protocol`**  | Contains utility functions, error handling, and messages for protocol communication. |
 
+### Setting Up Git Hooks
+
+After cloning the repository, set up the pre-commit hook by running:
+
+```bash
+ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit
+```
 
 ## Build and Run
 

--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Check Rust formatting and automatically correct it
+echo "Auto-correcting code style with rustfmt..."
+cargo fmt
+
+# Check Clippy lints
+echo "Checking code quality with Clippy..."
+if ! cargo clippy --all-targets -- -D warnings; then
+    echo "Clippy issues detected."
+    echo "Please fix the Clippy issues before committing."
+    exit 1 
+fi
+
+exit 0 


### PR DESCRIPTION
Added git-hook directory to add pre-commit hook to .git directory. It adds a symbolic link to .git/precommit. This pre-commit hook automatically resolves fmt issues and warn on clippy errors.
1. Updated Readme 
2. Added command to link precommit to .git/pre-commit