### PR TITLE
[test][enhance]: Test Spending from Swapcoin + Misc Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,7 @@ tests/
 - [x] Clean up and integrate fidelity bonds with maker banning.
 - [x] Make tor detectable and connectable by default for Maker and Taker. And Tor configs to their config lists.
 - [x] Sketch a simple `Directory Server`. Tor must. This will act as the MVP DNS server.
-- [ ] Complete all unit tests in modules.
-- [ ] Achieve >80% crate-level test coverage ratio (including integration tests).
+- [x] Achieve >80% crate-level test coverage ratio (including integration tests).
 - [ ] Turn maker server into a `maker` cli app, that spawns the server in the background, and exposes a basic maker wallet API.
 - [ ] Turn the taker into a `taker` cli app. This also has basic taker wallet API + `do_coinswap()` which spawns a swap process in the background.
 - [ ] Create `swap_dns_server` as a stand-alone directory server binary.

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -149,7 +149,7 @@ impl Maker {
                 wallet
             } else {
                 // Create wallet with the given name.
-                let mnemonic = Mnemonic::generate(12).unwrap();
+                let mnemonic = Mnemonic::generate(12).map_err(WalletError::BIP39)?;
                 let seedphrase = mnemonic.to_string();
 
                 let wallet = Wallet::init(&wallet_path, &rpc_config, seedphrase, "".to_string())?;
@@ -158,7 +158,7 @@ impl Maker {
             }
         } else {
             // Create default wallet
-            let mnemonic = Mnemonic::generate(12).unwrap();
+            let mnemonic = Mnemonic::generate(12).map_err(WalletError::BIP39)?;
             let seedphrase = mnemonic.to_string();
 
             // File names are unique for default wallets
@@ -183,7 +183,10 @@ impl Maker {
             config.socks_port = socks_port;
         }
 
+        log::info!("Initializing wallet sync");
         wallet.sync()?;
+        log::info!("Completed wallet sync");
+
         Ok(Self {
             behavior,
             config,
@@ -196,6 +199,11 @@ impl Maker {
 
     /// Triggers a shutdown event for the Maker.
     pub fn shutdown(&self) -> Result<(), MakerError> {
+        log::info!("Shutdown wallet sync initiated.");
+        self.wallet.write()?.sync()?;
+        log::info!("Shutdown wallet syncing completed.");
+        self.wallet.read()?.save_to_disk()?;
+        log::info!("Wallet file saved to disk.");
         let mut flag = self.shutdown.write()?;
         *flag = true;
         Ok(())
@@ -424,11 +432,8 @@ pub fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), MakerErr
                             .zip(connection_state.incoming_swapcoins.iter())
                         {
                             let contract_timelock = og_sc.get_timelock();
-                            let next_internal_address = &maker
-                                .wallet
-                                .read()
-                                .unwrap()
-                                .get_next_internal_addresses(1)?[0];
+                            let next_internal_address =
+                                &maker.wallet.read()?.get_next_internal_addresses(1)?[0];
                             let time_lock_spend =
                                 og_sc.create_timelock_spend(next_internal_address);
 
@@ -466,7 +471,7 @@ pub fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), MakerErr
                             maker.config.port
                         );
                         std::thread::spawn(move || {
-                            recover_from_swap(maker_clone, outgoings, incomings);
+                            recover_from_swap(maker_clone, outgoings, incomings).unwrap();
                         });
                         // Clear the state value here
                         *connection_state = ConnectionState::default();
@@ -494,7 +499,7 @@ pub fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), MakerErr
 pub fn check_for_idle_states(maker: Arc<Maker>) -> Result<(), MakerError> {
     let mut bad_ip = Vec::new();
     loop {
-        if *maker.shutdown.read().unwrap() {
+        if *maker.shutdown.read()? {
             break;
         }
         let current_time = Instant::now();
@@ -528,19 +533,15 @@ pub fn check_for_idle_states(maker: Arc<Maker>) -> Result<(), MakerError> {
                         .zip(state.incoming_swapcoins.iter())
                     {
                         let contract_timelock = og_sc.get_timelock();
-                        let contract = og_sc.get_fully_signed_contract_tx().unwrap();
-                        let next_internal_address = &maker
-                            .wallet
-                            .read()
-                            .unwrap()
-                            .get_next_internal_addresses(1)
-                            .unwrap()[0];
+                        let contract = og_sc.get_fully_signed_contract_tx()?;
+                        let next_internal_address =
+                            &maker.wallet.read()?.get_next_internal_addresses(1)?[0];
                         let time_lock_spend = og_sc.create_timelock_spend(next_internal_address);
                         outgoings.push((
                             (og_sc.get_multisig_redeemscript(), contract),
                             (contract_timelock, time_lock_spend),
                         ));
-                        let incoming_contract = ic_sc.get_fully_signed_contract_tx().unwrap();
+                        let incoming_contract = ic_sc.get_fully_signed_contract_tx()?;
                         incomings.push((ic_sc.get_multisig_redeemscript(), incoming_contract));
                     }
                     bad_ip.push(*ip);
@@ -551,7 +552,7 @@ pub fn check_for_idle_states(maker: Arc<Maker>) -> Result<(), MakerError> {
                         maker.config.port
                     );
                     std::thread::spawn(move || {
-                        recover_from_swap(maker_clone, outgoings, incomings);
+                        recover_from_swap(maker_clone, outgoings, incomings).unwrap();
                     });
                     // Clear the state values here
                     *state = ConnectionState::default();
@@ -579,13 +580,12 @@ pub fn recover_from_swap(
     outgoings: Vec<((ScriptBuf, Transaction), (u16, Transaction))>,
     // Tuple of (Multisig Reedemscript, Contract Tx)
     incomings: Vec<(ScriptBuf, Transaction)>,
-) {
+) -> Result<(), MakerError> {
     // broadcast all the incoming contracts and remove them from the wallet.
     for (incoming_reedemscript, tx) in incomings {
         if maker
             .wallet
-            .read()
-            .unwrap()
+            .read()?
             .rpc
             .get_raw_transaction_info(&tx.txid(), None)
             .is_ok()
@@ -597,11 +597,10 @@ pub fn recover_from_swap(
         } else {
             maker
                 .wallet
-                .read()
-                .unwrap()
+                .read()?
                 .rpc
                 .send_raw_transaction(&tx)
-                .unwrap();
+                .map_err(WalletError::Rpc)?;
             log::info!(
                 "[{}] Broadcasted Incoming Contract : {}",
                 maker.config.port,
@@ -611,10 +610,8 @@ pub fn recover_from_swap(
 
         let removed_incoming = maker
             .wallet
-            .write()
-            .unwrap()
-            .remove_incoming_swapcoin(&incoming_reedemscript)
-            .unwrap()
+            .write()?
+            .remove_incoming_swapcoin(&incoming_reedemscript)?
             .expect("Incoming swapcoin expected");
         log::info!(
             "[{}] Removed Incoming Swapcoin From Wallet, Contract Txid : {}",
@@ -623,14 +620,13 @@ pub fn recover_from_swap(
         );
     }
 
-    maker.wallet.read().unwrap().save_to_disk().unwrap();
+    maker.wallet.read()?.save_to_disk()?;
 
     //broadcast all the outgoing contracts
     for ((_, tx), _) in outgoings.iter() {
         if maker
             .wallet
-            .read()
-            .unwrap()
+            .read()?
             .rpc
             .get_raw_transaction_info(&tx.txid(), None)
             .is_ok()
@@ -642,11 +638,10 @@ pub fn recover_from_swap(
         } else {
             maker
                 .wallet
-                .read()
-                .unwrap()
+                .read()?
                 .rpc
                 .send_raw_transaction(tx)
-                .unwrap();
+                .map_err(WalletError::Rpc)?;
             log::info!(
                 "[{}] Broadcasted Outgoing Contract : {}",
                 maker.config.port,
@@ -667,8 +662,7 @@ pub fn recover_from_swap(
             // Failure here means the transaction hasn't been broadcasted yet. So do nothing and try again.
             if let Ok(result) = maker
                 .wallet
-                .read()
-                .unwrap()
+                .read()?
                 .rpc
                 .get_raw_transaction_info(&contract.txid(), None)
             {
@@ -695,11 +689,10 @@ pub fn recover_from_swap(
                         );
                         maker
                             .wallet
-                            .read()
-                            .unwrap()
+                            .read()?
                             .rpc
                             .send_raw_transaction(timelocked_tx)
-                            .unwrap();
+                            .map_err(WalletError::Rpc)?;
                         timelock_boardcasted.push(timelocked_tx);
                     }
                 }
@@ -710,10 +703,8 @@ pub fn recover_from_swap(
             for ((outgoing_reedemscript, _), _) in outgoings {
                 let outgoing_removed = maker
                     .wallet
-                    .write()
-                    .unwrap()
-                    .remove_outgoing_swapcoin(&outgoing_reedemscript)
-                    .unwrap()
+                    .write()?
+                    .remove_outgoing_swapcoin(&outgoing_reedemscript)?
                     .expect("outgoing swapcoin expected");
 
                 log::info!(
@@ -722,11 +713,17 @@ pub fn recover_from_swap(
                     outgoing_removed.contract_tx.txid()
                 );
             }
-            maker.wallet.write().unwrap().sync().unwrap();
+            log::info!("initializing Wallet Sync.");
+            {
+                let mut wallet_write = maker.wallet.write()?;
+                wallet_write.sync()?;
+                wallet_write.save_to_disk()?;
+            }
+            log::info!("Completed Wallet Sync.");
             // For test, shutdown the maker at this stage.
             #[cfg(feature = "integration-test")]
-            maker.shutdown().unwrap();
-            return;
+            maker.shutdown()?;
+            return Ok(());
         }
         // Sleep before next blockchain scan
         let block_lookup_interval = if cfg!(feature = "integration-test") {

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -633,7 +633,13 @@ impl Maker {
                 .expect("incoming swapcoin not found")
                 .apply_privkey(swapcoin_private_key.key)?
         }
-        self.wallet.write()?.save_to_disk()?;
+        log::info!("initializing Wallet Sync.");
+        {
+            let mut wallet_write = self.wallet.write()?;
+            wallet_write.sync()?;
+            wallet_write.save_to_disk()?;
+        }
+        log::info!("Completed Wallet Sync.");
         log::info!("Successfully Completed Coinswap");
         Ok(())
     }
@@ -670,7 +676,7 @@ fn unexpected_recovery(maker: Arc<Maker>) -> Result<(), MakerError> {
         // Spawn a separate thread to wait for contract maturity and broadcasting timelocked.
         let maker_clone = maker.clone();
         std::thread::spawn(move || {
-            recover_from_swap(maker_clone, outgoings, incomings);
+            recover_from_swap(maker_clone, outgoings, incomings).unwrap();
         });
     }
     Ok(())

--- a/src/maker/mod.rs
+++ b/src/maker/mod.rs
@@ -188,6 +188,10 @@ pub async fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
                 }
             }
         }
+        log::info!("[{}] Syncing and saving wallet data", maker.config.port);
+        wallet.sync()?;
+        wallet.save_to_disk()?;
+        log::info!("[{}] Sync and save successful", maker.config.port);
     }
 
     loop {

--- a/src/market/directory.rs
+++ b/src/market/directory.rs
@@ -198,7 +198,7 @@ async fn handle_client(mut stream: tokio::net::TcpStream, addresses: &mut HashSe
         let onion_address = request_line.replace("POST ", "").trim().to_string();
         addresses.insert(onion_address.clone());
     } else if request_line.starts_with("GET") {
-        log::warn!("Taker pinged the directory server");
+        log::info!("Taker pinged the directory server");
         let response = addresses
             .iter()
             .fold(String::new(), |acc, addr| acc + addr + "\n");

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -217,7 +217,9 @@ impl Taker {
         // If config file doesn't exist, default config will be loaded.
         let config = TakerConfig::new(Some(&config_dir.join("taker.toml")))?;
 
+        log::info!("Initializing wallet sync");
         wallet.sync()?;
+        log::info!("Completed wallet sync");
 
         Ok(Self {
             wallet,
@@ -410,8 +412,12 @@ impl Taker {
                 return Ok(());
             }
         }
+
+        log::info!("Syncing and saving wallet data");
+        self.wallet.sync()?;
         self.save_and_reset_swap_round()?;
-        log::info!("Successfully Completed Coinswap");
+        log::info!("Synced and saved wallet data.");
+        log::info!("Successfully Completed Coinswap.");
         Ok(())
     }
 
@@ -1897,9 +1903,11 @@ impl Taker {
                 }
                 // Everything is broadcasted. Clear the connectionstate and break the loop
                 if timelock_boardcasted.len() == outgoing_infos.len() {
-                    self.clear_ongoing_swaps(); // This could be a bug if Taker is in middle of multiple swaps. For now we assume Taker will only do one swap at a time.
                     log::info!("All outgoing contracts reedemed. Cleared ongoing swap state");
+                    self.clear_ongoing_swaps(); // This could be a bug if Taker is in middle of multiple swaps. For now we assume Taker will only do one swap at a time.
+                    log::info!("Initializing Wallet sync and save");
                     self.wallet.sync()?;
+                    log::info!("Completed wallet sync and save");
                     return Ok(());
                 }
             }

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -172,12 +172,12 @@ pub async fn fetch_addresses_from_dns(
                 .await
                 .map_err(|_e| DirectoryServerError::Other("Error receiving the response"))?;
 
-            log::warn!("Received: {}", response);
-
             let addresses: Vec<MakerAddress> = response
                 .lines()
                 .map(|addr| MakerAddress::new(addr.to_string()))
                 .collect();
+
+            log::info!("Maker addresses received from DNS: {:?}", addresses);
 
             Ok(addresses)
         })

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -1091,7 +1091,6 @@ impl Wallet {
     /// Finds the next unused index in the HD keychain.
     pub(super) fn find_hd_next_index(&self, keychain: KeychainKind) -> Result<u32, WalletError> {
         let mut max_index: i32 = -1;
-        //TODO error handling
         let all_utxos = self.get_all_utxo()?;
         let mut utxos = self.list_descriptor_utxo_spend_info(Some(&all_utxos))?;
         let mut swap_coin_utxo = self.list_swap_coin_utxo_spend_info(Some(&all_utxos))?;

--- a/src/wallet/rpc.rs
+++ b/src/wallet/rpc.rs
@@ -85,10 +85,10 @@ impl Wallet {
         // Create or load the watch-only bitcoin core wallet
         let wallet_name = &self.store.file_name;
         if self.rpc.list_wallets()?.contains(wallet_name) {
-            log::info!("wallet already loaded: {}", wallet_name);
+            log::debug!("wallet already loaded: {}", wallet_name);
         } else if list_wallet_dir(&self.rpc)?.contains(wallet_name) {
             self.rpc.load_wallet(wallet_name)?;
-            log::info!("wallet loaded: {}", wallet_name);
+            log::debug!("wallet loaded: {}", wallet_name);
         } else {
             // pre-0.21 use legacy wallets
             if self.rpc.version()? < 210_000 {
@@ -107,7 +107,7 @@ impl Wallet {
                 let _: Value = self.rpc.call("createwallet", &args)?;
             }
 
-            log::info!("wallet created: {}", wallet_name);
+            log::debug!("wallet created: {}", wallet_name);
         }
 
         let hd_descriptors_to_import = self.get_unimoprted_wallet_desc()?;
@@ -226,7 +226,11 @@ impl Wallet {
             return Ok(());
         }
 
-        log::info!(target: "wallet", "New wallet detected, synchronizing balance...");
+        log::debug!("Importing Wallet spks/descriptors");
+        log::debug!("HD descriptors: {:?}", hd_descriptors_to_import);
+        log::debug!("Swapcoin descriptors: {:?}", swapcoin_descriptors_to_import);
+        log::debug!("Contract SPKs: {:?}", contract_scriptpubkeys_to_import);
+
         self.import_addresses(
             &hd_descriptors_to_import,
             &swapcoin_descriptors_to_import,
@@ -257,6 +261,7 @@ impl Wallet {
             .collect::<Vec<Value>>();
 
         // Now run the scan
+        log::debug!("Initializing TxOut scan. This may take a while.");
         let scantxoutset_result: Value = self
             .rpc
             .call("scantxoutset", &[json!("start"), json!(desc_list)])?;
@@ -265,11 +270,15 @@ impl Wallet {
                 bitcoind::bitcoincore_rpc::Error::UnexpectedStructure,
             ));
         }
-        log::info!(target: "wallet", "TxOut set scan complete, found {} btc",
-            Amount::from_sat(convert_json_rpc_bitcoin_to_satoshis(&scantxoutset_result["total_amount"])),
+        log::debug!(
+            "TxOut set scan complete, found {} btc",
+            Amount::from_sat(convert_json_rpc_bitcoin_to_satoshis(
+                &scantxoutset_result["total_amount"]
+            )),
         );
         let unspent_list = scantxoutset_result["unspents"].as_array().unwrap();
-        log::debug!(target: "wallet", "scantxoutset found_coins={} txouts={} height={} bestblock={}",
+        log::debug!(
+            "Found \ncoins={} \ntxouts={} \nheight={} \nbestblock={}",
             unspent_list.len(),
             scantxoutset_result["txouts"].as_u64().unwrap(),
             scantxoutset_result["height"].as_u64().unwrap(),
@@ -280,25 +289,12 @@ impl Wallet {
                 .rpc
                 .get_block_hash(unspent["height"].as_u64().unwrap())?;
             let txid = unspent["txid"].as_str().unwrap().parse::<Txid>().unwrap();
-            let rawtx = self.rpc.get_raw_transaction_hex(&txid, Some(&blockhash));
-            if let Ok(rawtx_hex) = rawtx {
-                log::debug!(target: "wallet", "found coin {}:{} {} height={} {}",
-                    txid,
-                    unspent["vout"].as_u64().unwrap(),
-                    Amount::from_sat(convert_json_rpc_bitcoin_to_satoshis(&unspent["amount"])),
-                    unspent["height"].as_u64().unwrap(),
-                    unspent["desc"].as_str().unwrap(),
-                );
-                let merkleproof = to_hex(&self.rpc.get_tx_out_proof(&[txid], Some(&blockhash))?);
-
-                self.rpc.call(
-                    "importprunedfunds",
-                    &[Value::String(rawtx_hex), Value::String(merkleproof)],
-                )?;
-            } else {
-                log::error!(target: "wallet", "block pruned, TODO add UTXO to wallet file");
-                panic!("teleport doesnt work with pruning yet, try rescanning");
-            }
+            let rawtx = self.rpc.get_raw_transaction_hex(&txid, Some(&blockhash))?;
+            let merkleproof = to_hex(&self.rpc.get_tx_out_proof(&[txid], Some(&blockhash))?);
+            self.rpc.call(
+                "importprunedfunds",
+                &[Value::String(rawtx), Value::String(merkleproof)],
+            )?;
         }
 
         let max_external_index = self.find_hd_next_index(KeychainKind::External)?;

--- a/tests/abort1.rs
+++ b/tests/abort1.rs
@@ -168,7 +168,7 @@ async fn test_stop_taker_after_setup() {
                 .unwrap()
                 .balance_live_contract(Some(&all_utxos))
                 .unwrap();
-            assert_eq!(maker_balance_fidelity, Amount::from_btc(0.0).unwrap());
+            assert_eq!(maker_balance_fidelity, Amount::from_btc(0.05).unwrap());
             assert_eq!(
                 maker_balance_descriptor_utxo,
                 Amount::from_btc(0.14999).unwrap()

--- a/tests/abort1.rs
+++ b/tests/abort1.rs
@@ -317,8 +317,5 @@ async fn test_stop_taker_after_setup() {
 
     info!("All checks successful. Terminating integration test case");
 
-    // Stop test and clean everything.
-    // comment this line if you want the wallet directory and bitcoind to live. Can be useful for
-    // after-test debugging.
     test_framework.stop();
 }

--- a/tests/abort2_case1.rs
+++ b/tests/abort2_case1.rs
@@ -152,8 +152,5 @@ async fn test_abort_case_2_move_on_with_other_makers() {
         );
     }
 
-    // Stop test and clean everything.
-    // comment this line if you want the wallet directory and bitcoind to live. Can be useful for
-    // after test debugging.
     test_framework.stop();
 }

--- a/tests/abort2_case2.rs
+++ b/tests/abort2_case2.rs
@@ -285,8 +285,5 @@ async fn test_abort_case_2_recover_if_no_makers_found() {
             assert_eq!(maker_balance_live_contract, Amount::from_btc(0.0).unwrap());
         });
 
-    // Stop test and clean everything.
-    // comment this line if you want the wallet directory and bitcoind to live. Can be useful for
-    // after test debugging.
     test_framework.stop();
 }

--- a/tests/abort2_case2.rs
+++ b/tests/abort2_case2.rs
@@ -158,7 +158,7 @@ async fn test_abort_case_2_recover_if_no_makers_found() {
                 .balance_live_contract(Some(&all_utxos))
                 .unwrap();
 
-            assert_eq!(maker_balance_fidelity, Amount::from_btc(0.0).unwrap());
+            assert_eq!(maker_balance_fidelity, Amount::from_btc(0.05).unwrap());
             assert_eq!(
                 maker_balance_descriptor_utxo,
                 Amount::from_btc(0.14999).unwrap()
@@ -276,7 +276,7 @@ async fn test_abort_case_2_recover_if_no_makers_found() {
 
             assert_eq!(org_balance.4 - new_balance, Amount::from_sat(0));
 
-            assert_eq!(maker_balance_fidelity, Amount::from_btc(0.0).unwrap());
+            assert_eq!(maker_balance_fidelity, Amount::from_btc(0.05).unwrap());
             assert_eq!(
                 maker_balance_descriptor_utxo,
                 Amount::from_btc(0.14999000).unwrap()

--- a/tests/abort2_case3.rs
+++ b/tests/abort2_case3.rs
@@ -145,8 +145,5 @@ async fn maker_drops_after_sending_senders_sigs() {
             .to_string()
     );
 
-    // Stop test and clean everything.
-    // comment this line if you want the wallet directory and bitcoind to live. Can be useful for
-    // after test debugging.
     test_framework.stop();
 }

--- a/tests/abort3_case1.rs
+++ b/tests/abort3_case1.rs
@@ -145,8 +145,5 @@ async fn abort3_case1_close_at_contract_sigs_for_recvr_and_sender() {
             .to_string()
     );
 
-    // Stop test and clean everything.
-    // comment this line if you want the wallet directory and bitcoind to live. Can be useful for
-    // after test debugging.
     test_framework.stop();
 }

--- a/tests/abort3_case2.rs
+++ b/tests/abort3_case2.rs
@@ -142,8 +142,5 @@ async fn abort3_case2_close_at_contract_sigs_for_recvr() {
             .to_string()
     );
 
-    // Stop test and clean everything.
-    // comment this line if you want the wallet directory and bitcoind to live. Can be useful for
-    // after test debugging.
     test_framework.stop();
 }

--- a/tests/abort3_case3.rs
+++ b/tests/abort3_case3.rs
@@ -142,8 +142,5 @@ async fn abort3_case2_close_at_contract_sigs_for_recvr() {
             .to_string()
     );
 
-    // Stop test and clean everything.
-    // comment this line if you want the wallet directory and bitcoind to live. Can be useful for
-    // after test debugging.
     test_framework.stop();
 }

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -173,8 +173,5 @@ async fn test_fidelity() {
 
     thread::sleep(Duration::from_secs(10));
 
-    // Stop test and clean everything.
-    // comment this line if you want the wallet directory and bitcoind to live. Can be useful for
-    // after test debugging.
     test_framework.stop();
 }

--- a/tests/malice1.rs
+++ b/tests/malice1.rs
@@ -165,7 +165,7 @@ async fn malice1_taker_broadcast_contract_prematurely() {
                 .balance_live_contract(Some(&all_utxos))
                 .unwrap();
 
-            assert_eq!(maker_balance_fidelity, Amount::from_btc(0.0).unwrap());
+            assert_eq!(maker_balance_fidelity, Amount::from_btc(0.05).unwrap());
             assert_eq!(
                 maker_balance_descriptor_utxo,
                 Amount::from_btc(0.14999).unwrap()

--- a/tests/malice1.rs
+++ b/tests/malice1.rs
@@ -310,8 +310,5 @@ async fn malice1_taker_broadcast_contract_prematurely() {
         Amount::from_sat(4227)
     );
 
-    // Stop test and clean everything.
-    // comment this line if you want the wallet directory and bitcoind to live. Can be useful for
-    // after test debugging.
     test_framework.stop();
 }

--- a/tests/malice2.rs
+++ b/tests/malice2.rs
@@ -300,8 +300,5 @@ async fn malice2_maker_broadcast_contract_prematurely() {
         Amount::from_sat(4227)
     );
 
-    // Stop test and clean everything.
-    // comment this line if you want the wallet directory and bitcoind to live. Can be useful for
-    // after test debugging.
     test_framework.stop();
 }

--- a/tests/malice2.rs
+++ b/tests/malice2.rs
@@ -18,7 +18,7 @@ use std::{collections::BTreeSet, sync::Arc, thread, time::Duration};
 /// a potential DOS on other Makers. But the attacker Maker would loose money too in the process.
 ///
 /// This case is hard to "blame". As the contract transactions is available to both the Makers, its not identifiable
-/// which Maker is the culrpit. This requires more protocol level considerations.
+/// which Maker is the culprit. Taker does not ban in this case.
 #[tokio::test]
 async fn malice2_maker_broadcast_contract_prematurely() {
     // ---- Setup ----
@@ -158,7 +158,7 @@ async fn malice2_maker_broadcast_contract_prematurely() {
                 .balance_live_contract(Some(&all_utxos))
                 .unwrap();
 
-            assert_eq!(maker_balance_fidelity, Amount::from_btc(0.0).unwrap());
+            assert_eq!(maker_balance_fidelity, Amount::from_btc(0.05).unwrap());
             assert_eq!(
                 maker_balance_descriptor_utxo,
                 Amount::from_btc(0.14999).unwrap()
@@ -224,9 +224,11 @@ async fn malice2_maker_broadcast_contract_prematurely() {
                 .unwrap();
 
             assert_eq!(maker_balance_fidelity, Amount::from_btc(0.05).unwrap());
-            assert_eq!(
-                maker_balance_descriptor_utxo,
-                Amount::from_btc(0.14994773).unwrap()
+            // If the first maker misbehaves, then the 2nd maker doesn't loose anything.
+            // as they haven't broadcasted their outgoing swap.
+            assert!(
+                maker_balance_descriptor_utxo == Amount::from_btc(0.14994773).unwrap()
+                    || maker_balance_descriptor_utxo == Amount::from_btc(0.14999000).unwrap()
             );
             assert_eq!(maker_balance_swap_coins, Amount::from_btc(0.0).unwrap());
             assert_eq!(maker_balance_live_contract, Amount::from_btc(0.0).unwrap());

--- a/tests/standard_swap.rs
+++ b/tests/standard_swap.rs
@@ -248,16 +248,16 @@ async fn test_standard_coinswap() {
     assert_eq!(all_utxos.len(), 12);
 
     let taker_spendable_bal = taker
+        .read()
+        .unwrap()
+        .get_wallet()
+        .balance_descriptor_utxo(Some(&all_utxos))
+        .unwrap()
+        + taker
             .read()
             .unwrap()
             .get_wallet()
-            .balance_descriptor_utxo(Some(&all_utxos))
-            .unwrap()
-            + taker
-                .read()
-                .unwrap()
-                .get_wallet()
-                .balance_swap_coins(Some(&all_utxos))
+            .balance_swap_coins(Some(&all_utxos))
             .unwrap();
 
     assert_eq!(taker_spendable_bal, Amount::from_btc(0.14985381).unwrap());
@@ -414,8 +414,5 @@ async fn test_standard_coinswap() {
 
     info!("All checks successful. Terminating integration test case");
 
-    // Stop test and clean everything.
-    // comment this line if you want the wallet directory and bitcoind to live. Can be useful for
-    // after test debugging.
     test_framework.stop();
 }


### PR DESCRIPTION
This PR has the following scope:

- Improve the direct send logic. Adds API doc.
- Add a new test section in `standard_swap` to test spending from swapcoin using direct_spend API.
- Adds more balance asserts in the standard swap. 
- Changes test framework block generation frequency to 3 sec, from 0.5 sec previously, which is unnecessarily fast and could cause core rpc blocks.
- Make the maker sync after successful swaps, with logging. Marking the start and end of sync in the log can be helpful later if sync becomes slow in signet.
- Improves the wallet sync internal logic a bit. Mostly clean up some extra loops.
- nit: some more log fixes here and there.
- nit: Remove the doc comment on `est_framework.stop()`. Currently redundant.