### PR TITLE
[nit] Debug log + Test Framework

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -251,12 +251,6 @@ impl Maker {
         }
 
         for funding_info in &message.confirmed_funding_txes {
-            //check that the funding transaction pays to correct multisig
-            log::debug!(
-                "Proof of Funding: \ntx = {:#?}\nMultisig_Reedimscript = {:x}",
-                funding_info.funding_tx,
-                funding_info.multisig_redeemscript
-            );
             // check that the new locktime is sufficently short enough compared to the
             // locktime in the provided funding tx
             let locktime = read_contract_locktime(&funding_info.contract_redeemscript)?;

--- a/src/maker/mod.rs
+++ b/src/maker/mod.rs
@@ -116,7 +116,6 @@ pub async fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
         directory_onion_address
     );
 
-    log::debug!("Running maker with special behavior = {:?}", maker.behavior);
     maker.wallet.write()?.refresh_offer_maxsize_cache()?;
 
     let network = maker.get_wallet().read()?.store.network;
@@ -275,7 +274,6 @@ pub async fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
                 if Instant::now().saturating_duration_since(last_rpc_ping) > rpc_ping_interval {
                     last_rpc_ping = Instant::now();
                     rpc_ping_success = maker.wallet.write()?.refresh_offer_maxsize_cache().is_ok();
-                    log::debug!("rpc_ping_success = {}", rpc_ping_success);
                 }
                 accepting_clients = rpc_ping_success;
                 if !accepting_clients {
@@ -350,7 +348,6 @@ pub async fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
                     Ok(reply) => {
                         if let Some(message) = reply {
                             log::info!("[{}] ===> {} ", maker_clone.config.port, message);
-                            log::debug!("{:#?}", message);
                             if let Err(e) = send_message(&mut socket_writer, &message).await {
                                 log::error!("Closing due to IO error in sending message: {:?}", e);
                                 continue;

--- a/src/market/directory.rs
+++ b/src/market/directory.rs
@@ -194,9 +194,9 @@ async fn handle_client(mut stream: tokio::net::TcpStream, addresses: &mut HashSe
     reader.read_line(&mut request_line).await.unwrap();
 
     if request_line.starts_with("POST") {
-        log::info!("Maker pinged the directory server");
         let onion_address = request_line.replace("POST ", "").trim().to_string();
         addresses.insert(onion_address.clone());
+        log::info!("Got new maker address: {}", onion_address);
     } else if request_line.starts_with("GET") {
         log::info!("Taker pinged the directory server");
         let response = addresses

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -126,7 +126,6 @@ pub async fn fetch_offer_from_makers(
         let taker_config: TakerConfig = config.clone();
         tokio::spawn(async move {
             let offer = download_maker_offer(addr, taker_config).await;
-            log::debug!("Received Maker Offer: {:?}", offer);
             offers_writer.send(offer).await.unwrap();
         });
     }

--- a/src/taker/routines.rs
+++ b/src/taker/routines.rs
@@ -77,7 +77,7 @@ pub async fn handshake_maker(
         }),
     )
     .await?;
-    let makerhello = match read_maker_message(&mut socket_reader).await {
+    let _makerhello = match read_maker_message(&mut socket_reader).await {
         Ok(MakerToTakerMessage::MakerHello(m)) => m,
         Ok(any) => {
             return Err((ProtocolError::WrongMessage {
@@ -90,8 +90,6 @@ pub async fn handshake_maker(
             return Err(e.into());
         }
     };
-
-    log::debug!("{:#?}", makerhello);
     Ok((socket_reader, socket_writer))
 }
 
@@ -451,7 +449,6 @@ pub(crate) async fn send_hash_preimage_and_get_private_keys(
 }
 
 async fn download_maker_offer_attempt_once(addr: &MakerAddress) -> Result<Offer, TakerError> {
-    log::debug!(target: "offerbook", "Connecting to {}", addr);
     let address = addr.as_str();
     let mut socket = Socks5Stream::connect("127.0.0.1:19050", address)
         .await?
@@ -475,7 +472,6 @@ async fn download_maker_offer_attempt_once(addr: &MakerAddress) -> Result<Offer,
         }
     };
 
-    log::debug!(target: "offerbook", "Obtained offer from {}", addr);
     Ok(*offer)
 }
 

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -79,13 +79,12 @@ pub fn seed_phrase_to_unique_id(seed: &str) -> String {
 /// Setup function that will only run once, even if called multiple times.
 pub fn setup_logger() {
     Once::new().call_once(|| {
-        env::set_var("RUST_LOG", "info");
+        env::set_var("RUST_LOG", "coinswap=info");
         env_logger::Builder::from_env(
             env_logger::Env::default()
                 .default_filter_or("coinswap=info")
                 .default_write_style_or("always"),
         )
-        // .is_test(true)
         .init();
     });
 }
@@ -177,7 +176,7 @@ pub fn get_hd_path_from_descriptor(descriptor: &str) -> Option<(&str, u32, i32)>
     let close = descriptor.find(']');
     if open.is_none() || close.is_none() {
         //unexpected, so printing it to stdout
-        println!("unknown descriptor = {}", descriptor);
+        log::error!("unknown descriptor = {}", descriptor);
         return None;
     }
     let path = &descriptor[open.unwrap() + 1..close.unwrap()];
@@ -188,7 +187,7 @@ pub fn get_hd_path_from_descriptor(descriptor: &str) -> Option<(&str, u32, i32)>
     }
     let addr_type = path_chunks[1].parse::<u32>();
     if addr_type.is_err() {
-        log::debug!(target: "wallet", "unexpected address_type = {}", path);
+        log::error!(target: "wallet", "unexpected address_type = {}", path);
         return None;
     }
     let index = path_chunks[2].parse::<i32>();

--- a/src/wallet/rpc.rs
+++ b/src/wallet/rpc.rs
@@ -85,10 +85,10 @@ impl Wallet {
         // Create or load the watch-only bitcoin core wallet
         let wallet_name = &self.store.file_name;
         if self.rpc.list_wallets()?.contains(wallet_name) {
-            log::debug!("wallet already loaded: {}", wallet_name);
+            log::info!("wallet already loaded: {}", wallet_name);
         } else if list_wallet_dir(&self.rpc)?.contains(wallet_name) {
             self.rpc.load_wallet(wallet_name)?;
-            log::debug!("wallet loaded: {}", wallet_name);
+            log::info!("wallet loaded: {}", wallet_name);
         } else {
             // pre-0.21 use legacy wallets
             if self.rpc.version()? < 210_000 {
@@ -107,7 +107,7 @@ impl Wallet {
                 let _: Value = self.rpc.call("createwallet", &args)?;
             }
 
-            log::debug!("wallet created: {}", wallet_name);
+            log::info!("wallet created: {}", wallet_name);
         }
 
         let hd_descriptors_to_import = self.get_unimoprted_wallet_desc()?;
@@ -195,7 +195,6 @@ impl Wallet {
 
             let is_first_imported = if let Some(spk) = first_addr {
                 let ad = Address::from_script(&spk, self.store.network)?;
-                log::debug!("First Fidelity Addrs: {}", ad);
                 self.rpc
                     .get_address_info(&ad)?
                     .is_watchonly
@@ -206,7 +205,6 @@ impl Wallet {
 
             let is_last_imported = if let Some(spk) = last_addr {
                 let ad = Address::from_script(&spk, self.store.network)?;
-                log::debug!("Last Fidelity Addr: {}", ad);
                 self.rpc
                     .get_address_info(&ad)?
                     .is_watchonly
@@ -297,13 +295,6 @@ impl Wallet {
             )),
         );
         let unspent_list = scantxoutset_result["unspents"].as_array().unwrap();
-        log::debug!(
-            "Found \ncoins={} \ntxouts={} \nheight={} \nbestblock={}",
-            unspent_list.len(),
-            scantxoutset_result["txouts"].as_u64().unwrap(),
-            scantxoutset_result["height"].as_u64().unwrap(),
-            scantxoutset_result["bestblock"].as_str().unwrap(),
-        );
         for unspent in unspent_list {
             let blockhash = self
                 .rpc

--- a/tests/abort1.rs
+++ b/tests/abort1.rs
@@ -81,7 +81,7 @@ async fn test_stop_taker_after_setup() {
     });
 
     // confirm balances
-    test_framework.generate_1_block();
+    test_framework.generate_blocks(1);
 
     let mut all_utxos = taker.read().unwrap().get_wallet().get_all_utxo().unwrap();
 

--- a/tests/abort2_case1.rs
+++ b/tests/abort2_case1.rs
@@ -83,7 +83,7 @@ async fn test_abort_case_2_move_on_with_other_makers() {
     });
 
     // confirm balances
-    test_framework.generate_1_block();
+    test_framework.generate_blocks(1);
 
     // ---- Start Servers and attempt Swap ----
 

--- a/tests/abort2_case2.rs
+++ b/tests/abort2_case2.rs
@@ -84,7 +84,7 @@ async fn test_abort_case_2_recover_if_no_makers_found() {
     });
 
     // confirm balances
-    test_framework.generate_1_block();
+    test_framework.generate_blocks(1);
 
     let mut all_utxos = taker.read().unwrap().get_wallet().get_all_utxo().unwrap();
 

--- a/tests/abort2_case3.rs
+++ b/tests/abort2_case3.rs
@@ -79,7 +79,7 @@ async fn maker_drops_after_sending_senders_sigs() {
     });
 
     // confirm balances
-    test_framework.generate_1_block();
+    test_framework.generate_blocks(1);
 
     // ---- Start Servers and attempt Swap ----
 

--- a/tests/abort3_case1.rs
+++ b/tests/abort3_case1.rs
@@ -79,7 +79,7 @@ async fn abort3_case1_close_at_contract_sigs_for_recvr_and_sender() {
     });
 
     // confirm balances
-    test_framework.generate_1_block();
+    test_framework.generate_blocks(1);
 
     // ---- Start Servers and attempt Swap ----
 

--- a/tests/abort3_case2.rs
+++ b/tests/abort3_case2.rs
@@ -76,7 +76,7 @@ async fn abort3_case2_close_at_contract_sigs_for_recvr() {
     });
 
     // confirm balances
-    test_framework.generate_1_block();
+    test_framework.generate_blocks(1);
 
     // ---- Start Servers and attempt Swap ----
 

--- a/tests/abort3_case3.rs
+++ b/tests/abort3_case3.rs
@@ -76,7 +76,7 @@ async fn abort3_case2_close_at_contract_sigs_for_recvr() {
     });
 
     // confirm balances
-    test_framework.generate_1_block();
+    test_framework.generate_blocks(1);
 
     // ---- Start Servers and attempt Swap ----
 

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -55,7 +55,7 @@ async fn test_fidelity() {
         .get_next_external_address()
         .unwrap();
     test_framework.send_to_address(&maker_addrs, Amount::from_btc(0.04).unwrap());
-    test_framework.generate_1_block();
+    test_framework.generate_blocks(1);
 
     let maker_clone = maker.clone();
     let maker_thread = thread::spawn(move || start_maker_server(maker_clone));
@@ -74,7 +74,7 @@ async fn test_fidelity() {
 
     // Give Maker more funds and check fidelity bond is created at the restart of server.
     test_framework.send_to_address(&maker_addrs, Amount::from_btc(0.04).unwrap());
-    test_framework.generate_1_block();
+    test_framework.generate_blocks(1);
 
     let maker_clone = maker.clone();
     let maker_thread = thread::spawn(move || start_maker_server(maker_clone));

--- a/tests/malice1.rs
+++ b/tests/malice1.rs
@@ -77,7 +77,7 @@ async fn malice1_taker_broadcast_contract_prematurely() {
     });
 
     // confirm balances
-    test_framework.generate_1_block();
+    test_framework.generate_blocks(1);
 
     let mut all_utxos = taker.read().unwrap().get_wallet().get_all_utxo().unwrap();
 

--- a/tests/malice2.rs
+++ b/tests/malice2.rs
@@ -73,7 +73,7 @@ async fn malice2_maker_broadcast_contract_prematurely() {
     });
 
     // confirm balances
-    test_framework.generate_1_block();
+    test_framework.generate_blocks(1);
 
     let mut all_utxos = taker.read().unwrap().get_wallet().get_all_utxo().unwrap();
 

--- a/tests/standard_swap.rs
+++ b/tests/standard_swap.rs
@@ -74,7 +74,7 @@ async fn test_standard_coinswap() {
     });
 
     // confirm balances
-    test_framework.generate_1_block();
+    test_framework.generate_blocks(1);
 
     // --- Basic Checks ----
 
@@ -407,7 +407,7 @@ async fn test_standard_coinswap() {
         .send_raw_transaction(&tx)
         .unwrap();
 
-    test_framework.generate_1_block();
+    test_framework.generate_blocks(1);
 
     taker.write().unwrap().get_wallet_mut().sync().unwrap();
 

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -158,8 +158,7 @@ impl TestFramework {
         let tf_clone = test_framework.clone();
         thread::spawn(move || loop {
             thread::sleep(Duration::from_secs(3));
-            tf_clone.generate_1_block();
-            log::debug!("created 1 block");
+            tf_clone.generate_blocks(10);
             if *tf_clone.shutdown.read().unwrap() {
                 log::info!("ending block generation thread");
                 return;
@@ -174,8 +173,8 @@ impl TestFramework {
         &self.bitcoind.client
     }
 
-    /// Generate 1 block in the backend bitcoind.
-    pub fn generate_1_block(&self) {
+    /// Generate Blocks in regtest node.
+    pub fn generate_blocks(&self, n: u64) {
         let mining_address = self
             .bitcoind
             .client
@@ -185,7 +184,7 @@ impl TestFramework {
             .unwrap();
         self.bitcoind
             .client
-            .generate_to_address(1, &mining_address)
+            .generate_to_address(n, &mining_address)
             .unwrap();
     }
 


### PR DESCRIPTION
This PR includes mostly removing the majority of the debug logs.

Debug logging is usually verbose and overuse can lead to noisy logs.

Here we remove most of the debug logs and only have the most useful ones. Some of them are turned into Info, Warn and Error logs.

This PR also includes a new `generate_blocks()` function to generate multiple blocks via one rpc call. This is used in the block generation test to generate 10 blocks every 3 secs. Which makes our tests faster.  