### PR TITLE
Follow up on Tor/Clearnet testing

### DIFF
--- a/tests/abort2_case2.rs
+++ b/tests/abort2_case2.rs
@@ -2,7 +2,6 @@
 use bitcoin::Amount;
 use coinswap::{
     maker::{start_maker_server, MakerBehavior},
-    market::directory::{start_directory_server, DirectoryServer},
     taker::SwapParams,
     utill::ConnectionType,
 };
@@ -11,7 +10,7 @@ mod test_framework;
 use test_framework::*;
 
 use log::{info, warn};
-use std::{fs::File, io::Read, path::PathBuf, sync::Arc, thread, time::Duration};
+use std::{fs::File, io::Read, path::PathBuf, thread, time::Duration};
 
 /// ABORT 2: Maker Drops Before Setup
 /// This test demonstrates the situation where a Maker prematurely drops connections after doing
@@ -26,14 +25,8 @@ async fn test_abort_case_2_recover_if_no_makers_found() {
 
     // 6102 is naughty. And theres not enough makers.
     let makers_config_map = [
-        (
-            (6102, 19051, ConnectionType::CLEARNET),
-            MakerBehavior::CloseAtReqContractSigsForSender,
-        ),
-        (
-            (16102, 19052, ConnectionType::CLEARNET),
-            MakerBehavior::Normal,
-        ),
+        ((6102, None), MakerBehavior::CloseAtReqContractSigsForSender),
+        ((16102, None), MakerBehavior::Normal),
     ];
 
     warn!(
@@ -45,17 +38,13 @@ async fn test_abort_case_2_recover_if_no_makers_found() {
 
     // Initiate test framework, Makers.
     // Taker has normal behavior.
-    let (test_framework, taker, makers) =
-        TestFramework::init(None, makers_config_map.into(), None).await;
-
-    info!("Initiating Directory Server .....");
-
-    let directory_server_instance =
-        Arc::new(DirectoryServer::new(None, Some(ConnectionType::CLEARNET)).unwrap());
-    let directory_server_instance_clone = directory_server_instance.clone();
-    thread::spawn(move || {
-        start_directory_server(directory_server_instance_clone);
-    });
+    let (test_framework, taker, makers, directory_server_instance) = TestFramework::init(
+        None,
+        makers_config_map.into(),
+        None,
+        ConnectionType::CLEARNET,
+    )
+    .await;
 
     // Fund the Taker and Makers with 3 utxos of 0.05 btc each.
     for _ in 0..3 {

--- a/tests/abort3_case3.rs
+++ b/tests/abort3_case3.rs
@@ -2,7 +2,6 @@
 use bitcoin::Amount;
 use coinswap::{
     maker::{start_maker_server, MakerBehavior},
-    market::directory::{start_directory_server, DirectoryServer},
     taker::SwapParams,
     utill::ConnectionType,
 };
@@ -11,7 +10,7 @@ mod test_framework;
 use test_framework::*;
 
 use log::{info, warn};
-use std::{fs::File, io::Read, path::PathBuf, sync::Arc, thread, time::Duration};
+use std::{fs::File, io::Read, path::PathBuf, thread, time::Duration};
 
 /// ABORT 3: Maker Drops After Setup
 /// Case 3: CloseAtHashPreimage
@@ -25,31 +24,21 @@ async fn abort3_case2_close_at_contract_sigs_for_recvr() {
 
     // 6102 is naughty. And theres not enough makers.
     let makers_config_map = [
-        (
-            (6102, 19051, ConnectionType::CLEARNET),
-            MakerBehavior::CloseAtHashPreimage,
-        ),
-        (
-            (16102, 19052, ConnectionType::CLEARNET),
-            MakerBehavior::Normal,
-        ),
+        ((6102, None), MakerBehavior::CloseAtHashPreimage),
+        ((16102, None), MakerBehavior::Normal),
     ];
 
     // Initiate test framework, Makers.
     // Taker has normal behavior.
-    let (test_framework, taker, makers) =
-        TestFramework::init(None, makers_config_map.into(), None).await;
+    let (test_framework, taker, makers, directory_server_instance) = TestFramework::init(
+        None,
+        makers_config_map.into(),
+        None,
+        ConnectionType::CLEARNET,
+    )
+    .await;
 
     warn!("Running Test: Maker closes conneciton at hash preimage handling");
-
-    info!("Initiating Directory Server .....");
-
-    let directory_server_instance =
-        Arc::new(DirectoryServer::new(None, Some(ConnectionType::CLEARNET)).unwrap());
-    let directory_server_instance_clone = directory_server_instance.clone();
-    thread::spawn(move || {
-        start_directory_server(directory_server_instance_clone);
-    });
 
     info!("Initiating Takers...");
     // Fund the Taker and Makers with 3 utxos of 0.05 btc each.

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -2,7 +2,6 @@
 use bitcoin::{absolute::LockTime, Amount};
 use coinswap::{
     maker::{error::MakerError, start_maker_server, MakerBehavior},
-    market::directory::{start_directory_server, DirectoryServer},
     utill::ConnectionType,
     wallet::{FidelityError, WalletError},
 };
@@ -10,8 +9,7 @@ use coinswap::{
 mod test_framework;
 use test_framework::*;
 
-use log::info;
-use std::{sync::Arc, thread, time::Duration};
+use std::{thread, time::Duration};
 
 /// Test Fidelity Transactions
 ///
@@ -30,22 +28,15 @@ use std::{sync::Arc, thread, time::Duration};
 async fn test_fidelity() {
     // ---- Setup ----
 
-    let makers_config_map = [(
-        (6102, 19051, ConnectionType::CLEARNET),
-        MakerBehavior::Normal,
-    )];
+    let makers_config_map = [((6102, None), MakerBehavior::Normal)];
 
-    let (test_framework, _, makers) =
-        TestFramework::init(None, makers_config_map.into(), None).await;
-
-    info!("Initiating Directory Server .....");
-
-    let directory_server_instance =
-        Arc::new(DirectoryServer::new(None, Some(ConnectionType::CLEARNET)).unwrap());
-    let directory_server_instance_clone = directory_server_instance.clone();
-    thread::spawn(move || {
-        start_directory_server(directory_server_instance_clone);
-    });
+    let (test_framework, _, makers, directory_server_instance) = TestFramework::init(
+        None,
+        makers_config_map.into(),
+        None,
+        ConnectionType::CLEARNET,
+    )
+    .await;
 
     let maker = makers.first().unwrap();
 


### PR DESCRIPTION
This commit adds the following changes:

- initiate directory_server inside TestFramework. We do not need to manually initiate it at every test site.

- Use a global ConnectionType value to set connection type for makers, taker, and directory server.

- Turn the maker socks port optional. Only needed for tor tests.

- Made the standard swap as a tor test to cover for our tor codes.