### PR TITLE
fix: remove `&` to avoid taking double references

### DIFF
--- a/src/protocol/contract.rs
+++ b/src/protocol/contract.rs
@@ -1151,7 +1151,7 @@ mod test {
         tx_input_2.witness.push(sig_1.to_vec());
         tx_input_2
             .witness
-            .push(&mutlisig_2_of_2_redeemscript.to_bytes());
+            .push(mutlisig_2_of_2_redeemscript.to_bytes());
 
         assert_eq!(tx_input_1, tx_input_2);
 
@@ -1173,7 +1173,7 @@ mod test {
         tx_input_2.witness.push(sig_1.to_vec());
         tx_input_2
             .witness
-            .push(&mutlisig_2_of_2_redeemscript.to_bytes());
+            .push(mutlisig_2_of_2_redeemscript.to_bytes());
 
         assert_eq!(tx_input_1, tx_input_2);
     }


### PR DESCRIPTION
As per this https://rust-lang.github.io/rust-clippy/master/index.html#/needless_borrows_for_generic_args 


I was getting this error ->

![Screenshot from 2024-05-26 15-05-43](https://github.com/utxo-teleport/teleport-transactions/assets/133089376/f5cde1a8-b490-43ae-9222-7bfc885e207b)




as `mutlisig_2_of_2_redeemscript` is a reference of `Script` -> thus passing double reference is causing this error.