### PR TITLE
fixes #525: add test to assert fidelity spending

### DIFF
--- a/src/wallet/split_utxos.rs
+++ b/src/wallet/split_utxos.rs
@@ -65,7 +65,7 @@ impl Wallet {
                 let sum: f64 = randomized.iter().sum();
                 let normalized: Vec<u64> = randomized
                     .iter()
-                    .map(|&r| ((total as f64 * r / sum).round() as u64))
+                    .map(|&r| (total as f64 * r / sum).round() as u64)
                     .collect();
 
                 // Fix rounding errors


### PR DESCRIPTION
This pr - 
- Creates a fidelity bond and lets it expire by advancing blockchain height
- Verifies that regular transactions never select expired fidelity bond UTXOs for spending
- Confirms that new fidelity bond creation can properly consume expired fidelity bond UTXOs
