### PR TITLE
Add Tutorials

### DIFF
--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,40 @@
+# Overview
+
+These guides explains how to:
+
+- [Simulating a Regular Swap With 2 Makers and 1 Taker](./simulating-swap.md)
+- [Simulating a Failed Swap and Triggering Recovery](./failed-swap-recovery.md)
+- [Check Fidelity Bond on Blockchain](./verify-fidelity-bond.md)
+- [Maker Selection Process](./maker-selection.md)
+
+## Prerequisites
+
+Before proceeding, ensure you have the following installed and configured:
+
+- **Rust and Cargo**: The Coinswap project is built with Rust. Install `rustup` by following the instructions on [rust-lang.org](https://www.rust-lang.org/tools/install).
+- **Bitcoin Core**: A running `bitcoind` instance configured for `custom signet` is essential. Refer to the [demo setup guide](../demo.md) for detailed instructions on setting up Bitcoin Core for `custom signet`.
+- **Tor**: Installed and configured. Follow the [Tor setup guide](../tor.md) if you haven't already.
+- **Coinswap Binaries v0.1.0**: Ensure `makerd`, `maker-cli`, and `taker` binaries are compiled and available in your `PATH` or you know their location (e.g., `target/release/`). You can build them by cloning the repository and running `cargo build --release`.
+
+## Troubleshooting
+
+- **Version compatibility**: This tutorial is based on Bitcoin Core v29.0 and Coinswap binaries v0.1.0. Command syntax or behavior might differ in other versions.
+
+## See Also
+
+- [Coinswap Market](http://a4ovtjlwiclzy37bjaurcbb6wpl6dtckmlqwrywq7uoajeaz6kth4uyd.onion/): Lists available makers on `custom signet` (accessible via Tor Browser).
+- [Bitcoin Core documentation](https://developer.bitcoin.org/reference/rpc/index.html)
+- [Coinswap Protocol Specification](https://github.com/citadel-tech/Coinswap-Protocol-Specification)
+- [Coinswap Setup](../demo.md)
+- [Bitcoin Core Setup](../bitcoind.md)
+- [Maker Server Guide](../makerd.md)
+- [Maker CLI Reference](../maker-cli.md)
+- [Taker Client Guide](../taker.md)
+
+## Glossary
+
+- **Custom signet**: A custom-configured Bitcoin Signet network used for development and testing.
+- **Fidelity bond**: A security mechanism in CoinSwap where makers lock up a certain amount of Bitcoin to ensure honest behavior.
+- **Maker**: A participant in the CoinSwap protocol who provides liquidity by offering to swap coins.
+- **Taker**: A participant in the CoinSwap protocol who initiates a swap by accepting a maker's offer.
+- **Timelock contract**: A Bitcoin script that locks funds until a specified time or block height, used in CoinSwap for recovery in case of a failed swap.

--- a/docs/tutorials/failed-swap-recovery.md
+++ b/docs/tutorials/failed-swap-recovery.md
@@ -1,0 +1,69 @@
+# Simulating a Failed Swap and Triggering Recovery
+
+After the taker has broadcasted the first funding transaction and is waiting for it to be confirmed, stop any one maker. This action will cause the protocol to fail, and the taker's funds will be locked in a timelocked contract.
+
+### Trigger a Failed Swap
+
+Initiate a new swap, and while the taker is waiting for the funding transaction to be confirmed, stop one of the makers by terminating its process (e.g., using `CTRL+C` in the terminal where `makerd` is running).
+
+```bash
+taker coinswap
+```
+
+Output:
+
+```bash
+...
+2025-09-10T22:00:45.908066166+05:30 INFO coinswap::taker::api - Funding tx Seen in Mempool. Waiting for confirmation for 30 secs
+2025-09-10T22:00:46.747387294+05:30 ERROR coinswap::taker::api - error sending wait-notif to maker 6upcl2ga6icymftil4u62bvx7e7ydljsuysazfvnkpt2yobnpm3ushid.onion:6102 | IO(Custom { kind: Other, error: "general SOCKS server failure" })
+2025-09-10T22:00:47.797797194+05:30 ERROR coinswap::taker::api - error sending wait-notif to maker reale54c4zdorlpjljtpfrv6tin7z26qcdwndn5mfn6l7t7k3l3bn5id.onion:6104 | IO(Custom { kind: Other, error: "general SOCKS server failure" })
+2025-09-10T22:01:17.806521771+05:30 INFO coinswap::taker::api - Tx 8bd64f6ef55abd90ec23230d23491a9495a4dba5ef9822b6a53012006f225317 | Confirmed at 1
+2025-09-10T22:01:17.808207071+05:30 INFO coinswap::wallet::rpc - Initializing wallet sync and save
+2025-09-10T22:01:18.760803371+05:30 INFO coinswap::wallet::rpc - Completed wallet sync and save
+2025-09-10T22:01:19.520647771+05:30 WARN coinswap::taker::api - Banning Maker : 6upcl2ga6icymftil4u62bvx7e7ydljsuysazfvnkpt2yobnpm3ushid.onion:6102
+2025-09-10T22:01:19.520828271+05:30 ERROR coinswap::taker::api - Incoming SwapCoin Generation failed : IO(Custom { kind: Other, error: "general SOCKS server failure" })
+2025-09-10T22:01:19.520860271+05:30 WARN coinswap::taker::api - Starting recovery from existing swap
+...
+2025-09-10T22:01:22.495612868+05:30 INFO coinswap::taker::api - Contract Tx : 90c664878791227b042838b9909832b04e6a50cdd559b120418a51a08263e850, reached confirmation : None, required : 60
+2025-09-10T22:01:22.495757568+05:30 INFO coinswap::taker::api - 1 outgoing contracts detected | 0 timelock txs broadcasted.
+```
+
+### List Locked Funds
+
+If the swap failed, this command will list the funds that are locked in a timelocked contract.
+
+```bash
+taker list-utxo-contract
+{
+  "addr": "bcrt1qkcz7yx64a4ta0rfgazkd0erqyuj6njnzmrfdewkszxg8gr229m2qpyyf8j",
+  "amount": 19700,
+  "confirmations": 0,
+  "utxo_type": "timelock-contract"
+}
+```
+
+### Recover the Funds
+
+Use the `taker recover` command to reclaim the funds from the failed swap. This will create and broadcast a transaction to spend the timelocked UTXO after the timelock has expired.
+
+```bash
+taker recover
+```
+
+Output during recovery:
+
+```bash
+...
+2025-09-10T22:20:25.413471527+05:30 INFO coinswap::taker::api - Contract Tx : 90c664878791227b042838b9909832b04e6a50cdd559b120418a51a08263e850, reached confirmation : Some(68), required : 60
+2025-09-10T22:20:25.413500427+05:30 INFO coinswap::taker::api - Timelock maturity of 60 blocks for Contract Tx is reached : 90c664878791227b042838b9909832b04e6a50cdd559b120418a51a08263e850
+2025-09-10T22:20:25.413507627+05:30 INFO coinswap::taker::api - Broadcasting timelocked tx: 5574ff04651236e13b18c15907517f59037752758ad3ab5421a3870a77f8109f
+2025-09-10T22:20:25.443093327+05:30 INFO coinswap::taker::api - Removed Outgoing Swapcoin from Wallet, Contract Txid: 90c664878791227b042838b9909832b04e6a50cdd559b120418a51a08263e850
+2025-09-10T22:20:25.443226827+05:30 INFO coinswap::wallet::rpc - Initializing wallet sync and save
+2025-09-10T22:20:26.525635127+05:30 INFO coinswap::wallet::rpc - Completed wallet sync and save
+2025-09-10T22:20:26.525776727+05:30 INFO coinswap::taker::api - 1 outgoing contracts detected | 1 timelock txs broadcasted.
+2025-09-10T22:20:26.525805727+05:30 INFO coinswap::taker::api - All outgoing contracts redeemed. Cleared ongoing swap state
+2025-09-10T22:20:26.525828527+05:30 INFO coinswap::taker::api - Recovery completed.
+2025-09-10T22:20:26.525857427+05:30 INFO coinswap::taker::api - Shutting down taker.
+2025-09-10T22:20:26.526175627+05:30 INFO coinswap::taker::api - offerbook data saved to disk.
+2025-09-10T22:20:26.526518127+05:30 INFO coinswap::wallet::api - Wallet data saved to disk.
+```

--- a/docs/tutorials/maker-selection.md
+++ b/docs/tutorials/maker-selection.md
@@ -1,0 +1,24 @@
+# Maker Selection Process
+
+This section outlines how a taker selects makers for a swap and under what conditions a maker is marked as "bad."
+
+## Maker Selection Criteria
+
+The taker selects a maker by filtering the available pool based on the following criteria.
+
+1. **Swap Size Compatibility**: The maker's advertised `min_size` and `max_size` must be compatible with the swap amount.
+2. **Exclusion of Unsuitable Makers**: The taker excludes:
+   - Makers it is currently swapping with.
+   - Makers present in the `bad_makers` list.
+
+### Conditions for Marking a Maker as "Bad"
+
+A maker is added to the `bad_makers` list if they fail to cooperate during the swap protocol. This prevents the taker from selecting them for future swaps.
+
+A maker is marked as "bad" under the following circumstances:
+
+- **Fidelity Proof Verification Failure**: The maker's fidelity bond fails verification.
+- **Failure to Provide Signatures**: The maker does not provide the required signatures for the contract transaction during the swap.
+- **Funding Timeout**: The maker’s funding transaction does not appear in the mempool or get confirmed within the expected time.
+- **Settlement Failure**: The maker is unresponsive or uncooperative during the final settlement phase.
+- **Malicious Behavior**: The maker broadcasts the contract transaction prematurely, which is considered malicious behavior.

--- a/docs/tutorials/simulating-swap.md
+++ b/docs/tutorials/simulating-swap.md
@@ -1,0 +1,313 @@
+# Simulating a Regular Swap With 2 Makers and 1 Taker
+
+## Start Bitcoin Core on Custom Signet
+
+Ensure your `bitcoind` instance is running and configured for `custom signet`. If you followed the [demo setup guide](../demo.md), you can start it as follows:
+
+```bash
+bitcoind
+```
+
+## Makers Setup
+
+Set up two independent maker nodes. Each maker requires its own data directory and unique RPC/network ports to avoid conflicts.
+
+To view all available `makerd` options:
+
+```bash
+makerd --help
+```
+
+For more detailed information, refer to `docs/makerd.md`.
+
+### Maker 1 Setup
+
+1. **Start Maker 1**
+   Start the first maker daemon. You will be prompted to create an encryption passphrase for its wallet, and the logs will display the wallet address.
+
+```bash
+makerd -d .coinswap/maker-one -w maker-one
+OR
+makerd -a user:password -d .coinswap/maker-one -w maker-one -r <127.0.0.1:port>
+```
+
+2. **Configure Maker 1 (optional)**
+   Edit the configuration file to customize the fidelity bond amount and timelock period. Restart makerd to apply the changes.
+
+```bash
+nano $HOME/.coinswap/maker-one/config.toml
+```
+
+3. **Fund Maker 1**
+   Fund the maker's wallet using the address displayed in the console output. The [Custom Signet Faucet](http://s2ncekhezyo2tkwtftti3aiukfpqmxidatjrdqmwie6xnf2dfggyscad.onion/) is accessible via the Tor browser. Ensure you send enough funds to cover the fidelity bond and transaction fees.
+
+Output:
+
+```bash
+2025-08-29T20:16:23.418640097+05:30 INFO coinswap::maker::server - No active Fidelity Bonds found. Creating one.
+...
+2025-08-29T20:16:23.427692286+05:30 INFO coinswap::maker::server - Send at least 0.00050324 BTC to tb1qu385x7dr7fx73ua78ffdyq37vvj7f8fsxd26p8 | If you send extra, that will be added to your wallet balance
+```
+
+> **Note:** In the log examples, `...` indicates omitted log lines to keep the example short.
+
+After sufficient funds are received and confirmed, `makerd` automatically creates the fidelity bond
+
+Output:
+
+```bash
+2025-08-29T20:21:03.558348147+05:30 INFO coinswap::wallet::api - Selected 1 regular UTXOs
+2025-08-29T20:21:03.560301107+05:30 INFO coinswap::wallet::spend - Adding change output with 75564 sats (fee: 354 sats)
+2025-08-29T20:21:03.560913632+05:30 INFO coinswap::wallet::spend - Created Funding tx, txid: d00fba5e115e387ee3872a308a690deb093c211a7a4df04e7c825c04f78b428e | Size: 178 vB | Fee: 354 sats | Feerate: 1.99 sat/vB
+2025-08-29T20:21:03.586657773+05:30 INFO coinswap::wallet::api - Transaction seen in mempool,waiting for confirmation, txid: d00fba5e115e387ee3872a308a690deb093c211a7a4df04e7c825c04f78b428e
+2025-08-29T20:21:03.586726465+05:30 INFO coinswap::wallet::api - Next sync in 10 secs
+2025-08-29T20:21:13.591821200+05:30 INFO coinswap::wallet::api - Transaction seen in mempool,waiting for confirmation, txid: d00fba5e115e387ee3872a308a690deb093c211a7a4df04e7c825c04f78b428e
+```
+
+Wait until the transaction is confirmed. You can monitor its status using the provided `txid` on the [Custom Signet Explorer](http://xlrj7ilheypw67premos73gxlcl7ha77kbhrqys7mydp7jve25olsxyd.onion/) (accessible via Tor).
+After confirmation, the fidelity bond is created.
+
+Output:
+
+```bash
+2025-08-29T21:11:03.602222774+05:30 INFO coinswap::wallet::api - Transaction confirmed at blockheight: 99649, txid : d00fba5e115e387ee3872a308a690deb093c211a7a4df04e7c825c04f78b428e
+2025-08-29T21:11:03.602293774+05:30 INFO coinswap::wallet::rpc - Initializing wallet sync and save
+2025-08-29T21:11:03.772161931+05:30 INFO coinswap::wallet::rpc - Completed wallet sync and save
+2025-08-29T21:11:03.772629331+05:30 INFO coinswap::maker::server - [6102] Successfully created fidelity bond
+...
+2025-08-29T21:11:06.995136026+05:30 INFO coinswap::maker::server - [6102] Server Setup completed!! Use maker-cli to operate the server and the internal wallet.
+2025-08-29T21:11:33.904427980+05:30 INFO coinswap::wallet::fidelity - Fidelity Bond found | Index: 0 | Bond Value : 0.00000029 BTC
+```
+
+4. **Interact with Maker 1**
+   After the fidelity bond is created, you can interact with `makerd` using `maker-cli`.
+
+```bash
+maker-cli get-balances
+{
+  "contract": 0,
+  "fidelity": 50000,
+  "regular": 75564,
+  "spendable": 75564,
+  "swap": 0
+}
+```
+
+### Maker 2 Setup
+
+1. **Configure Maker 2 ports**
+   When running multiple makers on a single system, their default network port (`6102`) and RPC ports (`6104`) will clash. You must update the configuration for Maker 2.
+
+Run Maker 2 once to generate the default config.toml, then exit `makerd` using `CTRL+C`.
+
+```bash
+makerd -a user:password -d .coinswap/maker-two -w maker-two -r <address:port>
+OR
+makerd -d .coinswap/maker-two -w maker-two
+```
+
+Edit the `config.toml` file for Maker 2:
+
+```bash
+nano .coinswap/maker-two/config.toml
+```
+
+Update the following fields:
+
+```bash
+# Maker Configuration File
+# Network port for client connections
+network_port = 6104
+# RPC port for maker-cli operations
+rpc_port = 6105
+```
+
+> **Note:** You can use `ss -tulnp` to check for active ports and avoid conflicts.
+
+2. **Start Maker 2**
+   Start the second maker daemon with its unique data directory and updated ports.
+
+```bash
+makerd -a user:password -d ./coinswap/maker-two -w maker-two -r <address:port>
+OR
+makerd -d ./coinswap/maker-two -w maker-two
+```
+
+3. **Fund and initialize Maker 2**
+   Similar to Maker 1:
+   1. Fund the wallet address displayed in Maker 2's console output using the [Custom Signet Faucet](http://s2ncekhezyo2tkwtftti3aiukfpqmxidatjrdqmwie6xnf2dfggyscad.onion/).
+   2. Wait for transaction confirmations on the `custom signet` blockchain.
+   3. Verify that the fidelity bond is created successfully in the console logs.
+
+```bash
+2025-08-29T22:19:05.861976862+05:30 INFO coinswap::maker::server - [6104] Server Setup completed!! Use maker-cli to operate the server and the internal wallet.
+2025-08-29T22:18:42.112734371+05:30 INFO coinswap::wallet::fidelity - Fidelity Bond found | Index: 0 | Bond Value : 0.00000029
+
+# Verify bond using maker-cli
+$ maker-cli -p 127.0.0.1:6105 get-balances
+{
+  "contract": 0,
+  "fidelity": 50000,
+  "regular": 121342,
+  "spendable": 121342,
+  "swap": 0
+}
+```
+
+Maker 2 is now ready to participate in swaps.
+
+### Set Up and Execute the Taker Swap
+
+#### Set Up Taker
+
+Generate a new funding address. The default taker directory is `$HOME/.coinswap/taker`.
+
+```bash
+ taker get-new-address
+ tb1qdnk0q48guzc3m3js004jdyds94pklq47x6pduy
+```
+
+#### Fund the Taker
+
+Fund the taker's wallet using the address obtained in the previous step. Use the [Custom Signet Faucet](http://s2ncekhezyo2tkwtftti3aiukfpqmxidatjrdqmwie6xnf2dfggyscad.onion/). send enough funds to cover the swap amount and transaction fees.
+
+Verify taker balances after funding:
+
+```bash
+taker get-balances
+```
+
+Output:
+
+```json
+{
+  "contract": 0,
+  "regular": 677071,
+  "spendable": 677071,
+  "swap": 0
+}
+```
+
+#### Fetch Offers
+
+This command fetches offers from available makers in the market and stores them in the offer book (`.coinswap/taker/offerbook.json`).
+
+```bash
+taker fetch-offers
+```
+
+Output:
+
+```bash
+...
+2025-08-30T00:58:08.415899890+05:30 INFO coinswap::taker::api - Found offer from 127.0.0.1:6102. Verifying Fidelity Proof
+2025-08-30T00:58:08.423967990+05:30 INFO coinswap::taker::api - Fidelity Bond verification success. Adding offer to our OfferBook
+2025-08-30T00:58:08.424036190+05:30 INFO coinswap::taker::api - Found offer from 127.0.0.1:6104. Verifying Fidelity Proof
+2025-08-30T00:58:08.426471090+05:30 INFO coinswap::taker::api - Fidelity Bond verification success. Adding offer to our OfferBook
+{
+  "base_fee": 1000,
+  "amount_relative_fee_pct": 2.5,
+  "time_relative_fee_pct": 0.1,
+  "required_confirms": 1,
+  "minimum_locktime": 20,
+  "max_size": 75564,
+  "min_size": 10000,
+  "bond_outpoint": "d00fba5e115e387ee3872a308a690deb093c211a7a4df04e7c825c04f78b428e:0",
+  "bond_value": 28,
+  "bond_expiry": 100595,
+  "tor_address": "127.0.0.1:6102"
+}
+...
+```
+
+#### Execute the Coinswap
+
+Once offers are fetched, you can initiate a coinswap. The `taker coinswap` command allows you to specify the swap amount and the number of makers.
+
+- `-a, --amount [AMOUNT]`: Sets the swap amount in sats (default: `20000` sats).
+- `-m, --makers [MAKERS]`: Sets the maker count to swap with. Swapping with less than 2 makers is not allowed to maintain client privacy. Adding more makers in the swap will incur more swap fees (default: `2`).
+
+```bash
+taker coinswap --amount 20000 --makers 2
+```
+
+Initializing First Hop
+Output:
+
+```bash
+...
+2025-08-30T01:25:11.587410848+05:30 INFO coinswap::taker::api - Found 2 suitable makers for this swap round
+2025-08-30T01:25:11.587481648+05:30 INFO coinswap::taker::api - Initiating coinswap with id : 54fc81645a9808d0
+2025-08-30T01:25:11.587535548+05:30 INFO coinswap::taker::api - Initializing First Hop.
+2025-08-30T01:25:11.587596648+05:30 INFO coinswap::taker::api - Choosing next maker: 127.0.0.1:6102
+2025-08-30T01:25:11.754258549+05:30 INFO coinswap::wallet::api - Address grouping: Selected 2 regular UTXOs (total: 677071 sats, target+fee: 20324 sats)
+2025-08-30T01:25:11.755999849+05:30 INFO coinswap::wallet::spend - Adding change output with 656631 sats (fee: 440 sats)
+...
+2025-08-30T01:25:11.757332049+05:30 INFO coinswap::taker::api - ===> ReqContractSigsForSender | 127.0.0.1:6102
+2025-08-30T01:25:12.418760455+05:30 INFO coinswap::taker::api - <=== RespContractSigsForSender | 127.0.0.1:6102
+2025-08-30T01:25:12.419252155+05:30 INFO coinswap::taker::api - Total Funding Txs Fees: 0.00000440 BTC
+2025-08-30T01:25:12.419278055+05:30 INFO coinswap::taker::api - Transaction size: 220 vB (0.220 kvB)
+2025-08-30T01:25:12.448798755+05:30 INFO coinswap::taker::api - Broadcasted Funding tx. txid: a72091d5eeafe6915b023107416217ccfc2c49402c173192b046327bf10fee85
+2025-08-30T01:25:12.448891655+05:30 INFO coinswap::taker::api - Waiting for funding transaction
+```
+
+Wait for the funding transaction to be confirmed. After confirmation, the taker will proceed with the next hop.
+
+Output:
+
+```bash
+a72091d5eeafe6915b023107416217ccfc2c49402c173192b046327bf10fee85 | Confirmed at 1
+2025-08-30T02:43:30.294218569+05:30 INFO coinswap::taker::api - Connecting to 127.0.0.1:6102 | Send Sigs Init Next Hop
+2025-08-30T02:44:57.745290283+05:30 INFO coinswap::taker::api - ===> ProofOfFunding | 127.0.0.1:6102
+2025-08-30T02:44:57.745333683+05:30 INFO coinswap::taker::api - Fundix Txids: [a72091d5eeafe6915b023107416217ccfc2c49402c173192b046327bf10fee85]
+2025-08-30T02:44:57.988673984+05:30 INFO coinswap::taker::routines - Maker Received = 0.00020000 BTC | Maker is Forwarding = 0.00017260 BTC |  Coinswap Fees = 0.00002300 BTC
+2025-08-30T02:44:57.988719484+05:30 INFO coinswap::taker::api - <=== ReqContractSigsAsRecvrAndSender | 127.0.0.1:6102
+2025-08-30T02:44:58.137767685+05:30 INFO coinswap::taker::api - ===> ReqContractSigsForSender | 127.0.0.1:6104
+2025-08-30T02:44:58.716216190+05:30 INFO coinswap::taker::api - <=== RespContractSigsForSender | 127.0.0.1:6104
+2025-08-30T02:44:58.716350090+05:30 INFO coinswap::taker::api - Taker is previous peer. Signing Receivers Contract Txs
+2025-08-30T02:44:58.716861890+05:30 INFO coinswap::taker::api - ===> RespContractSigsForRecvrAndSender | 127.0.0.1:6102
+2025-08-30T02:44:58.717058190+05:30 INFO coinswap::taker::api - Waiting for funding transaction confirmation. Txids : [b0223aac017dba5480a13f74d19090188637c86cd954c00105199ff1b1cbba47]
+2025-08-30T02:44:58.726610890+05:30 INFO coinswap::taker::api - Waiting for funding tx to appear in mempool | 0 secs
+...
+```
+
+Final hop and sweep completion:
+
+```bash
+...
+2025-08-30T03:19:45.140704175+05:30 INFO coinswap::taker::api - Tx 42607e39c9c4c5f5972595ad2c74164f5dea43e836cdead0b630cd5c7034e2fb | Confirmed at 1
+2025-08-30T03:19:45.144089575+05:30 INFO coinswap::wallet::rpc - Initializing wallet sync and save
+2025-08-30T03:19:45.381942277+05:30 INFO coinswap::wallet::rpc - Completed wallet sync and save
+2025-08-30T03:19:48.536561116+05:30 INFO coinswap::taker::api - ===> ReqContractSigsForRecvr | 127.0.0.1:6104
+2025-08-30T03:24:53.055859144+05:30 WARN coinswap::taker::api - Failed to connect to maker 127.0.0.1:6104 to request signatures for receiver, reattempting, 1 of 10 |  error=Net(IO(Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }))
+2025-08-30T03:24:54.057118208+05:30 INFO coinswap::taker::api - ===> ReqContractSigsForRecvr | 127.0.0.1:6104
+2025-08-30T03:26:58.877750262+05:30 INFO coinswap::taker::api - <=== RespContractSigsForRecvr | 127.0.0.1:6104
+2025-08-30T03:27:01.871558700+05:30 INFO coinswap::taker::api - ===> HashPreimage | 127.0.0.1:6102
+2025-08-30T03:27:01.879753600+05:30 INFO coinswap::taker::api - <=== PrivateKeyHandover | 127.0.0.1:6102
+2025-08-30T03:27:01.880016800+05:30 INFO coinswap::taker::api - ===> PrivateKeyHandover | 127.0.0.1:6102
+2025-08-30T03:27:04.880540039+05:30 INFO coinswap::taker::api - ===> HashPreimage | 127.0.0.1:6104
+2025-08-30T03:27:04.881710439+05:30 INFO coinswap::taker::api - <=== PrivateKeyHandover | 127.0.0.1:6104
+2025-08-30T03:27:04.881915739+05:30 INFO coinswap::taker::api - ===> PrivateKeyHandover | 127.0.0.1:6104
+2025-08-30T03:27:04.882043839+05:30 INFO coinswap::taker::api - Swaps settled successfully. Sweeping the coins and reseting everything.
+...
+2025-08-30T03:27:06.361030450+05:30 INFO coinswap::wallet::api - Transaction seen in mempool,waiting for confirmation, txid: da79d2e415579982de3a93fb612fd0bf34094baa5e707317847cfdd546907f39
+...
+```
+
+Sweep complete:
+
+```bash
+2025-08-30T06:36:03.594637029+05:30 INFO coinswap::wallet::api - Sweep Transaction da79d2e415579982de3a93fb612fd0bf34094baa5e707317847cfdd546907f39 confirmed at blockheight: 99720
+2025-08-30T06:36:03.594651329+05:30 INFO coinswap::wallet::api - Successfully swept incoming swap coin, txid: da79d2e415579982de3a93fb612fd0bf34094baa5e707317847cfdd546907f39
+2025-08-30T06:36:03.594665129+05:30 INFO coinswap::wallet::api - Successfully removed incoming swaps coins
+2025-08-30T06:36:03.594878529+05:30 INFO coinswap::taker::api - Successfully swept 1 incoming swap coins: [da79d2e415579982de3a93fb612fd0bf34094baa5e707317847cfdd546907f39]
+2025-08-30T06:36:03.594933329+05:30 INFO coinswap::taker::api - Successfully Completed Coinswap.
+2025-08-30T06:36:03.594948629+05:30 INFO coinswap::taker::api - Shutting down taker.
+2025-08-30T06:36:03.595819629+05:30 INFO coinswap::taker::api - offerbook data saved to disk.
+2025-08-30T06:36:03.595989629+05:30 INFO coinswap::taker::api - Wallet data saved to disk.
+```
+
+## Troubleshooting
+
+- **RPC connection issues**: If you encounter "connection refused" errors, verify that `bitcoind` is running, the RPC port is correct (e.g., 38332 for `signet`).
+- **Port clashes**: When running multiple `makerd` or `taker` instances on the same machine, ensure each uses unique `network_port` and `rpc_port` values in their respective `config.toml` files. Use `ss -tulnp` to inspect active ports.

--- a/docs/tutorials/verify-fidelity-bond.md
+++ b/docs/tutorials/verify-fidelity-bond.md
@@ -1,0 +1,43 @@
+# How to Check Fidelity Bond on Blockchain
+
+### Maker Fidelity Bond
+
+To view all fidelity bonds (current and previous), use the following command:
+
+```bash
+maker-cli -p 127.0.0.1:6103 show-fidelity
+```
+
+Output:
+
+```bash
+[
+  {
+    "amount": 50000,
+    "bond_value": 890,
+    "index": 0,
+    "outpoint": "1e32a14ff27ac4b036e691c033cd01bf619b87e38c828aa9e2b45c86bc8fdac3:0",
+    "status": "Live"
+  }
+]
+```
+
+The `outpoint` field (e.g., `1e32a14ff27ac4b036e691c033cd01bf619b87e38c828aa9e2b45c86bc8fdac3:0`) represents the transaction output in the Bitcoin blockchain. To verify the fidelity bond:
+
+1. **Using a Block Explorer**: Access a [Custom Signet Explorer](http://xlrj7ilheypw67premos73gxlcl7ha77kbhrqys7mydp7jve25olsxyd.onion/) (via Tor) and enter the transaction ID (TXID) to view details.
+2. **Using `bitcoin-cli`**: Run the following command:
+
+```bash
+bitcoin-cli getrawtransaction <fidelity_bond_txid> true
+```
+
+Replace `<fidelity_bond_txid>` with the actual transaction ID. This command provides detailed transaction information, including confirmation status and locked amounts.
+
+### Taker Fidelity Bond
+
+The taker automatically verifies the maker's fidelity bond when fetching offers. This ensures the maker has a valid and active fidelity bond before proceeding with a swap.
+
+To manually verify the fidelity bond:
+
+1. Check the offer data stored in `.coinswap/taker/offerbook.json` after fetching offers.
+2. Use a [Custom Signet Explorer](http://xlrj7ilheypw67premos73gxlcl7ha77kbhrqys7mydp7jve25olsxyd.onion/) or `bitcoin-cli` (as described above) to verify the bond's transaction ID.


### PR DESCRIPTION
Addresses #551 

### What this PR covers
I've added tutorials for the following:
- Simulating a Regular Swap with 2 Makers and 1 Taker
- Simulating a failed Swap and Triggering Recovery
- How To Check Your Fidelity Bond in the Blockchain
- How Makers are scored in the marketplace

All tutorials are currently in the `docs/tutorial.md` file.  
As an alternative, we could have a `docs/tutorials/` directory with each tutorial in a separate file. Please let me know which structure you’d prefer.

### Not included
- In-depth code walk-through