### PR TITLE
Enabling balance check before running interactive utxo selection 

### DIFF
--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -243,7 +243,7 @@ fn main() -> Result<(), TakerError> {
                         Some(
                             coinswap::utill::interactive_select(
                                 taker.get_wallet().list_all_utxo_spend_info(),
-                                None,
+                                amount,
                             )?
                             .iter()
                             .map(|(utxo, _)| bitcoin::OutPoint::new(utxo.txid, utxo.vout))
@@ -304,7 +304,7 @@ fn main() -> Result<(), TakerError> {
                         Some(
                             coinswap::utill::interactive_select(
                                 taker.get_wallet().list_all_utxo_spend_info(),
-                                Some(target_amount),
+                                target_amount,
                             )?
                             .iter()
                             .map(|(utxo, _)| bitcoin::OutPoint::new(utxo.txid, utxo.vout))

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -853,21 +853,19 @@ where
 /// Interactive Selection by User for Utxos
 pub fn interactive_select(
     mut choices: Vec<(ListUnspentResultEntry, UTXOSpendInfo)>,
-    required_amount: Option<Amount>,
+    required_amount: Amount,
 ) -> Result<Vec<(ListUnspentResultEntry, UTXOSpendInfo)>, WalletError> {
     if choices.is_empty() {
         return Err(WalletError::General("No UTXOs available".to_string()));
     }
 
-    if let Some(target) = required_amount {
-        let total_available: Amount = choices.iter().map(|(utxo, _)| utxo.amount).sum();
-        if total_available < target {
-            return Err(WalletError::General(format!(
-                "Insufficient balance: {} sats available, {} sats required",
-                total_available.to_sat(),
-                target.to_sat()
-            )));
-        }
+    let total_available: Amount = choices.iter().map(|(utxo, _)| utxo.amount).sum();
+    if total_available < required_amount {
+        return Err(WalletError::General(format!(
+            "Insufficient balance: {} sats available, {} sats required",
+            total_available.to_sat(),
+            required_amount.to_sat()
+        )));
     }
 
     choices.sort_by_key(|(_, spend_info)| match spend_info {


### PR DESCRIPTION
resolves #613 
@stark-3k review this and request if any further changes are required !! 
before : 

<img width="1096" height="356" alt="Screenshot 2025-10-07 at 3 14 00 PM" src="https://github.com/user-attachments/assets/0dd7d8cb-3e6a-4114-92c5-1337bf590b4b" />

After : 

<img width="1092" height="309" alt="Screenshot 2025-10-07 at 3 14 22 PM" src="https://github.com/user-attachments/assets/88383c3c-53a8-4eac-aabd-38b706431b99" />
