### PR TITLE
docker: enhance swap type selection and unexpose makerd port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,6 @@ services:
 
         makerd -t "$${TOR_AUTH_PASSWORD}" -r $${BITCOIN_RPC_HOST} -a $${BITCOIN_RPC_AUTH} $${MAKERD_EXTRA_ARGS} -w "$$WALLET_NAME"
     ports:
-      - "${MAKERD_PORT:-6102}:${MAKERD_PORT:-6102}"
       - "${MAKERD_RPC_PORT:-6103}:${MAKERD_RPC_PORT:-6103}"
     volumes:
       - maker-data:/home/coinswap/.coinswap

--- a/docker-setup
+++ b/docker-setup
@@ -465,8 +465,22 @@ configure_setup() {
     read -p "Makerd RPC port [${DEFAULT_MAKERD_RPC_PORT}]: " makerd_rpc
     MAKERD_RPC_PORT="${makerd_rpc:-$DEFAULT_MAKERD_RPC_PORT}"
     
-    read -p "Use Taproot (experimental)? [Y/n]: " use_taproot
-    if [[ "${use_taproot:-Y}" =~ ^[Yy]$ ]]; then
+    echo ""
+    echo "Select Swap Type:"
+    echo ""
+    echo "  1) Taproot (Recommended New Protocol)"
+    echo "     - Contract Tx with [Musig2 + Taproot HTLC]. Cheaper swap fees, more private. "
+    echo ""
+    echo "  2) Legacy (Original Atomic Swap Protocol)"
+    echo "     - Contract Tx with [2of2 Multisig + P2WSH HTLC]. Higher swap fees, less private."
+    echo -e "${YELLOW}NOTE:${NC}"
+    echo -e "${YELLOW}  Currently, a maker can only perform Legacy or Taproot swaps, but cannot perform both.${NC}"
+    echo -e "${YELLOW}  Although it can handle both taproot and legacy transactions for regular wallet operations.${NC}" 
+    echo -e "${YELLOW}  If you wanna serve both types of swap in the market, run two separate makers of each type.${NC}" 
+    echo -e "${YELLOW}  You can use the existing bitcoind Docker sockets for the second maker too to avoid multiple node IBD.${NC}"
+    read -p "Selected Option [1]: " swap_type
+
+    if [[ "${swap_type:-1}" == "1" ]]; then
         USE_TAPROOT="true"
     else
         USE_TAPROOT="false"


### PR DESCRIPTION
Unexpose the network port of makerd inside the docker compose because there's no option change it, so it will prevent to start the stack if there's an existed maker that run on the same port. Also, we don't need to expose it so it doesn't make any difference 