### PR TITLE
[Fix] Coinselect: `can_use_regular` flagged as true even when `target` + `fee` < `balance(regular)`

### DIFF
--- a/tests/utxo_behavior.rs
+++ b/tests/utxo_behavior.rs
@@ -342,12 +342,12 @@ fn test_separated_utxo_coin_selection() {
                 available,
                 required,
             } => {
+                // Available balance being returned here is Swap. Not regular.
+                // In default impl, it loops through Regular -> Swap.
                 println!("✅ Correctly failed with InsufficientFund");
-                println!(
-                    "   Available: {available} sats (regular only), Required: {required} sats"
-                );
+                println!("   Available: {available} sats (swap only), Required: {required} sats");
                 assert_eq!(*required, target_3.to_sat() + 324); // Should include 324 sats estimated fee
-                assert_eq!(*available, balances.regular.to_sat());
+                assert_eq!(*available, balances.swap.to_sat());
                 println!("✅ Confirmed: Only regular balance reported in insufficient funds error");
             }
             _ => panic!(


### PR DESCRIPTION
- Currently, `can_use_regular` only checks against `target`, not adding the `estimated_fee`.
- The coinselection crate also overshoots the fee by some sats, above the { `estimated_fee` + `target` } range.

Now, 
- This gives an edge case where `can_use_regular` can be flagged as true, but coinselect fails due to the overshoot difference(This becomes an issue when the target amount is small). As a fix : 
- Addition of fee during calc of `can_use_x` bool.
- Added a debug log for fee. 
- Loops through swap if regular isn't enough. An important caveat : During manual selection, it instead throws a harderror when either chosen balance type is insufficient and does NOT loop through the other balance type.

Below is a swap with the new behavior : 
<img width="1634" height="352" alt="image" src="https://github.com/user-attachments/assets/522831b3-37a4-4752-b3ee-abbd1d76d007" />
