### PR TITLE
CI test improvements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,14 +8,27 @@ name: test
 
 jobs:
   test_with_codecov:
-    name: Run tests with coverage reporting
+    name: Run tests coverage (Partition ${{ matrix.partition }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1,2,3,4,5,6,7,8,9,10]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{  hashFiles('**/Cargo.toml','**/Cargo.lock') }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -28,14 +41,23 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
+      - name: Setup nextest config
+        run: |
+          mkdir -p .config
+          cat <<'EOF' > .config/nextest.toml
+          [profile.default]
+          global-timeout = "1h"
+          slow-timeout = "3m"
+          EOF
+
       - name: Run cargo-llvm-cov
         run: |
           mkdir -p ./coverage/reports/
-          cargo llvm-cov nextest --lib --bins --tests --fail-fast --features integration-test --no-capture
-          cargo llvm-cov report --cobertura --output-path ./coverage/reports/cobertura.xml
-        
+          cargo llvm-cov nextest --lib --bins --tests --retries 1 --max-fail 2:immediate --partition hash:${{ matrix.partition }}/${{strategy.job-total}} --features integration-test --no-capture
+          cargo llvm-cov report --cobertura --output-path ./coverage/reports/cobertura-${{ strategy.job-index }}.xml
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage/reports/cobertura.xml
+          files: ./coverage/reports/cobertura-${{ strategy.job-index }}.xml

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,3 +1,8 @@
+codecov:
+  notify:
+    after_n_builds: 10
+comment:
+  after_n_builds: 10
 coverage:
   status:
     project:

--- a/src/taker/error.rs
+++ b/src/taker/error.rs
@@ -90,6 +90,12 @@ impl From<std::sync::mpsc::RecvError> for TakerError {
     }
 }
 
+impl From<std::sync::mpsc::RecvTimeoutError> for TakerError {
+    fn from(value: std::sync::mpsc::RecvTimeoutError) -> Self {
+        Self::MPSC(value.to_string())
+    }
+}
+
 impl<T> From<std::sync::mpsc::SendError<T>> for TakerError {
     fn from(value: std::sync::mpsc::SendError<T>) -> Self {
         Self::MPSC(value.to_string())

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -584,8 +584,8 @@ pub(crate) fn fetch_offer_from_makers(
     }
 
     let mut offers = Vec::new();
-    for _ in 0..total {
-        if let Some(offer) = rx.recv()? {
+    for _ in 0..threads.len() {
+        if let Some(offer) = rx.recv_timeout(Duration::from_secs(180))? {
             offers.push(offer);
         }
     }

--- a/tests/abort2_case1.rs
+++ b/tests/abort2_case1.rs
@@ -105,15 +105,6 @@ fn maker_abort2_case1() {
     };
     taker.do_coinswap(swap_params).unwrap();
 
-    // After Swap is done, wait for maker threads to conclude.
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
     info!("🎯 All coinswaps processed successfully. Transaction complete.");
 
     thread::sleep(Duration::from_secs(10));
@@ -335,6 +326,15 @@ fn maker_abort2_case1() {
     );
 
     info!("🎉 All checks successful. Terminating integration test case");
+
+    // After all balance checks are complete, shut down maker threads
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
 
     test_framework.stop();
 

--- a/tests/abort2_case2.rs
+++ b/tests/abort2_case2.rs
@@ -109,15 +109,6 @@ fn maker_abort2_case2() {
 
     taker.do_coinswap(swap_params).unwrap();
 
-    // After Swap is done, wait for maker threads to conclude.
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
     info!("🎯 All coinswaps processed successfully. Transaction complete.");
 
     thread::sleep(Duration::from_secs(10));
@@ -286,6 +277,15 @@ fn maker_abort2_case2() {
     log::info!("✅ Swap results verification complete");
 
     info!("🎉 All checks successful. Terminating integration test case");
+
+    // After all balance checks are complete, shut down maker threads
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
 
     test_framework.stop();
     block_generation_handle.join().unwrap();

--- a/tests/abort3_case3.rs
+++ b/tests/abort3_case3.rs
@@ -107,16 +107,6 @@ fn maker_abort3_case3() {
     info!("Waiting for maker to complete recovery");
     thread::sleep(Duration::from_secs(60));
 
-    // shutdown makers thread
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    //join makers thread
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
     let taker_wallet = taker.get_wallet_mut();
     taker_wallet.sync_and_save().unwrap();
 
@@ -256,6 +246,15 @@ fn maker_abort3_case3() {
     log::info!("✅ Swap results verification complete");
 
     info!("🎉 All checks successful. Terminating integration test case");
+
+    // After all balance checks are complete, shut down maker threads
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
 
     test_framework.stop();
     block_generation_handle.join().unwrap();

--- a/tests/malice1.rs
+++ b/tests/malice1.rs
@@ -104,16 +104,6 @@ fn malice_1() {
     info!("Waiting for maker to complete recovery");
     thread::sleep(Duration::from_secs(60));
 
-    // shutdown makers thread
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    //join makers thread
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
     ///////////////////
     let taker_wallet = taker.get_wallet_mut();
     taker_wallet.sync_and_save().unwrap();
@@ -247,6 +237,15 @@ fn malice_1() {
     log::info!("✅ Swap results verification complete");
 
     info!("🎉 All checks successful. Terminating integration test case");
+
+    // After all balance checks are complete, shut down maker threads
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
 
     test_framework.stop();
     block_generation_handle.join().unwrap();

--- a/tests/standard_swap.rs
+++ b/tests/standard_swap.rs
@@ -93,15 +93,6 @@ fn test_standard_coinswap() {
     };
     taker.do_coinswap(swap_params).unwrap();
 
-    // After Swap is done, wait for maker threads to conclude.
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
     info!("🎯 All coinswaps processed successfully. Transaction complete.");
 
     thread::sleep(Duration::from_secs(10));
@@ -279,6 +270,15 @@ fn test_standard_coinswap() {
     );
 
     info!("🎉 All checks successful. Terminating integration test case");
+
+    // After all balance checks are complete, shut down maker threads
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
 
     test_framework.stop();
     block_generation_handle.join().unwrap();


### PR DESCRIPTION
Fixes #735 
- cache test builds
- retry once if a test fails
- replace fail-fast with a maximum of 3 test failures
- test timeout after 1h
- parallel test execution
- fix offer sync deadlock
- moved-all-makers-shutdown-after-the-checks
