### PR TITLE
moved-all-makers-shutdown-after-the-checks

### DIFF
--- a/tests/abort2_case1.rs
+++ b/tests/abort2_case1.rs
@@ -105,15 +105,6 @@ fn maker_abort2_case1() {
     };
     taker.do_coinswap(swap_params).unwrap();
 
-    // After Swap is done, wait for maker threads to conclude.
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
     info!("🎯 All coinswaps processed successfully. Transaction complete.");
 
     thread::sleep(Duration::from_secs(10));
@@ -335,6 +326,15 @@ fn maker_abort2_case1() {
     );
 
     info!("🎉 All checks successful. Terminating integration test case");
+
+    // After all balance checks are complete, shut down maker threads
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
 
     test_framework.stop();
 

--- a/tests/abort2_case2.rs
+++ b/tests/abort2_case2.rs
@@ -109,15 +109,6 @@ fn maker_abort2_case2() {
 
     taker.do_coinswap(swap_params).unwrap();
 
-    // After Swap is done, wait for maker threads to conclude.
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
     info!("🎯 All coinswaps processed successfully. Transaction complete.");
 
     thread::sleep(Duration::from_secs(10));
@@ -286,6 +277,15 @@ fn maker_abort2_case2() {
     log::info!("✅ Swap results verification complete");
 
     info!("🎉 All checks successful. Terminating integration test case");
+
+    // After all balance checks are complete, shut down maker threads
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
 
     test_framework.stop();
     block_generation_handle.join().unwrap();

--- a/tests/abort3_case3.rs
+++ b/tests/abort3_case3.rs
@@ -107,16 +107,6 @@ fn maker_abort3_case3() {
     info!("Waiting for maker to complete recovery");
     thread::sleep(Duration::from_secs(60));
 
-    // shutdown makers thread
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    //join makers thread
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
     let taker_wallet = taker.get_wallet_mut();
     taker_wallet.sync_and_save().unwrap();
 
@@ -256,6 +246,15 @@ fn maker_abort3_case3() {
     log::info!("✅ Swap results verification complete");
 
     info!("🎉 All checks successful. Terminating integration test case");
+
+    // After all balance checks are complete, shut down maker threads
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
 
     test_framework.stop();
     block_generation_handle.join().unwrap();

--- a/tests/malice1.rs
+++ b/tests/malice1.rs
@@ -104,16 +104,6 @@ fn malice_1() {
     info!("Waiting for maker to complete recovery");
     thread::sleep(Duration::from_secs(60));
 
-    // shutdown makers thread
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    //join makers thread
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
     ///////////////////
     let taker_wallet = taker.get_wallet_mut();
     taker_wallet.sync_and_save().unwrap();
@@ -247,6 +237,15 @@ fn malice_1() {
     log::info!("✅ Swap results verification complete");
 
     info!("🎉 All checks successful. Terminating integration test case");
+
+    // After all balance checks are complete, shut down maker threads
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
 
     test_framework.stop();
     block_generation_handle.join().unwrap();

--- a/tests/standard_swap.rs
+++ b/tests/standard_swap.rs
@@ -93,15 +93,6 @@ fn test_standard_coinswap() {
     };
     taker.do_coinswap(swap_params).unwrap();
 
-    // After Swap is done, wait for maker threads to conclude.
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
     info!("🎯 All coinswaps processed successfully. Transaction complete.");
 
     thread::sleep(Duration::from_secs(10));
@@ -279,6 +270,15 @@ fn test_standard_coinswap() {
     );
 
     info!("🎉 All checks successful. Terminating integration test case");
+
+    // After all balance checks are complete, shut down maker threads
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+
+    maker_threads
+        .into_iter()
+        .for_each(|thread| thread.join().unwrap());
 
     test_framework.stop();
     block_generation_handle.join().unwrap();


### PR DESCRIPTION


## Fixed #731  race condition in legacy integration tests by delaying maker server shutdown until after balance checks.

### Changes

Moved maker server shutdown from immediately after swap completion to the end of tests in:
- `tests/standard_swap.rs`
- `tests/abort2_case1.rs` 
- `tests/abort2_case2.rs`
- `tests/abort3_case3.rs`
- `tests/malice1.rs`

## Problem

Early shutdown before balance verification could cause sporadic failures when coinciding with wallet operations.

## Solution

Makers now remain running during all balance checks, eliminating race conditions. Matches pattern used in taproot tests.