### PR TITLE
test: replace recovery sleeps with log-based assert_log

### DIFF
--- a/tests/taproot_timelock_recovery.rs
+++ b/tests/taproot_timelock_recovery.rs
@@ -161,7 +161,12 @@ fn test_taproot_timelock_recovery_end_to_end() {
     // Wait for maker's automatic recovery to trigger
     // The idle-checker detects dropped connections after 60 seconds (IDLE_CONNECTION_TIMEOUT)
     info!("⏳ Waiting for maker's automatic recovery (65 seconds)...");
-    thread::sleep(Duration::from_secs(65));
+    let log_path = test_framework.temp_dir.join("debug.log");
+    test_framework.assert_log(
+    "timelock recovery completed",
+    log_path.to_str().unwrap(),
+);
+
     // Mine blocks to confirm maker's recovery transactions
     generate_blocks(bitcoind, 10);
 

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -659,22 +659,36 @@ impl TestFramework {
     }
 
     /// Assert that a log message exists in the debug.log file
-    pub fn assert_log(&self, expected_message: &str, log_path: &str) {
-        match std::fs::read_to_string(log_path) {
-            Ok(log_contents) => {
-                assert!(
-                    log_contents.contains(expected_message),
-                    "Expected log message '{}' not found in log file: {}",
-                    expected_message,
-                    log_path
-                );
-                log::info!("✅ Found expected log message: '{expected_message}'");
-            }
-            Err(e) => {
-                panic!("Could not read log file at {}: {}", log_path, e);
-            }
+    /// Wait until a log message appears in the debug.log file (or timeout)
+pub fn assert_log(&self, expected_message: &str, log_path: &str) {
+    use std::time::{Duration, Instant};
+
+    let timeout = Duration::from_secs(120); // generous for slow CI
+    let poll_interval = Duration::from_millis(200);
+    let start = Instant::now();
+
+    loop {
+        let log_contents = std::fs::read_to_string(log_path).unwrap_or_default();
+
+        if log_contents.contains(expected_message) {
+            log::info!("✅ Found expected log message: '{expected_message}'");
+            return;
         }
+
+        if start.elapsed() > timeout {
+            panic!(
+                "❌ Timed out waiting for log message:\n\
+                 '{}'\n\n\
+                 Last log contents:\n{}",
+                expected_message,
+                log_contents
+            );
+        }
+
+        std::thread::sleep(poll_interval);
     }
+}
+
 
     #[allow(clippy::type_complexity)]
     pub fn init_taproot(


### PR DESCRIPTION
### What changed
- Removed arbitrary sleep-based waits in recovery-related integration tests
- Updated `assert_log()` helper to block until the expected log message appears (with timeout)
- Wired recovery tests to wait on actual recovery completion instead of fixed delays

### Why
Tests were relying on hardcoded sleep durations (e.g. 60–65s) to wait for recovery.
This caused:
- redundant wait time
- flaky failures on slow CI runners
- tests progressing mid-recovery

Waiting on log signals makes the tests deterministic and faster.

### Impact
- Reduces random CI failures
- Improves test reliability without changing production logic
- Keeps existing `assert_log` API intact (behavioral improvement only)

Fixes #736
