### PR TITLE
feat: implement display to WalletError

### DIFF
--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -142,7 +142,7 @@ fn handle_request<M: MakerRpc>(maker: &Arc<M>, socket: &mut TcpStream) -> Result
             log::info!("Initializing wallet sync");
             let mut wallet = maker.wallet().write()?;
             if let Err(e) = wallet.sync_and_save() {
-                RpcMsgResp::ServerError(format!("{e:?}"))
+                RpcMsgResp::ServerError(e.to_string())
             } else {
                 log::info!("Completed wallet sync");
                 RpcMsgResp::Pong

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -151,3 +151,77 @@ impl From<bitcoin::taproot::SigFromSliceError> for ProtocolError {
         Self::TaprootSigSlice(value)
     }
 }
+
+impl std::fmt::Display for ProtocolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProtocolError::Secp(e) => write!(f, "Secp256k1 error: {}", e),
+            ProtocolError::Script(e) => write!(f, "Script error: {}", e),
+            ProtocolError::Hash(e) => write!(f, "Hash conversion error: {}", e),
+            ProtocolError::Key(e) => write!(f, "Key conversion error: {}", e),
+            ProtocolError::Sighash(e) => write!(f, "Sighash error: {}", e),
+            ProtocolError::WrongMessage { expected, received } => {
+                write!(
+                    f,
+                    "Wrong message: expected {}, received {}",
+                    expected, received
+                )
+            }
+            ProtocolError::WrongNumOfSigs { expected, received } => {
+                write!(
+                    f,
+                    "Wrong number of signatures: expected {}, received {}",
+                    expected, received
+                )
+            }
+            ProtocolError::WrongNumOfContractTxs { expected, received } => {
+                write!(
+                    f,
+                    "Wrong number of contract txs: expected {}, received {}",
+                    expected, received
+                )
+            }
+            ProtocolError::WrongNumOfPrivkeys { expected, received } => {
+                write!(
+                    f,
+                    "Wrong number of private keys: expected {}, received {}",
+                    expected, received
+                )
+            }
+            ProtocolError::IncorrectFundingAmount { expected, found } => {
+                write!(
+                    f,
+                    "Incorrect funding amount: expected {}, found {}",
+                    expected, found
+                )
+            }
+            ProtocolError::ScriptPubkey(e) => write!(f, "Script pubkey error: {}", e),
+            ProtocolError::ScalarOutOfRange(e) => write!(f, "Scalar out of range: {}", e),
+            ProtocolError::General(msg) => write!(f, "{}", msg),
+            ProtocolError::TaprootSecp(e) => write!(f, "Taproot secp256k1 error: {}", e),
+            ProtocolError::TaprootScript(e) => write!(f, "Taproot script error: {}", e),
+            ProtocolError::TaprootBuilder(e) => write!(f, "Taproot builder error: {:?}", e),
+            ProtocolError::MusigTweak(e) => write!(f, "MuSig tweak error: {}", e),
+            ProtocolError::TaprootSigSlice(e) => write!(f, "Taproot signature slice error: {}", e),
+            ProtocolError::TaprootSighash(e) => write!(f, "Taproot sighash error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for ProtocolError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ProtocolError::Secp(e) => Some(e),
+            ProtocolError::Script(e) => Some(e),
+            ProtocolError::Hash(e) => Some(e),
+            ProtocolError::Key(e) => Some(e),
+            ProtocolError::Sighash(e) => Some(e),
+            ProtocolError::ScriptPubkey(e) => Some(e),
+            ProtocolError::TaprootSecp(e) => Some(e),
+            ProtocolError::TaprootScript(e) => Some(e),
+            ProtocolError::TaprootSigSlice(e) => Some(e),
+            ProtocolError::TaprootSighash(e) => Some(e),
+            _ => None,
+        }
+    }
+}

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -179,3 +179,49 @@ impl From<rust_coinselect::types::SelectionError> for WalletError {
         Self::Selection(value)
     }
 }
+
+impl std::fmt::Display for WalletError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WalletError::IO(e) => write!(f, "I/O error: {}", e),
+            WalletError::Cbor(e) => write!(f, "CBOR error: {}", e),
+            WalletError::Json(e) => write!(f, "JSON error: {}", e),
+            WalletError::Rpc(e) => write!(f, "Bitcoin RPC error: {}", e),
+            WalletError::BIP32(e) => write!(f, "BIP32 error: {}", e),
+            WalletError::BIP39(e) => write!(f, "BIP39 error: {}", e),
+            WalletError::General(msg) => write!(f, "{}", msg),
+            WalletError::Protocol(e) => write!(f, "Protocol error: {}", e),
+            WalletError::Fidelity(e) => write!(f, "Fidelity error: {}", e),
+            WalletError::Locktime(e) => write!(f, "Locktime conversion error: {}", e),
+            WalletError::Secp(e) => write!(f, "Secp256k1 error: {}", e),
+            WalletError::Consensus(msg) => write!(f, "Consensus error: {}", msg),
+            WalletError::InsufficientFund {
+                available,
+                required,
+            } => {
+                write!(
+                    f,
+                    "Insufficient funds: available {} sats, required {} sats",
+                    available, required
+                )
+            }
+            WalletError::Selection(e) => write!(f, "Coin selection error: {:?}", e),
+        }
+    }
+}
+
+impl std::error::Error for WalletError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            WalletError::IO(e) => Some(e),
+            WalletError::Cbor(e) => Some(e),
+            WalletError::Json(e) => Some(e),
+            WalletError::Rpc(e) => Some(e),
+            WalletError::BIP32(e) => Some(e),
+            WalletError::BIP39(e) => Some(e),
+            WalletError::Locktime(e) => Some(e),
+            WalletError::Secp(e) => Some(e),
+            _ => None,
+        }
+    }
+}

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -63,6 +63,28 @@ pub enum FidelityError {
     BondUncomfirmed,
 }
 
+impl std::fmt::Display for FidelityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FidelityError::WrongScriptType => write!(f, "Wrong script type for fidelity bond"),
+            FidelityError::BondDoesNotExist => write!(f, "Fidelity bond does not exist"),
+            FidelityError::BondAlreadyRedeemed => {
+                write!(f, "Fidelity bond has already been redeemed")
+            }
+            FidelityError::BondLocktimeExpired => write!(f, "Fidelity bond locktime has expired"),
+            FidelityError::CertExpired => write!(f, "Fidelity certificate has expired"),
+            FidelityError::InvalidCertHash => write!(f, "Invalid fidelity certificate hash"),
+            FidelityError::InvalidBondLocktime => {
+                write!(f, "Fidelity bond locktime is outside the acceptable range")
+            }
+            FidelityError::BondUncomfirmed => write!(f, "Fidelity bond transaction is unconfirmed"),
+            FidelityError::General(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+impl std::error::Error for FidelityError {}
+
 // ------- Fidelity Helper Scripts -------------
 #[allow(rustdoc::invalid_html_tags)]
 /// Create a Fidelity Timelocked redeemscript.


### PR DESCRIPTION
It's better to implement the `Display` trait for `WalletError` instead of using debug to convert it to a string. I need it in [`maker-dashboard`](https://github.com/citadel-tech/maker-dashboard)