### PR TITLE
Optimize Claude Code Review workflow for precision and budget

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,21 @@ name: Claude Code Review
 on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    # Only run on these specific file changes
+    paths:
+      - "src/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "docker/**"
+      - "docs/**"
+      - ".github/**"
+      - "git_hooks/**"
+
+# Cancel in-flight reviews when a new push arrives on the same PR,
+# so only the latest commit gets reviewed. Saves budget on rapid pushes.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
@@ -31,31 +40,30 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
+      #TODO: With fetch-depth: 1, `github.event.pull_request.base.sha` won't be available. Find a fix.
+      # - name: Check PR size
+      #   id: pr_size
+      #   run: |
+      #     CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | wc -l)
+      #     TOTAL_CHANGES=$(git diff --stat ${{ github.event.pull_request.base.sha }} HEAD | tail -1 | awk '{print $4+$6}')
+          
+      #     echo "Changed files: $CHANGED_FILES"
+      #     echo "Total changes: $TOTAL_CHANGES lines"
+          
+      #     if [ $CHANGED_FILES -gt 30 ] || [ $TOTAL_CHANGES -gt 2000 ]; then
+      #       echo "skip=true" >> $GITHUB_OUTPUT
+      #     fi
 
-      - name: Check PR size
-        id: pr_size
-        run: |
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | wc -l)
-          TOTAL_CHANGES=$(git diff --stat ${{ github.event.pull_request.base.sha }} HEAD | tail -1 | awk '{print $4+$6}')
+      # - name: Check for code changes
+      #   id: has_code
+      #   run: |
+      #     CHANGED_CODE=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | grep -E '\.(rs|toml)$' | wc -l)
           
-          echo "Changed files: $CHANGED_FILES"
-          echo "Total changes: $TOTAL_CHANGES lines"
-          
-          if [ $CHANGED_FILES -gt 50 ] || [ $TOTAL_CHANGES -gt 2000 ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Check for code changes
-        id: has_code
-        run: |
-          CHANGED_CODE=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | grep -E '\.(rs|toml)$' | wc -l)
-          
-          if [ $CHANGED_CODE -eq 0 ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          fi
+      #     if [ $CHANGED_CODE -eq 0 ]; then
+      #       echo "skip=true" >> $GITHUB_OUTPUT
+      #     fi
 
       - name: Run Claude Code Review
-        if: steps.pr_size.outputs.skip != 'true' && steps.has_code.outputs.skip != 'true'
         id: claude-review
         timeout-minutes: 5
         uses: anthropics/claude-code-action@v1
@@ -71,32 +79,30 @@ jobs:
           include_fix_links: false
           use_sticky_comment: true
           prompt: |
-            Review ONLY the changed files in these directories:
-            - src/
-            - Cargo.toml
-            - docker/
-            - .github/
-            
-            Focus ONLY on:
-            - Security vulnerabilities
-            - Type errors and safety issues
-            - Performance problems
-            
-            Ignore: style, formatting, comments, documentation, variable naming.
-            
-            Format response as bullet points. Keep response under 150 words.
-            
-            PR: ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review the changed files with the following focus:
+
+            1. **Security** - Potential vulnerabilities, input validation, auth logic
+            2. **Correctness** - Type errors, safety issues, error handling, edge cases
+            3. **Performance** - Bottlenecks, resource leaks, inefficient patterns
+            4. **Documentation** - Accuracy of docs/, README, and inline code comments; flag outdated or misleading information
+
+            Ignore: style, formatting, variable naming.
+
+            Provide inline comments for specific issues. Keep feedback concise.
           claude_args: |
             --model haiku
-            --add-dir src/
-            --add-dir docker/
-            --add-dir .github/
             --disable-slash-commands
-            --append-system-prompt "Review ONLY src/, docker/, .github/, Cargo.toml. Focus: security vulnerabilities, type errors, performance problems. Ignore: style, formatting, documentation. Be concise and brief."
-            --max-turns 3
+            --append-system-prompt "
+              Review ONLY src/, docker/, docs/, .github/, git_hooks/, Cargo.toml, Cargo.lock.
+              Be concise and brief.
+            "
+            --max-turns 6
             --max-budget-usd 0.50
             --tools Read,Grep,Glob
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
- Add path filters to only trigger on meaningful file changes
- Add concurrency group to cancel stale in-flight reviews
- Disable broken PR size/code-change checks (fetch-depth:1 incompatible)
- Expand review scope to include docs and git_hooks
- Grant inline comment and gh CLI tools for richer feedback
- Bump max-turns to 6 for deeper reviews