### PR TITLE
Fix nostr fidelity outpoint rebroadcast logic and harden review workflow checkout

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,6 +45,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 20
+          persist-credentials: false
       
       #TODO: With fetch-depth: 1, `github.event.pull_request.base.sha` won't be available. Find a fix.
       # - name: Check PR size

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -107,6 +107,7 @@ fn spawn_nostr_broadcast_task(maker: Arc<Maker>) -> Result<(), MakerError> {
             // Force a first broadcast right after spawn.
             let mut elapsed = interval;
             let mut last_broadcasted_outpoint = None;
+            let mut last_attempted_outpoint = None;
 
             while !maker_clone.shutdown.load(Ordering::Acquire) {
                 let latest_fidelity = match maker_clone.highest_fidelity_proof.read() {
@@ -119,7 +120,7 @@ fn spawn_nostr_broadcast_task(maker: Arc<Maker>) -> Result<(), MakerError> {
 
                 if let Some(fidelity) = latest_fidelity {
                     let latest_outpoint = fidelity.bond.outpoint;
-                    let outpoint_changed = last_broadcasted_outpoint
+                    let outpoint_changed = last_attempted_outpoint
                         .map(|prev| prev != latest_outpoint)
                         .unwrap_or(true);
                     let periodic_reping_due = elapsed >= interval;
@@ -136,7 +137,8 @@ fn spawn_nostr_broadcast_task(maker: Arc<Maker>) -> Result<(), MakerError> {
                             log::debug!("re-pinging nostr relays with bond announcement");
                         }
 
-                        match broadcast_bond_on_nostr(fidelity) {
+                        last_attempted_outpoint = Some(latest_outpoint);
+                        match broadcast_bond_on_nostr(fidelity, maker_clone.config.socks_port) {
                             Ok(()) => {
                                 last_broadcasted_outpoint = Some(latest_outpoint);
                             }

--- a/src/nostr_coinswap.rs
+++ b/src/nostr_coinswap.rs
@@ -14,7 +14,13 @@ use nostr::{
     types::Timestamp,
     util::JsonUtil,
 };
+#[cfg(not(feature = "integration-test"))]
+use socks::Socks5Stream;
 use tungstenite::Message;
+#[cfg(not(feature = "integration-test"))]
+use tungstenite::client_tls;
+#[cfg(not(feature = "integration-test"))]
+use tungstenite::http::Uri;
 
 use crate::{maker::MakerError, protocol::messages::FidelityProof};
 
@@ -31,7 +37,7 @@ pub const COINSWAP_KIND: u16 = 37777;
 const EXPIRATION_SECS: u64 = 86400;
 
 /// Broadcasts a fidelity bond announcement over Nostr.
-pub fn broadcast_bond_on_nostr(fidelity: FidelityProof) -> Result<(), MakerError> {
+pub fn broadcast_bond_on_nostr(fidelity: FidelityProof, socks_port: u16) -> Result<(), MakerError> {
     let outpoint = fidelity.bond.outpoint;
     let content = format!("{}:{}", outpoint.txid, outpoint.vout);
 
@@ -66,7 +72,7 @@ pub fn broadcast_bond_on_nostr(fidelity: FidelityProof) -> Result<(), MakerError
 
     for relay in NOSTR_RELAYS {
         for attempt in 1..=MAX_RETRIES {
-            match broadcast_to_relay(relay, &msg) {
+            match broadcast_to_relay(relay, &msg, socks_port) {
                 Ok(()) => {
                     success = true;
                     break;
@@ -90,13 +96,50 @@ pub fn broadcast_bond_on_nostr(fidelity: FidelityProof) -> Result<(), MakerError
 
     if !success {
         log::warn!("nostr event was not accepted by any relay");
+        return Err(MakerError::General(
+            "nostr event was not accepted by any relay",
+        ));
     }
 
     Ok(())
 }
 
+#[cfg(not(feature = "integration-test"))]
+fn parse_relay_endpoint(relay: &str) -> Result<(String, u16), MakerError> {
+    let uri: Uri = relay.parse().map_err(|e| {
+        log::warn!("invalid nostr relay url {}: {}", relay, e);
+        MakerError::General("invalid nostr relay url")
+    })?;
+
+    let scheme = uri.scheme_str().ok_or_else(|| {
+        log::warn!("missing scheme in nostr relay url {}", relay);
+        MakerError::General("invalid nostr relay url")
+    })?;
+
+    if scheme != "ws" && scheme != "wss" {
+        log::warn!("unsupported nostr relay scheme {} in {}", scheme, relay);
+        return Err(MakerError::General("invalid nostr relay url"));
+    }
+
+    let host = uri.host().ok_or_else(|| {
+        log::warn!("missing host in nostr relay url {}", relay);
+        MakerError::General("invalid nostr relay url")
+    })?;
+
+    let port = uri
+        .port_u16()
+        .unwrap_or_else(|| if scheme == "wss" { 443 } else { 80 });
+
+    Ok((host.to_string(), port))
+}
+
 /// Sends a Nostr event to a single relay and waits for confirmation.
-fn broadcast_to_relay(relay: &str, msg: &ClientMessage) -> Result<(), MakerError> {
+#[cfg(feature = "integration-test")]
+fn broadcast_to_relay(
+    relay: &str,
+    msg: &ClientMessage,
+    _socks_port: u16,
+) -> Result<(), MakerError> {
     let (mut socket, _) = tungstenite::connect(relay).map_err(|e| {
         log::warn!("failed to connect to nostr relay {}: {}", relay, e);
         MakerError::General("failed to connect to nostr relay")
@@ -145,4 +188,109 @@ fn broadcast_to_relay(relay: &str, msg: &ClientMessage) -> Result<(), MakerError
     }
     log::warn!("nostr relay {} did not confirm event", relay);
     Err(MakerError::General("nostr relay did not confirm event"))
+}
+
+/// Sends a Nostr event to a single relay and waits for confirmation.
+#[cfg(not(feature = "integration-test"))]
+fn broadcast_to_relay(relay: &str, msg: &ClientMessage, socks_port: u16) -> Result<(), MakerError> {
+    let (mut socket, _) = {
+        let (host, port) = parse_relay_endpoint(relay)?;
+        let proxy_addr = format!("127.0.0.1:{socks_port}");
+
+        let stream = Socks5Stream::connect(proxy_addr.as_str(), (host.as_str(), port)).map_err(
+            |e| {
+                log::warn!(
+                    "failed to connect to nostr relay {} through tor socks {}: {}",
+                    relay,
+                    proxy_addr,
+                    e
+                );
+                MakerError::General("failed to connect to nostr relay via tor proxy")
+            },
+        )?;
+
+        // Use TLS for wss:// and plain websocket for ws:// on top of the already-proxied stream.
+        client_tls(relay, stream).map_err(|e| {
+            log::warn!(
+                "failed websocket handshake with nostr relay {} over tor proxy: {}",
+                relay,
+                e
+            );
+            MakerError::General("failed to complete nostr websocket handshake")
+        })?
+    };
+
+    socket
+        .write(Message::Text(msg.as_json().into()))
+        .map_err(|e| {
+            log::warn!("nostr relay write failed: {}", e);
+            MakerError::General("failed to write to nostr relay")
+        })?;
+    socket.flush().ok();
+
+    match socket.read() {
+        Ok(Message::Text(text)) => {
+            if let Ok(relay_msg) = RelayMessage::from_json(&text) {
+                match relay_msg {
+                    RelayMessage::Ok {
+                        event_id,
+                        status: true,
+                        ..
+                    } => {
+                        log::info!("nostr relay {} accepted event {}", relay, event_id);
+                        return Ok(());
+                    }
+                    RelayMessage::Ok {
+                        event_id,
+                        status: false,
+                        message,
+                    } => {
+                        log::warn!(
+                            "nostr relay {} rejected event {}: {}",
+                            relay,
+                            event_id,
+                            message
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(_) => {}
+        Err(e) => {
+            log::warn!("nostr relay {} read error: {}", relay, e);
+        }
+    }
+    log::warn!("nostr relay {} did not confirm event", relay);
+    Err(MakerError::General("nostr relay did not confirm event"))
+}
+
+#[cfg(all(test, not(feature = "integration-test")))]
+mod tests {
+    use super::parse_relay_endpoint;
+
+    #[test]
+    fn test_parse_relay_endpoint_defaults_ports() {
+        let (host_ws, port_ws) = parse_relay_endpoint("ws://relay.example").unwrap();
+        assert_eq!(host_ws, "relay.example");
+        assert_eq!(port_ws, 80);
+
+        let (host_wss, port_wss) = parse_relay_endpoint("wss://relay.example").unwrap();
+        assert_eq!(host_wss, "relay.example");
+        assert_eq!(port_wss, 443);
+    }
+
+    #[test]
+    fn test_parse_relay_endpoint_explicit_port() {
+        let (host, port) = parse_relay_endpoint("wss://relay.example:8443").unwrap();
+        assert_eq!(host, "relay.example");
+        assert_eq!(port, 8443);
+    }
+
+    #[test]
+    fn test_parse_relay_endpoint_rejects_invalid_input() {
+        assert!(parse_relay_endpoint("relay.example").is_err());
+        assert!(parse_relay_endpoint("http://relay.example").is_err());
+        assert!(parse_relay_endpoint("wss:///missing-host").is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- Fix maker nostr broadcast loops in src/maker/server.rs and src/maker/server2.rs to compare against last_attempted_outpoint so failed sends are treated as recently attempted and do not retry every tick
- Keep periodic re-ping behavior unchanged via existing elapsed >= interval flow
- Update .github/workflows/claude-code-review.yml checkout step to set persist-credentials: false
- Return an error from broadcast_bond_on_nostr when no relay accepts the event so caller success reflects actual relay acceptance

## Why
- Prevent stale or failed outpoint retries every tick
- Ensure updated fidelity outpoints are broadcast when proof changes
- Reduce token exposure risk in pull_request_target checkout
- Avoid false-positive broadcast success when all relays reject or fail

## Validation
- cargo check -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Tor proxy support for Nostr relay broadcasting, enhancing privacy for fidelity bond announcements.

* **Improvements**
  * Enhanced fidelity bond announcement reliability with improved outpoint change detection and periodic broadcast handling.
  * Refined broadcast timing logic to ensure consistent interval calculations across monitoring systems.

* **Chores**
  * Optimized CI/CD workflow for improved pull request checkout efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->