### PR TITLE
refactor(test-framework): unify stop and drop

### DIFF
--- a/tests/abort1.rs
+++ b/tests/abort1.rs
@@ -35,7 +35,7 @@ fn taker_abort1() {
 
     // Initiate test framework, Makers.
     // Taker has a special behavior DropConnectionAfterFullSetup.
-    let (test_framework, mut takers, makers, block_generation_handle) =
+    let (test_framework, mut takers, makers) =
         TestFramework::init(makers_config_map.into(), taker_behavior);
 
     warn!("🧪 Running Test: Taker cheats on everybody");
@@ -248,8 +248,4 @@ fn taker_abort1() {
     log::info!("✅ Swap results verification complete");
 
     info!("🎉 All checks successful. Terminating integration test case");
-
-    test_framework.stop();
-
-    block_generation_handle.join().unwrap();
 }

--- a/tests/abort2_case1.rs
+++ b/tests/abort2_case1.rs
@@ -39,7 +39,7 @@ fn maker_abort2_case1() {
 
     // Initiate test framework, Makers.
     // Taker has normal behavior.
-    let (test_framework, mut takers, makers, block_generation_handle) =
+    let (test_framework, mut takers, makers) =
         TestFramework::init(makers_config_map.into(), taker_behavior);
 
     warn!(
@@ -71,6 +71,8 @@ fn maker_abort2_case1() {
             })
         })
         .collect::<Vec<_>>();
+
+    test_framework.register_maker_threads(maker_threads);
 
     // Makers take time to fully setup.
     let org_maker_spend_balances = makers
@@ -324,17 +326,4 @@ fn maker_abort2_case1() {
     );
 
     info!("🎉 All checks successful. Terminating integration test case");
-
-    // After all balance checks are complete, shut down maker threads
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-
-    block_generation_handle.join().unwrap();
 }

--- a/tests/abort2_case2.rs
+++ b/tests/abort2_case2.rs
@@ -40,7 +40,7 @@ fn maker_abort2_case2() {
 
     // Initiate test framework, Makers.
     // Taker has normal behavior.
-    let (test_framework, mut takers, makers, block_generation_handle) =
+    let (test_framework, mut takers, makers) =
         TestFramework::init(makers_config_map.into(), taker_behavior);
 
     info!("💰 Funding taker and makers");
@@ -74,6 +74,8 @@ fn maker_abort2_case2() {
             })
         })
         .collect::<Vec<_>>();
+
+    test_framework.register_maker_threads(maker_threads);
 
     // Makers take time to fully setup.
     let org_maker_spend_balances = makers
@@ -275,16 +277,4 @@ fn maker_abort2_case2() {
     log::info!("✅ Swap results verification complete");
 
     info!("🎉 All checks successful. Terminating integration test case");
-
-    // After all balance checks are complete, shut down maker threads
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/abort2_case3.rs
+++ b/tests/abort2_case3.rs
@@ -31,7 +31,7 @@ fn maker_abort2_case3() {
     let taker_behavior = vec![TakerBehavior::Normal];
     // Initiate test framework, Makers.
     // Taker has normal behavior.
-    let (test_framework, mut takers, makers, block_generation_handle) =
+    let (test_framework, mut takers, makers) =
         TestFramework::init(makers_config_map.into(), taker_behavior);
 
     warn!(
@@ -69,6 +69,8 @@ fn maker_abort2_case3() {
             })
         })
         .collect::<Vec<_>>();
+
+    test_framework.register_maker_threads(maker_threads);
 
     // Makers take time to fully setup.
     let org_maker_spend_balances = makers
@@ -290,15 +292,4 @@ fn maker_abort2_case3() {
     log::info!("✅ Swap results verification complete");
 
     info!("🎉 All checks successful. Terminating integration test case");
-    // shutdown makers.
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/abort3_case1.rs
+++ b/tests/abort3_case1.rs
@@ -37,7 +37,7 @@ fn maker_abort3_case1() {
     let taker_behavior = vec![TakerBehavior::Normal];
     // Initiate test framework, Makers.
     // Taker has normal behavior.
-    let (test_framework, mut takers, makers, block_generation_handle) =
+    let (test_framework, mut takers, makers) =
         TestFramework::init(makers_config_map.into(), taker_behavior);
 
     warn!(
@@ -75,6 +75,8 @@ fn maker_abort3_case1() {
             })
         })
         .collect::<Vec<_>>();
+
+    test_framework.register_maker_threads(maker_threads);
 
     // Makers take time to fully setup.
     let org_maker_spend_balances = makers
@@ -299,15 +301,4 @@ fn maker_abort3_case1() {
     log::info!("✅ Swap results verification complete");
 
     info!("🎉 All checks successful. Terminating integration test case");
-    // Shutdown makers.
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/abort3_case2.rs
+++ b/tests/abort3_case2.rs
@@ -32,7 +32,7 @@ fn maker_abort3_case2() {
     let taker_behavior = vec![TakerBehavior::Normal];
     // Initiate test framework, Makers.
     // Taker has normal behavior.
-    let (test_framework, mut takers, makers, block_generation_handle) =
+    let (test_framework, mut takers, makers) =
         TestFramework::init(makers_config_map.into(), taker_behavior);
 
     warn!("🧪 Running Test: Maker closes connection after sending a ContractSigsForRecvr");
@@ -68,6 +68,8 @@ fn maker_abort3_case2() {
             })
         })
         .collect::<Vec<_>>();
+
+    test_framework.register_maker_threads(maker_threads);
 
     // Makers take time to fully setup.
     let org_maker_spend_balances = makers
@@ -277,15 +279,4 @@ fn maker_abort3_case2() {
         });
     log::info!("✅ Swap results verification complete");
     info!("🎉 All checks successful. Terminating integration test case");
-    // shutdown makers
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/abort3_case3.rs
+++ b/tests/abort3_case3.rs
@@ -31,7 +31,7 @@ fn maker_abort3_case3() {
     let taker_behavior = vec![TakerBehavior::Normal];
     // Initiate test framework, Makers.
     // Taker has normal behavior.
-    let (test_framework, mut takers, makers, block_generation_handle) =
+    let (test_framework, mut takers, makers) =
         TestFramework::init(makers_config_map.into(), taker_behavior);
 
     warn!("🧪 Running Test: Maker closes connection at hash preimage handling");
@@ -67,6 +67,8 @@ fn maker_abort3_case3() {
             })
         })
         .collect::<Vec<_>>();
+
+    test_framework.register_maker_threads(maker_threads);
 
     // Makers take time to fully setup.
     let org_maker_spend_balances = makers
@@ -247,16 +249,4 @@ fn maker_abort3_case3() {
     log::info!("✅ Swap results verification complete");
 
     info!("🎉 All checks successful. Terminating integration test case");
-
-    // After all balance checks are complete, shut down maker threads
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/fidelity.rs
+++ b/tests/fidelity.rs
@@ -38,8 +38,7 @@ fn test_fidelity() {
     let makers_config_map = [((6102, None), MakerBehavior::Normal)];
     let taker_behavior = vec![TakerBehavior::Normal];
 
-    let (test_framework, _, makers, block_generation_handle) =
-        TestFramework::init(makers_config_map.into(), taker_behavior);
+    let (test_framework, _, makers) = TestFramework::init(makers_config_map.into(), taker_behavior);
 
     log::info!("🧪 Running Test: Fidelity Bond Creation and Redemption");
 
@@ -240,9 +239,6 @@ fn test_fidelity() {
 
     thread::sleep(Duration::from_secs(10));
 
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
-
     log::info!("🎉 Fidelity bond lifecycle test completed successfully");
 }
 
@@ -260,8 +256,7 @@ fn test_fidelity_spending() {
     let makers_config_map = [((6102, None), MakerBehavior::Normal)];
     let taker_behavior = vec![TakerBehavior::Normal];
 
-    let (test_framework, _, makers, block_generation_handle) =
-        TestFramework::init(makers_config_map.into(), taker_behavior);
+    let (test_framework, _, makers) = TestFramework::init(makers_config_map.into(), taker_behavior);
 
     log::info!("🧪 Running Test: Assert Fidelity Spending Behavior");
 
@@ -484,6 +479,4 @@ fn test_fidelity_spending() {
     }
 
     log::info!("🎉 SUCCESS: All requirements from issue #525 verified!");
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/fidelity_renewal.rs
+++ b/tests/fidelity_renewal.rs
@@ -23,8 +23,7 @@ fn test_fidelity_auto_renewal_legacy() {
     let makers_config_map = [((6102, None), MakerBehavior::Normal)];
     let taker_behavior = vec![TakerBehavior::Normal];
 
-    let (test_framework, _, makers, block_generation_handle) =
-        TestFramework::init(makers_config_map.into(), taker_behavior);
+    let (test_framework, _, makers) = TestFramework::init(makers_config_map.into(), taker_behavior);
 
     log::info!("Running Test: Fidelity Bond Auto-Renewal (Legacy/P2WSH)");
 
@@ -40,7 +39,11 @@ fn test_fidelity_auto_renewal_legacy() {
 
     // Start the maker server
     let maker_clone = maker.clone();
-    let maker_thread = thread::spawn(move || start_maker_server(maker_clone));
+    let maker_thread = thread::spawn(move || {
+        let _ = start_maker_server(maker_clone);
+    });
+
+    test_framework.register_maker_threads(vec![maker_thread]);
 
     // Wait for setup to complete
     while !maker.is_setup_complete.load(Relaxed) {
@@ -166,12 +169,6 @@ fn test_fidelity_auto_renewal_legacy() {
     );
     test_framework.assert_log("Successfully created fidelity bond", log_path);
 
-    // Shutdown
-    maker.shutdown.store(true, Relaxed);
-    let _ = maker_thread.join();
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
-
     log::info!("Fidelity bond auto-renewal test (legacy) completed successfully");
 }
 
@@ -184,7 +181,7 @@ fn test_fidelity_auto_renewal_taproot() {
     let taproot_makers_config_map = vec![(7102, Some(19061), TaprootMakerBehavior::Normal)];
     let taker_behavior = vec![coinswap::taker::api2::TakerBehavior::Normal];
 
-    let (test_framework, _, taproot_makers, block_generation_handle) =
+    let (test_framework, _, taproot_makers) =
         TestFramework::init_taproot(taproot_makers_config_map, taker_behavior);
 
     let bitcoind = &test_framework.bitcoind;
@@ -200,7 +197,11 @@ fn test_fidelity_auto_renewal_taproot() {
 
     // Start the maker server
     let maker_clone = maker.clone();
-    let maker_thread = thread::spawn(move || start_maker_server_taproot(maker_clone));
+    let maker_thread = thread::spawn(move || {
+        let _ = start_maker_server_taproot(maker_clone);
+    });
+
+    test_framework.register_maker_threads(vec![maker_thread]);
 
     // Wait for setup to complete
     while !maker.is_setup_complete.load(Relaxed) {
@@ -325,12 +326,6 @@ fn test_fidelity_auto_renewal_taproot() {
         log_path,
     );
     test_framework.assert_log("Successfully created fidelity bond", log_path);
-
-    // shutdown
-    maker.shutdown.store(true, Relaxed);
-    let _ = maker_thread.join();
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 
     log::info!("Fidelity bond auto-renewal test (taproot) completed successfully");
 }

--- a/tests/funding_dynamic_splits.rs
+++ b/tests/funding_dynamic_splits.rs
@@ -46,8 +46,7 @@ fn test_create_funding_txn_with_varied_distributions() {
     );
 
     // Initialize the test framework with a single taker with Normal behavior
-    let (test_framework, mut takers, _, _) =
-        TestFramework::init(vec![], vec![TakerBehavior::Normal]);
+    let (test_framework, mut takers, _) = TestFramework::init(vec![], vec![TakerBehavior::Normal]);
 
     let bitcoind = &test_framework.bitcoind;
     let taker = &mut takers[0];
@@ -147,6 +146,6 @@ fn test_create_funding_txn_with_varied_distributions() {
             MIN_FEE_RATE
         );
     }
-    test_framework.stop();
+
     println!("\nTest completed successfully.");
 }

--- a/tests/malice1.rs
+++ b/tests/malice1.rs
@@ -28,7 +28,7 @@ fn malice_1() {
     let taker_behavior = vec![TakerBehavior::BroadcastContractAfterFullSetup];
     // Initiate test framework, Makers.
     // Taker has normal behavior.
-    let (test_framework, mut takers, makers, block_generation_handle) =
+    let (test_framework, mut takers, makers) =
         TestFramework::init(makers_config_map.into(), taker_behavior);
 
     warn!("🧪 Running Test: Malice 1 - Taker broadcasts contract transaction prematurely");
@@ -64,6 +64,8 @@ fn malice_1() {
             })
         })
         .collect::<Vec<_>>();
+
+    test_framework.register_maker_threads(maker_threads);
 
     // Makers take time to fully setup.
     let org_maker_spend_balances = makers
@@ -245,16 +247,4 @@ fn malice_1() {
     log::info!("✅ Swap results verification complete");
 
     info!("🎉 All checks successful. Terminating integration test case");
-
-    // After all balance checks are complete, shut down maker threads
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/malice2.rs
+++ b/tests/malice2.rs
@@ -30,7 +30,7 @@ fn malice_2() {
     let taker_behavior = vec![TakerBehavior::Normal];
     // Initiate test framework, Makers.
     // Taker has normal behavior.
-    let (test_framework, mut takers, makers, block_generation_handle) =
+    let (test_framework, mut takers, makers) =
         TestFramework::init(makers_config_map.into(), taker_behavior);
 
     warn!("🧪 Running Test: Malice 2 - Maker broadcasts contract transactions prematurely");
@@ -66,6 +66,8 @@ fn malice_2() {
             })
         })
         .collect::<Vec<_>>();
+
+    test_framework.register_maker_threads(maker_threads);
 
     // Makers take time to fully setup.
     let org_maker_spend_balances = makers
@@ -252,16 +254,4 @@ fn malice_2() {
     log::info!("✅ Swap results verification complete");
 
     info!("🎉 All checks successful. Terminating integration test case");
-
-    //Shutdown Makers.
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/multi-taker.rs
+++ b/tests/multi-taker.rs
@@ -37,7 +37,7 @@ fn multi_taker_single_maker_swap() {
     ];
     // Initiate test framework, Makers.
     // Taker has normal behavior.
-    let (test_framework, mut takers, makers, block_generation_handle) =
+    let (test_framework, mut takers, makers) =
         TestFramework::init(makers_config_map.into(), taker_behavior);
 
     warn!("🧪 Running Test: Multiple Takers with Different Behaviors");
@@ -73,6 +73,8 @@ fn multi_taker_single_maker_swap() {
             })
         })
         .collect::<Vec<_>>();
+
+    test_framework.register_maker_threads(maker_threads);
 
     // Makers take time to fully setup.
     let org_maker_spend_balances = makers
@@ -209,15 +211,4 @@ fn multi_taker_single_maker_swap() {
         });
 
     info!("🎉 All checks successful. Terminating integration test case");
-
-    //Shutdown Makers.
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/standard_swap.rs
+++ b/tests/standard_swap.rs
@@ -31,7 +31,7 @@ fn test_standard_coinswap() {
     let taker_behavior = vec![TakerBehavior::Normal];
 
     // Initiate test framework, Makers and a Taker with default behavior.
-    let (test_framework, mut takers, makers, block_generation_handle) =
+    let (test_framework, mut takers, makers) =
         TestFramework::init(makers_config_map.into(), taker_behavior);
 
     warn!("🧪 Running Test: Standard Coinswap Procedure");
@@ -59,6 +59,8 @@ fn test_standard_coinswap() {
             })
         })
         .collect::<Vec<_>>();
+
+    test_framework.register_maker_threads(maker_threads);
 
     // Makers take time to fully setup.
     let org_maker_spend_balances = makers
@@ -264,16 +266,4 @@ fn test_standard_coinswap() {
     );
 
     info!("🎉 All checks successful. Terminating integration test case");
-
-    // After all balance checks are complete, shut down maker threads
-    makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/taproot_hashlock_recovery.rs
+++ b/tests/taproot_hashlock_recovery.rs
@@ -38,7 +38,7 @@ fn test_taproot_hashlock_recovery_end_to_end() {
     let taker_behavior = vec![TakerBehavior::Normal];
 
     // Initialize test framework
-    let (test_framework, mut taproot_taker, taproot_makers, block_generation_handle) =
+    let (test_framework, mut taproot_taker, taproot_makers) =
         TestFramework::init_taproot(makers_config_map, taker_behavior);
 
     let bitcoind = &test_framework.bitcoind;
@@ -70,6 +70,8 @@ fn test_taproot_hashlock_recovery_end_to_end() {
             })
         })
         .collect::<Vec<_>>();
+
+    test_framework.register_maker_threads(taproot_maker_threads);
 
     // Wait for taproot maker to complete setup
     for maker in &taproot_makers {
@@ -238,15 +240,4 @@ fn test_taproot_hashlock_recovery_end_to_end() {
         );
     }
     info!("✅ Hashlock recovery test passed!");
-    // Shutdown maker
-    taproot_makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    taproot_maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/taproot_maker_abort1.rs
+++ b/tests/taproot_maker_abort1.rs
@@ -26,7 +26,7 @@ fn test_taproot_maker_abort1() {
     let taker_behavior = vec![TakerBehavior::Normal];
 
     // Initialize test framework
-    let (test_framework, mut taproot_taker, taproot_makers, block_generation_handle) =
+    let (test_framework, mut taproot_taker, taproot_makers) =
         TestFramework::init_taproot(makers_config_map, taker_behavior);
 
     let bitcoind = &test_framework.bitcoind;
@@ -58,6 +58,8 @@ fn test_taproot_maker_abort1() {
             })
         })
         .collect::<Vec<_>>();
+
+    test_framework.register_maker_threads(taproot_maker_threads);
 
     // Wait for taproot maker to complete setup
     for maker in &taproot_makers {
@@ -174,15 +176,4 @@ fn test_taproot_maker_abort1() {
         );
     }
     info!("✅ Taproot maker abort 1 test passed!");
-    // Shutdown maker
-    taproot_makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    taproot_maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/taproot_maker_abort2.rs
+++ b/tests/taproot_maker_abort2.rs
@@ -39,7 +39,7 @@ fn test_taproot_maker_abort2() {
     let taker_behavior = vec![TakerBehavior::Normal];
 
     // Initialize test framework
-    let (test_framework, mut taproot_taker, taproot_makers, block_generation_handle) =
+    let (test_framework, mut taproot_taker, taproot_makers) =
         TestFramework::init_taproot(makers_config_map, taker_behavior);
 
     let bitcoind = &test_framework.bitcoind;
@@ -71,6 +71,8 @@ fn test_taproot_maker_abort2() {
             })
         })
         .collect::<Vec<_>>();
+
+    test_framework.register_maker_threads(taproot_maker_threads);
 
     // Wait for taproot maker to complete setup
     for maker in &taproot_makers {
@@ -210,14 +212,6 @@ fn test_taproot_maker_abort2() {
         );
     }
     info!("✅ Taproot Maker abort 2 recovery test passed!");
-    // Shutdown maker
-    taproot_makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    taproot_maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
 
     info!("🚫 Verifying naughty maker gets banned");
     // Maker gets banned for being naughty.
@@ -225,7 +219,4 @@ fn test_taproot_maker_abort2() {
         format!("127.0.0.1:{naughty}"),
         taproot_taker.get_bad_makers()[0].address.to_string()
     );
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/taproot_maker_abort3.rs
+++ b/tests/taproot_maker_abort3.rs
@@ -32,7 +32,7 @@ fn test_taproot_maker_abort3() {
     let taker_behavior = vec![TakerBehavior::Normal];
 
     // Initialize test framework
-    let (test_framework, mut taproot_taker, taproot_makers, block_generation_handle) =
+    let (test_framework, mut taproot_taker, taproot_makers) =
         TestFramework::init_taproot(makers_config_map, taker_behavior);
 
     let bitcoind = &test_framework.bitcoind;
@@ -64,6 +64,8 @@ fn test_taproot_maker_abort3() {
             })
         })
         .collect::<Vec<_>>();
+
+    test_framework.register_maker_threads(taproot_maker_threads);
 
     // Wait for taproot maker to complete setup
     for maker in &taproot_makers {
@@ -190,15 +192,4 @@ fn test_taproot_maker_abort3() {
         );
     }
     info!("✅ Taproot maker abort 3 recovery test passed!");
-    // Shutdown maker
-    taproot_makers
-        .iter()
-        .for_each(|maker| maker.shutdown.store(true, Relaxed));
-
-    taproot_maker_threads
-        .into_iter()
-        .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/taproot_multi_maker.rs
+++ b/tests/taproot_multi_maker.rs
@@ -31,7 +31,7 @@ fn test_taproot_multi_maker() {
     let taker_behavior = vec![TakerBehavior::Normal];
 
     // Initialize test framework
-    let (test_framework, mut taproot_taker, taproot_makers, block_generation_handle) =
+    let (test_framework, mut taproot_taker, taproot_makers) =
         TestFramework::init_taproot(taproot_makers_config_map, taker_behavior);
 
     let bitcoind = &test_framework.bitcoind;
@@ -195,6 +195,4 @@ fn test_taproot_multi_maker() {
     }
 
     log::info!("✅ Taproot mutli maker test passed successfully.");
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/taproot_multi_taker.rs
+++ b/tests/taproot_multi_taker.rs
@@ -28,7 +28,7 @@ fn test_taproot_multi_taker() {
     let taker_behavior = vec![TakerBehavior::Normal, TakerBehavior::Normal];
 
     // Initialize test framework
-    let (test_framework, mut taproot_takers, taproot_makers, block_generation_handle) =
+    let (test_framework, mut taproot_takers, taproot_makers) =
         TestFramework::init_taproot(taproot_makers_config_map, taker_behavior);
 
     let bitcoind = &test_framework.bitcoind;
@@ -217,7 +217,4 @@ fn test_taproot_multi_taker() {
         }
     }
     info!("✅ Multi Taker test passed!");
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/taproot_swap.rs
+++ b/tests/taproot_swap.rs
@@ -31,7 +31,7 @@ fn test_taproot_coinswap() {
     let taker_behavior = vec![TakerBehavior::Normal];
 
     // Initialize test framework (without regular takers, we'll create taproot taker manually)
-    let (test_framework, mut taproot_taker, taproot_makers, block_generation_handle) =
+    let (test_framework, mut taproot_taker, taproot_makers) =
         TestFramework::init_taproot(taproot_makers_config_map, taker_behavior);
 
     let bitcoind = &test_framework.bitcoind;
@@ -198,7 +198,4 @@ fn test_taproot_coinswap() {
     }
 
     info!("All taproot swap tests completed successfully!");
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/taproot_taker_abort1.rs
+++ b/tests/taproot_taker_abort1.rs
@@ -31,7 +31,7 @@ fn test_taproot_taker_abort1() {
     let taker_behavior = vec![TakerBehavior::CloseAtAckResponse];
 
     // Initialize test framework
-    let (test_framework, mut taproot_taker, taproot_makers, block_generation_handle) =
+    let (test_framework, mut taproot_taker, taproot_makers) =
         TestFramework::init_taproot(makers_config_map, taker_behavior);
 
     let bitcoind = &test_framework.bitcoind;
@@ -186,7 +186,4 @@ fn test_taproot_taker_abort1() {
     taproot_maker_threads
         .into_iter()
         .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/taproot_taker_abort2.rs
+++ b/tests/taproot_taker_abort2.rs
@@ -35,7 +35,7 @@ fn test_taproot_taker_abort2() {
     let taker_behavior = vec![TakerBehavior::CloseAtSendersContract];
 
     // Initialize test framework
-    let (test_framework, mut taproot_taker, taproot_makers, block_generation_handle) =
+    let (test_framework, mut taproot_taker, taproot_makers) =
         TestFramework::init_taproot(makers_config_map, taker_behavior);
 
     let bitcoind = &test_framework.bitcoind;
@@ -212,7 +212,4 @@ fn test_taproot_taker_abort2() {
     taproot_maker_threads
         .into_iter()
         .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/taproot_taker_abort3.rs
+++ b/tests/taproot_taker_abort3.rs
@@ -32,7 +32,7 @@ fn test_taproot_taker_abort3() {
     let taker_behavior = vec![TakerBehavior::CloseAtSendersContractFromMaker];
 
     // Initialize test framework
-    let (test_framework, mut taproot_taker, taproot_makers, block_generation_handle) =
+    let (test_framework, mut taproot_taker, taproot_makers) =
         TestFramework::init_taproot(makers_config_map, taker_behavior);
 
     let bitcoind = &test_framework.bitcoind;
@@ -231,7 +231,4 @@ fn test_taproot_taker_abort3() {
     taproot_maker_threads
         .into_iter()
         .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/taproot_timelock_recovery.rs
+++ b/tests/taproot_timelock_recovery.rs
@@ -45,7 +45,7 @@ fn test_taproot_timelock_recovery_end_to_end() {
     let taker_behavior = vec![TakerBehavior::Normal];
 
     // Initialize test framework
-    let (test_framework, mut taproot_taker, taproot_makers, block_generation_handle) =
+    let (test_framework, mut taproot_taker, taproot_makers) =
         TestFramework::init_taproot(makers_config_map, taker_behavior);
 
     let bitcoind = &test_framework.bitcoind;
@@ -250,7 +250,4 @@ fn test_taproot_timelock_recovery_end_to_end() {
     taproot_maker_threads
         .into_iter()
         .for_each(|thread| thread.join().unwrap());
-
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -38,7 +38,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering::Relaxed},
-        mpsc, Arc,
+        mpsc, Arc, Mutex,
     },
     thread::{self, JoinHandle},
     time::{Duration, Instant},
@@ -537,6 +537,10 @@ pub struct TestFramework {
     shutdown: AtomicBool,
     nostr_relay_shutdown: mpsc::Sender<()>,
     nostr_relay_handle: Option<JoinHandle<()>>,
+    block_generation_handle: Mutex<Option<JoinHandle<()>>>,
+    makers: Mutex<Option<Vec<Arc<Maker>>>>,
+    taproot_makers: Mutex<Option<Vec<Arc<TaprootMaker>>>>, // Added
+    maker_threads: Mutex<Option<Vec<JoinHandle<()>>>>,
 }
 
 impl TestFramework {
@@ -555,7 +559,7 @@ impl TestFramework {
     pub fn init(
         makers_config_map: Vec<((u16, Option<u16>), MakerBehavior)>,
         taker_behavior: Vec<TakerBehavior>,
-    ) -> (Arc<Self>, Vec<Taker>, Vec<Arc<Maker>>, JoinHandle<()>) {
+    ) -> (Arc<Self>, Vec<Taker>, Vec<Arc<Maker>>) {
         // Setup directory
         let temp_dir = env::temp_dir().join("coinswap");
         // Remove if previously existing
@@ -573,7 +577,6 @@ impl TestFramework {
 
         log::info!("🌐 Spawning local nostr relay for tests");
         let (nostr_relay_shutdown, nostr_relay_handle) = spawn_nostr_relay(&temp_dir);
-
         _ = wait_for_relay_healthy();
 
         let shutdown = AtomicBool::new(false);
@@ -583,6 +586,10 @@ impl TestFramework {
             shutdown,
             nostr_relay_shutdown,
             nostr_relay_handle: Some(nostr_relay_handle),
+            block_generation_handle: Mutex::new(None),
+            makers: Mutex::new(None),
+            taproot_makers: Mutex::new(None),
+            maker_threads: Mutex::new(None),
         });
 
         // Translate a RpcConfig from the test framework.
@@ -652,7 +659,10 @@ impl TestFramework {
 
         log::info!("✅ Test Framework initialization complete");
 
-        (test_framework, takers, makers, generate_blocks_handle)
+        *test_framework.makers.lock().unwrap() = Some(makers.clone());
+        *test_framework.block_generation_handle.lock().unwrap() = Some(generate_blocks_handle);
+
+        (test_framework, takers, makers)
     }
 
     /// Assert that a log message exists in the debug.log file
@@ -687,12 +697,7 @@ impl TestFramework {
     pub fn init_taproot(
         makers_config_map: Vec<(u16, Option<u16>, TaprootMakerBehavior)>,
         taker_behavior: Vec<TaprootTakerBehavior>,
-    ) -> (
-        Arc<Self>,
-        Vec<TaprootTaker>,
-        Vec<Arc<TaprootMaker>>,
-        JoinHandle<()>,
-    ) {
+    ) -> (Arc<Self>, Vec<TaprootTaker>, Vec<Arc<TaprootMaker>>) {
         // Setup directory
         let temp_dir = env::temp_dir().join("coinswap");
         // Remove if previously existing
@@ -718,6 +723,10 @@ impl TestFramework {
             shutdown,
             nostr_relay_shutdown,
             nostr_relay_handle: Some(nostr_relay_handle),
+            block_generation_handle: Mutex::new(None),
+            makers: Mutex::new(None),
+            taproot_makers: Mutex::new(None),
+            maker_threads: Mutex::new(None),
         });
 
         // Translate a RpcConfig from the test framework.
@@ -784,29 +793,70 @@ impl TestFramework {
             // tf_clone.generate_blocks(10);
             generate_blocks(&tf_clone.bitcoind, 10);
         });
-
         log::info!("✅ Test Framework initialization complete");
 
-        (test_framework, takers, makers, generate_blocks_handle)
+        *test_framework.taproot_makers.lock().unwrap() = Some(makers.clone());
+        *test_framework.block_generation_handle.lock().unwrap() = Some(generate_blocks_handle);
+
+        (test_framework, takers, makers)
     }
 
-    /// Stop bitcoind and clean up all test data.
-    pub fn stop(&self) {
-        log::info!("🛑 Stopping Test Framework");
-        // stop all framework threads.
-        self.shutdown.store(true, Relaxed);
-        _ = self.nostr_relay_shutdown.send(());
-        // stop bitcoind
-        let _ = self.bitcoind.client.stop().unwrap();
+    pub fn register_maker_threads(&self, handles: Vec<JoinHandle<()>>) {
+        let mut guard = self.maker_threads.lock().unwrap();
+        if guard.is_some() {
+            log::warn!("register_maker_threads called twice; previous handles will be dropped");
+        }
+        *guard = Some(handles);
     }
 }
 
 impl Drop for TestFramework {
     fn drop(&mut self) {
-        let handle = self.nostr_relay_handle.take();
-        if let Some(handle) = handle {
-            _ = handle.join();
+        log::info!("Stopping Test Framework...");
+        self.shutdown.store(true, Relaxed);
+
+        if let Some(makers) = self.makers.lock().unwrap().as_ref() {
+            log::info!("Shutting down makers...");
+            makers
+                .iter()
+                .for_each(|maker| maker.shutdown.store(true, Relaxed));
         }
+        if let Some(makers) = self.taproot_makers.lock().unwrap().as_ref() {
+            log::info!("Shutting down taproot makers...");
+            makers
+                .iter()
+                .for_each(|maker| maker.shutdown.store(true, Relaxed));
+        }
+
+        if let Some(threads) = self.maker_threads.lock().unwrap().take() {
+            log::info!("Joining maker threads...");
+            threads.into_iter().for_each(|t| {
+                if let Err(e) = t.join() {
+                    log::error!("Error joining maker thread: {:?}", e);
+                }
+            });
+        }
+
+        if let Some(handle) = self.block_generation_handle.lock().unwrap().take() {
+            log::info!("Joining block generation thread...");
+            if let Err(e) = handle.join() {
+                log::error!("Block generation thread join failed: {:?}", e);
+            }
+        }
+
+        log::info!("Shutting down bitcoind...");
+        let _ = self.bitcoind.client.stop().unwrap();
+
+        log::info!("Shutting down nostr relay...");
+        _ = self.nostr_relay_shutdown.send(());
+
+        if let Some(handle) = self.nostr_relay_handle.take() {
+            if let Err(e) = handle.join() {
+                log::error!("Nostr relay thread join failed: {:?}", e);
+            }
+        }
+
+        log::info!("Test Framework cleanup complete.");
     }
 }
 

--- a/tests/utxo_behavior.rs
+++ b/tests/utxo_behavior.rs
@@ -88,8 +88,7 @@ fn test_address_grouping_behavior() {
     let makers_config_map = [((6102, None), MakerBehavior::Normal)];
     let taker_behavior = vec![TakerBehavior::Normal];
 
-    let (test_framework, _, makers, block_generation_handle) =
-        TestFramework::init(makers_config_map.into(), taker_behavior);
+    let (test_framework, _, makers) = TestFramework::init(makers_config_map.into(), taker_behavior);
 
     println!("=== Testing Smart Address Grouping Behavior ===");
 
@@ -193,10 +192,6 @@ fn test_address_grouping_behavior() {
 
     println!("\n=== Test Completed Successfully ===");
     println!("✅ All address grouping scenarios work correctly");
-
-    // Clean shutdown
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }
 
 fn test_separated_utxo_coin_selection() {
@@ -207,7 +202,7 @@ fn test_separated_utxo_coin_selection() {
     ];
     let taker_behavior = vec![TakerBehavior::Normal];
 
-    let (test_framework, mut takers, makers, block_generation_handle) =
+    let (test_framework, mut takers, makers) =
         TestFramework::init(makers_config_map.into(), taker_behavior);
 
     warn!("🔧 Running Test: Separated UTXO Coin Selection");
@@ -395,14 +390,10 @@ fn test_separated_utxo_coin_selection() {
     }
 
     println!("\n=== Test Completed Successfully ===");
-
-    // Clean shutdown
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }
 
 fn test_manual_coinselection() {
-    let (test_framework, mut takers, maker, block_generation_handle) = TestFramework::init(
+    let (test_framework, mut takers, maker) = TestFramework::init(
         vec![
             ((26102, Some(19053)), MakerBehavior::Normal),
             ((36102, Some(19054)), MakerBehavior::Normal),
@@ -696,6 +687,4 @@ fn test_manual_coinselection() {
     }
 
     println!("✅ All test cases completed successfully");
-    test_framework.stop();
-    block_generation_handle.join().unwrap();
 }


### PR DESCRIPTION
Close #737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Initialization now returns one fewer explicit background handle; lifecycle and shutdown are centralized and Drop-based.
  * Added thread-registration so the framework tracks maker/server threads.
  * Tests updated to remove manual teardown, stop, and thread-join calls; cleanup is handled automatically by the framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->