### PR TITLE
Failed and Recovery Swap reports for taker and Save to disk

### DIFF
--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -54,7 +54,7 @@ use crate::{
     utill::*,
     wallet::{
         ffi::MakerFeeInfo, IncomingSwapCoin, OutgoingSwapCoin, RPCConfig, SwapCoin, SwapReport,
-        Wallet, WalletError, WatchOnlySwapCoin,
+        SwapStatus, Wallet, WalletError, WatchOnlySwapCoin,
     },
     watch_tower::{
         registry_storage::FileRegistry,
@@ -353,7 +353,8 @@ impl Taker {
         swap_params: SwapParams,
     ) -> Result<Option<SwapReport>, TakerError> {
         let swap_start_time = std::time::Instant::now();
-        let initial_utxoset = self.wallet.list_all_utxo().cloned().collect();
+        let initial_utxoset: Vec<ListUnspentResultEntry> =
+            self.wallet.list_all_utxo().cloned().collect();
         self.ongoing_swap_state.swap_params = swap_params.clone();
 
         // Check if we have enough balance - try regular first, then swap
@@ -416,6 +417,13 @@ impl Taker {
         // Try first hop. Abort if error happens.
         if let Err(e) = self.init_first_hop() {
             log::error!("Could not initiate first hop: {e:?}");
+            self.generate_swap_report(
+                &self.ongoing_swap_state.clone(),
+                swap_start_time,
+                &initial_utxoset,
+                SwapStatus::Failed,
+                Some(format!("{e:?}")),
+            )?;
             self.recover_from_swap()?;
             return Err(e);
         }
@@ -464,6 +472,13 @@ impl Taker {
                     Err(e) => {
                         log::error!("Could not initiate next hop. Error : {e:?}");
                         log::warn!("Starting recovery from existing swap");
+                        self.generate_swap_report(
+                            &self.ongoing_swap_state.clone(),
+                            swap_start_time,
+                            &initial_utxoset,
+                            SwapStatus::Failed,
+                            Some(format!("{e:?}")),
+                        )?;
                         self.recover_from_swap()?;
                         return Ok(None);
                     }
@@ -484,6 +499,13 @@ impl Taker {
                         let bad_maker = &self.ongoing_swap_state.peer_infos[maker_index].peer;
                         self.offerbook.add_bad_maker(bad_maker);
                     }
+                    self.generate_swap_report(
+                        &self.ongoing_swap_state.clone(),
+                        swap_start_time,
+                        &initial_utxoset,
+                        SwapStatus::Failed,
+                        Some(format!("{e:?}")),
+                    )?;
                     self.recover_from_swap()?;
                     return Ok(None);
                 }
@@ -500,6 +522,13 @@ impl Taker {
                     Err(e) => {
                         log::error!("Incoming SwapCoin Generation failed : {e:?}");
                         log::warn!("Starting recovery from existing swap");
+                        self.generate_swap_report(
+                            &self.ongoing_swap_state.clone(),
+                            swap_start_time,
+                            &initial_utxoset,
+                            SwapStatus::Failed,
+                            Some(format!("{e:?}")),
+                        )?;
                         self.recover_from_swap()?;
                         return Ok(None);
                     }
@@ -543,7 +572,9 @@ impl Taker {
                 let swap_report = Some(self.generate_swap_report(
                     prereset_swapstate,
                     swap_start_time,
-                    initial_utxoset,
+                    &initial_utxoset,
+                    SwapStatus::Success,
+                    None,
                 )?);
                 log::info!("Successfully Completed Coinswap.");
                 Ok(swap_report)
@@ -551,6 +582,13 @@ impl Taker {
             Err(e) => {
                 log::error!("Swap Settlement Failed : {e:?}");
                 log::warn!("Starting recovery from existing swap");
+                self.generate_swap_report(
+                    &self.ongoing_swap_state.clone(),
+                    swap_start_time,
+                    &initial_utxoset,
+                    SwapStatus::Failed,
+                    Some(format!("{e:?}")),
+                )?;
                 self.recover_from_swap()?;
                 Ok(None)
             }
@@ -561,7 +599,9 @@ impl Taker {
         &self,
         prereset_swapstate: &OngoingSwapState,
         start_time: std::time::Instant,
-        initial_utxos: Vec<ListUnspentResultEntry>,
+        initial_utxos: &[ListUnspentResultEntry],
+        status: SwapStatus,
+        error_message: Option<String>,
     ) -> Result<SwapReport, TakerError> {
         let swap_state = &prereset_swapstate;
 
@@ -675,11 +715,21 @@ impl Taker {
             })
             .collect::<Vec<_>>();
 
-        // Collect maker fee information
+        // Peer_infos is maker_count (only makers participated in swap) + 1 (the last is the taker's info),
+        // so cap at maker_count to avoid double-counting, or else
+        // it will give an underflow error when the last entry is included.
         let mut maker_fee_info = Vec::new();
         let mut temp_target_amount = swap_state.swap_params.send_amount.to_sat();
-
-        let total_maker_fees = (0..swap_state.swap_params.maker_count)
+        let completed_hops = swap_state
+            .peer_infos
+            .len()
+            .min(swap_state.swap_params.maker_count);
+        log::info!(
+            "Calculating fees for peer info : {} and maker count: {}",
+            swap_state.peer_infos.len(),
+            swap_state.swap_params.maker_count
+        );
+        let total_maker_fees = (0..completed_hops)
             .map(|maker_index| {
                 let maker_refund_locktime = REFUND_LOCKTIME
                     + REFUND_LOCKTIME_STEP
@@ -721,15 +771,42 @@ impl Taker {
         let fee_percentage =
             (total_fee as f64 / swap_state.swap_params.send_amount.to_sat() as f64) * 100.0;
 
-        let report = SwapReport::taker_success(
-            swap_state.id.clone(),
-            swap_duration.as_secs_f64(),
-            swap_state.swap_params.send_amount.to_sat(),
-            total_output_amount,
-            swap_state.swap_params.maker_count,
+        let outgoing_contract_txid = if !swap_state.outgoing_swapcoins.is_empty() {
+            Some(
+                swap_state
+                    .outgoing_swapcoins
+                    .iter()
+                    .map(|sc| sc.contract_tx.compute_txid().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            )
+        } else {
+            None
+        };
+
+        let incoming_contract_txid = if !swap_state.incoming_swapcoins.is_empty() {
+            Some(
+                swap_state
+                    .incoming_swapcoins
+                    .iter()
+                    .map(|sc| sc.contract_tx.compute_txid().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            )
+        } else {
+            None
+        };
+
+        let report = SwapReport::taker_report(SwapReport {
+            status,
+            swap_id: swap_state.id.clone(),
+            swap_duration_seconds: swap_duration.as_secs_f64(),
+            outgoing_amount: swap_state.swap_params.send_amount.to_sat(),
+            incoming_amount: total_output_amount,
+            fee_paid_or_earned: -(total_fee as i64),
+            makers_count: Some(swap_state.swap_params.maker_count),
             maker_addresses,
             funding_txids,
-            total_fee,
             total_maker_fees,
             mining_fee,
             fee_percentage,
@@ -739,8 +816,12 @@ impl Taker {
             output_swap_amounts,
             output_change_utxos,
             output_swap_utxos,
-            network.to_string(),
-        );
+            network: network.to_string(),
+            error_message,
+            incoming_contract_txid,
+            outgoing_contract_txid,
+            ..Default::default()
+        });
 
         report.print();
         let _ = report.save_to_disk(&get_taker_dir()).map_err(|e| {
@@ -2112,7 +2193,10 @@ impl Taker {
 
     /// Recover from a bad swap
     pub fn recover_from_swap(&mut self) -> Result<(), TakerError> {
+        let recovery_start = std::time::Instant::now();
         let (incomings, outgoings) = self.wallet.find_unfinished_swapcoins();
+        let mut hashlock_recovery_txids: Vec<String> = Vec::new();
+        let mut timelock_recovery_txids: Vec<String> = Vec::new();
 
         // First try to spend the hashlock contracts.
         // If fails, then try to spend the timelock contracts.
@@ -2138,6 +2222,10 @@ impl Taker {
                 );
                 if hashlock_broadcasted.len() == incoming_infos.len() {
                     log::info!("All incoming contracts redeemed. Cleared ongoing swap state");
+                    hashlock_recovery_txids = hashlock_broadcasted
+                        .into_iter()
+                        .map(|tx| tx.compute_txid().to_string())
+                        .collect();
                     self.clear_ongoing_swaps();
                     break;
                 }
@@ -2170,6 +2258,10 @@ impl Taker {
                 );
                 if timelock_broadcasted.len() == outgoing_infos.len() {
                     log::info!("All outgoing contracts redeemed. Cleared ongoing swap state");
+                    timelock_recovery_txids = timelock_broadcasted
+                        .into_iter()
+                        .map(|tx| tx.compute_txid().to_string())
+                        .collect();
                     self.clear_ongoing_swaps();
                     break;
                 }
@@ -2182,6 +2274,25 @@ impl Taker {
                 };
                 std::thread::sleep(block_wait_time);
             }
+        }
+
+        let duration = recovery_start.elapsed().as_secs_f64();
+        if !hashlock_recovery_txids.is_empty() || !timelock_recovery_txids.is_empty() {
+            let (status, txids) = if !hashlock_recovery_txids.is_empty() {
+                (SwapStatus::RecoveryHashlock, &hashlock_recovery_txids)
+            } else {
+                (SwapStatus::RecoveryTimelock, &timelock_recovery_txids)
+            };
+            let data_dir = get_taker_dir();
+            SwapReport::emit_taker_recovery_report(
+                &data_dir,
+                self.ongoing_swap_state.id.clone(),
+                self.wallet.store.network.to_string(),
+                self.ongoing_swap_state.swap_params.send_amount.to_sat(),
+                status,
+                txids,
+                duration,
+            );
         }
         log::info!("Recovery completed.");
         Ok(())

--- a/src/taker/api2.rs
+++ b/src/taker/api2.rs
@@ -25,7 +25,7 @@ use crate::{
     utill::{check_tor_status, get_taker_dir, read_message, send_message},
     wallet::{
         ffi::MakerFeeInfo, AddressType, IncomingSwapCoinV2, OutgoingSwapCoinV2, RPCConfig,
-        SwapReport, Wallet, WalletError,
+        SwapReport, SwapStatus, Wallet, WalletError,
     },
     watch_tower::{
         registry_storage::FileRegistry,
@@ -340,7 +340,8 @@ impl Taker {
         swap_params: SwapParams,
     ) -> Result<Option<SwapReport>, TakerError> {
         let swap_start_time = std::time::Instant::now();
-        let initial_utxoset = self.wallet.list_all_utxo().cloned().collect();
+        let initial_utxoset: Vec<ListUnspentResultEntry> =
+            self.wallet.list_all_utxo().cloned().collect();
 
         let available = self.wallet.get_balances()?.spendable;
 
@@ -426,7 +427,9 @@ impl Taker {
                 let swap_report = self.generate_swap_report(
                     &prereset_swapstate,
                     swap_start_time,
-                    initial_utxoset,
+                    &initial_utxoset,
+                    SwapStatus::Success,
+                    None,
                 )?;
 
                 log::info!("Successfully Completed Taproot Coinswap.");
@@ -435,18 +438,29 @@ impl Taker {
             Err(e) => {
                 log::error!("Swap Settlement Failed: {:?}", e);
                 log::warn!("Starting recovery from existing swap");
+                self.generate_swap_report(
+                    &self.ongoing_swap_state.clone(),
+                    swap_start_time,
+                    &initial_utxoset,
+                    SwapStatus::Failed,
+                    Some(format!("{e:?}")),
+                )?;
                 self.recover_from_swap()?;
                 Ok(None)
             }
         }
     }
 
-    /// Generate a swap report after successful completion of a taproot coinswap
+    /// Build a swap report from current state. Handles all four statuses:
+    /// `Success`, `Failed`, `RecoveryHashlock`, `RecoveryTimelock`.
+    #[allow(clippy::too_many_arguments)]
     fn generate_swap_report(
         &self,
         prereset_swapstate: &OngoingSwapState,
         start_time: std::time::Instant,
-        initial_utxos: Vec<ListUnspentResultEntry>,
+        initial_utxos: &[ListUnspentResultEntry],
+        status: SwapStatus,
+        error_message: Option<String>,
     ) -> Result<SwapReport, TakerError> {
         let swap_state = prereset_swapstate;
         let swap_duration = start_time.elapsed();
@@ -604,15 +618,33 @@ impl Taker {
         let fee_percentage =
             (total_fee as f64 / swap_state.swap_params.send_amount.to_sat() as f64) * 100.0;
 
-        let report = SwapReport::taker_success(
-            swap_state.id.clone(),
-            swap_duration.as_secs_f64(),
-            swap_state.swap_params.send_amount.to_sat(),
-            total_output_amount,
-            swap_state.swap_params.maker_count,
+        let outgoing_contract_txid = if !swap_state.outgoing_contract.contract_tx.input.is_empty() {
+            Some(
+                swap_state
+                    .outgoing_contract
+                    .contract_tx
+                    .compute_txid()
+                    .to_string(),
+            )
+        } else {
+            None
+        };
+
+        let incoming_contract_txid = swap_state
+            .incoming_contract
+            .contract_txid
+            .map(|txid| txid.to_string());
+
+        let report = SwapReport::taker_report(SwapReport {
+            status,
+            swap_id: swap_state.id.clone(),
+            swap_duration_seconds: swap_duration.as_secs_f64(),
+            outgoing_amount: swap_state.swap_params.send_amount.to_sat(),
+            incoming_amount: total_output_amount,
+            fee_paid_or_earned: -(total_fee as i64),
+            makers_count: Some(swap_state.swap_params.maker_count),
             maker_addresses,
             funding_txids,
-            total_fee,
             total_maker_fees,
             mining_fee,
             fee_percentage,
@@ -622,8 +654,12 @@ impl Taker {
             output_swap_amounts,
             output_change_utxos,
             output_swap_utxos,
-            network.to_string(),
-        );
+            network: network.to_string(),
+            error_message,
+            incoming_contract_txid,
+            outgoing_contract_txid,
+            ..Default::default()
+        });
 
         report.print();
         let _ = report.save_to_disk(&get_taker_dir()).map_err(|e| {
@@ -1642,7 +1678,10 @@ impl Taker {
     /// 1. For incoming contracts: Try hashlock spend using stored preimage, fallback to timelock
     /// 2. For outgoing contracts: Wait for timelock maturity, then spend via timelock
     /// 3. Skip contracts that were already spent (via keypath, hashlock, or timelock)
+    ///
+    /// Emits a recovery report on completion and saves it to disk.
     pub fn recover_from_swap(&mut self) -> Result<(), TakerError> {
+        let recovery_start = std::time::Instant::now();
         log::info!("Starting taproot swap recovery");
 
         // Find unfinished swapcoins (contracts that weren't cooperatively swept)
@@ -1652,6 +1691,10 @@ impl Taker {
             log::info!("No unfinished swapcoins found - nothing to recover");
             return Ok(());
         }
+
+        // Track recovery txids for reporting
+        let mut hashlock_recovery_txids: Vec<String> = Vec::new();
+        let mut timelock_recovery_txids: Vec<String> = Vec::new();
 
         log::info!(
             "Found {} incoming and {} outgoing unfinished swapcoins",
@@ -1736,6 +1779,7 @@ impl Taker {
                                         "Taker Successfully recovered incoming contract via hashlock: {}",
                                         txid
                                     );
+                                    hashlock_recovery_txids.push(txid.to_string());
                                 }
                                 Err(e) => {
                                     log::warn!("Failed to spend via hashlock: {:?}, will retry with timelock after maturity", e);
@@ -1835,6 +1879,7 @@ impl Taker {
                                     {
                                         Ok(txid) => {
                                             log::info!("Taker Successfully recovered outgoing contract via timelock: {}", txid);
+                                            timelock_recovery_txids.push(txid.to_string());
                                             recovered_indices.push(idx);
                                         }
                                         Err(e) => {
@@ -1877,6 +1922,32 @@ impl Taker {
             }
         }
 
+        let duration = recovery_start.elapsed().as_secs_f64();
+
+        if !hashlock_recovery_txids.is_empty() {
+            let data_dir = get_taker_dir();
+            SwapReport::emit_taker_recovery_report(
+                &data_dir,
+                self.ongoing_swap_state.id.clone(),
+                self.wallet.store.network.to_string(),
+                self.ongoing_swap_state.swap_params.send_amount.to_sat(),
+                SwapStatus::RecoveryHashlock,
+                &hashlock_recovery_txids,
+                duration,
+            );
+        }
+        if !timelock_recovery_txids.is_empty() {
+            let data_dir = get_taker_dir();
+            SwapReport::emit_taker_recovery_report(
+                &data_dir,
+                self.ongoing_swap_state.id.clone(),
+                self.wallet.store.network.to_string(),
+                self.ongoing_swap_state.swap_params.send_amount.to_sat(),
+                SwapStatus::RecoveryTimelock,
+                &timelock_recovery_txids,
+                duration,
+            );
+        }
         log::info!("Taproot swap recovery completed");
         Ok(())
     }

--- a/src/wallet/report.rs
+++ b/src/wallet/report.rs
@@ -6,7 +6,38 @@
 //! is a taker or maker. It supports success, failure, and recovery scenarios.
 
 use serde::{Deserialize, Serialize};
-use std::{path::Path, str::FromStr, time::Instant};
+use std::{
+    path::Path,
+    str::FromStr,
+    time::{Duration, Instant},
+};
+
+fn format_unix_timestamp_utc(timestamp: Duration) -> String {
+    let secs = timestamp.as_secs();
+    let millis = timestamp.subsec_millis();
+    let days = (secs / 86_400) as i64;
+    let sod = secs % 86_400;
+
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = mp + if mp < 10 { 3 } else { -9 };
+    let year = y + if m <= 2 { 1 } else { 0 };
+
+    let hour = sod / 3_600;
+    let minute = (sod % 3_600) / 60;
+    let second = sod % 60;
+
+    format!(
+        "{:04}-{:02}-{:02}T{:02}-{:02}-{:02}.{:03}Z",
+        year, m, d, hour, minute, second, millis
+    )
+}
 
 /// Role of the participant in the swap.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -94,13 +125,15 @@ pub struct SwapReport {
     pub status: SwapStatus,
     /// Total duration of the swap in seconds.
     pub swap_duration_seconds: f64,
+    /// Duration of the recovery phase in seconds (0 if no recovery).
+    pub recovery_duration_seconds: f64,
     /// Unix timestamp when the swap started.
     pub start_timestamp: u64,
     /// Unix timestamp when the swap completed.
     pub end_timestamp: u64,
     /// Bitcoin network used (mainnet, testnet, signet, regtest).
     pub network: String,
-    /// Error message if the swap failed.
+    /// Error message if the swap failed or triggered recovery.
     pub error_message: Option<String>,
 
     /// Amount received in the incoming contract (satoshis).
@@ -116,15 +149,15 @@ pub struct SwapReport {
     /// Negative for takers (fee paid).
     pub fee_paid_or_earned: i64,
 
-    /// Transaction ID of the incoming contract (maker only).
+    /// Transaction IDs of the incoming contracts.
     pub incoming_contract_txid: Option<String>,
-    /// Transaction ID of the outgoing contract (maker only).
+    /// Transaction IDs of the outgoing contracts.
     pub outgoing_contract_txid: Option<String>,
     /// Funding transaction IDs organized by hop (taker only).
     /// Each inner vector contains txids for one hop in the swap route.
     pub funding_txids: Vec<Vec<String>>,
-    /// Transaction ID of the recovery transaction (hashlock/timelock).
-    pub recovery_txid: Option<String>,
+    /// Transaction IDs of recovery transactions (hashlock/timelock).
+    pub recovery_txids: Option<Vec<String>>,
 
     /// Timelock value in blocks for the contract.
     pub timelock: u16,
@@ -154,41 +187,26 @@ pub struct SwapReport {
     pub output_swap_utxos: Vec<(u64, String)>,
 }
 
-impl SwapReport {
-    /// Create a successful maker swap report.
-    pub fn maker_success(
-        swap_id: String,
-        start_time: Instant,
-        incoming_amount: u64,
-        outgoing_amount: u64,
-        incoming_contract_txid: String,
-        outgoing_contract_txid: String,
-        timelock: u16,
-        network: String,
-    ) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default();
-        let end_timestamp = now.as_secs();
-        let swap_duration = start_time.elapsed();
-
+impl Default for SwapReport {
+    fn default() -> Self {
         Self {
-            swap_id,
-            role: SwapRole::Maker,
-            status: SwapStatus::Success,
-            swap_duration_seconds: swap_duration.as_secs_f64(),
-            start_timestamp: end_timestamp.saturating_sub(swap_duration.as_secs()),
-            end_timestamp,
-            network,
+            swap_id: String::new(),
+            role: SwapRole::Taker,
+            status: SwapStatus::Failed,
+            swap_duration_seconds: 0.0,
+            recovery_duration_seconds: 0.0,
+            start_timestamp: 0,
+            end_timestamp: 0,
+            network: String::new(),
             error_message: None,
-            incoming_amount,
-            outgoing_amount,
-            fee_paid_or_earned: (incoming_amount as i64) - (outgoing_amount as i64),
-            incoming_contract_txid: Some(incoming_contract_txid),
-            outgoing_contract_txid: Some(outgoing_contract_txid),
+            incoming_amount: 0,
+            outgoing_amount: 0,
+            fee_paid_or_earned: 0,
+            incoming_contract_txid: None,
+            outgoing_contract_txid: None,
             funding_txids: vec![],
-            recovery_txid: None,
-            timelock,
+            recovery_txids: None,
+            timelock: 0,
             makers_count: None,
             maker_addresses: vec![],
             maker_fee_info: vec![],
@@ -201,6 +219,51 @@ impl SwapReport {
             output_change_utxos: vec![],
             output_swap_utxos: vec![],
         }
+    }
+}
+
+impl SwapReport {
+    fn maker_report(mut report: Self, swap_duration_seconds: f64) -> Self {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default();
+        let end_timestamp = now.as_secs();
+
+        report.role = SwapRole::Maker;
+        report.swap_duration_seconds = swap_duration_seconds;
+        report.start_timestamp = end_timestamp.saturating_sub(swap_duration_seconds as u64);
+        report.end_timestamp = end_timestamp;
+        report
+    }
+
+    /// Create a successful maker swap report.
+    pub fn maker_success(
+        swap_id: String,
+        start_time: Instant,
+        incoming_amount: u64,
+        outgoing_amount: u64,
+        incoming_contract_txid: String,
+        outgoing_contract_txid: String,
+        timelock: u16,
+        network: String,
+    ) -> Self {
+        let swap_duration = start_time.elapsed();
+
+        Self::maker_report(
+            Self {
+                swap_id,
+                status: SwapStatus::Success,
+                network,
+                incoming_amount,
+                outgoing_amount,
+                fee_paid_or_earned: (incoming_amount as i64) - (outgoing_amount as i64),
+                incoming_contract_txid: Some(incoming_contract_txid),
+                outgoing_contract_txid: Some(outgoing_contract_txid),
+                timelock,
+                ..Default::default()
+            },
+            swap_duration.as_secs_f64(),
+        )
     }
 
     /// Create a maker recovery report (hashlock or timelock).
@@ -215,46 +278,27 @@ impl SwapReport {
         timelock: u16,
         network: String,
     ) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default();
-        let end_timestamp = now.as_secs();
-
         let status = match recovery_type {
             "hashlock" => SwapStatus::RecoveryHashlock,
             "timelock" => SwapStatus::RecoveryTimelock,
             _ => SwapStatus::Failed,
         };
 
-        Self {
-            swap_id,
-            role: SwapRole::Maker,
-            status,
-            swap_duration_seconds: 0.0,
-            start_timestamp: end_timestamp,
-            end_timestamp,
-            network,
-            error_message: None,
-            incoming_amount,
-            outgoing_amount,
-            fee_paid_or_earned: 0,
-            incoming_contract_txid: Some(incoming_contract_txid),
-            outgoing_contract_txid: Some(outgoing_contract_txid),
-            funding_txids: vec![],
-            recovery_txid: Some(recovery_txid),
-            timelock,
-            makers_count: None,
-            maker_addresses: vec![],
-            maker_fee_info: vec![],
-            total_maker_fees: 0,
-            mining_fee: 0,
-            fee_percentage: 0.0,
-            input_utxos: vec![],
-            output_change_amounts: vec![],
-            output_swap_amounts: vec![],
-            output_change_utxos: vec![],
-            output_swap_utxos: vec![],
-        }
+        Self::maker_report(
+            Self {
+                swap_id,
+                status,
+                network,
+                incoming_amount,
+                outgoing_amount,
+                incoming_contract_txid: Some(incoming_contract_txid),
+                outgoing_contract_txid: Some(outgoing_contract_txid),
+                recovery_txids: Some(vec![recovery_txid]),
+                timelock,
+                ..Default::default()
+            },
+            0.0,
+        )
     }
 
     /// Create a failed maker swap report.
@@ -268,104 +312,68 @@ impl SwapReport {
         network: String,
         error_message: String,
     ) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default();
-        let end_timestamp = now.as_secs();
-
-        Self {
-            swap_id,
-            role: SwapRole::Maker,
-            status: SwapStatus::Failed,
-            swap_duration_seconds: 0.0,
-            start_timestamp: end_timestamp,
-            end_timestamp,
-            network,
-            error_message: Some(error_message),
-            incoming_amount,
-            outgoing_amount,
-            fee_paid_or_earned: 0,
-            incoming_contract_txid: Some(incoming_contract_txid),
-            outgoing_contract_txid: Some(outgoing_contract_txid),
-            funding_txids: vec![],
-            recovery_txid: None,
-            timelock,
-            makers_count: None,
-            maker_addresses: vec![],
-            maker_fee_info: vec![],
-            total_maker_fees: 0,
-            mining_fee: 0,
-            fee_percentage: 0.0,
-            input_utxos: vec![],
-            output_change_amounts: vec![],
-            output_swap_amounts: vec![],
-            output_change_utxos: vec![],
-            output_swap_utxos: vec![],
-        }
+        Self::maker_report(
+            Self {
+                swap_id,
+                status: SwapStatus::Failed,
+                network,
+                error_message: Some(error_message),
+                incoming_amount,
+                outgoing_amount,
+                incoming_contract_txid: Some(incoming_contract_txid),
+                outgoing_contract_txid: Some(outgoing_contract_txid),
+                timelock,
+                ..Default::default()
+            },
+            0.0,
+        )
     }
 
-    /// Create a successful taker swap report.
-    #[allow(clippy::too_many_arguments)]
-    pub fn taker_success(
-        swap_id: String,
-        swap_duration_seconds: f64,
-        target_amount: u64,
-        total_output: u64,
-        makers_count: usize,
-        maker_addresses: Vec<String>,
-        funding_txids: Vec<Vec<String>>,
-        total_fee: u64,
-        total_maker_fees: u64,
-        mining_fee: u64,
-        fee_percentage: f64,
-        maker_fee_info: Vec<MakerFeeInfo>,
-        input_utxos: Vec<u64>,
-        output_change_amounts: Vec<u64>,
-        output_swap_amounts: Vec<u64>,
-        output_change_utxos: Vec<(u64, String)>,
-        output_swap_utxos: Vec<(u64, String)>,
-        network: String,
-    ) -> Self {
+    /// Create a taker swap report for any status (success, failed, or recovery).
+    pub fn taker_report(mut report: Self) -> Self {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default();
         let end_timestamp = now.as_secs();
-        let start_timestamp = end_timestamp - (swap_duration_seconds as u64);
+        report.role = SwapRole::Taker;
+        report.start_timestamp = end_timestamp.saturating_sub(report.swap_duration_seconds as u64);
+        report.end_timestamp = end_timestamp;
+        report
+    }
 
-        Self {
+    /// Emit a minimal taker recovery report to disk and console.
+    pub fn emit_taker_recovery_report(
+        data_dir: &Path,
+        swap_id: String,
+        network: String,
+        outgoing_amount: u64,
+        status: SwapStatus,
+        recovery_txids: &[String],
+        recovery_duration: f64,
+    ) {
+        let report = Self::taker_report(SwapReport {
+            status,
             swap_id,
-            role: SwapRole::Taker,
-            status: SwapStatus::Success,
-            swap_duration_seconds,
-            start_timestamp,
-            end_timestamp,
+            outgoing_amount,
             network,
-            error_message: None,
-            incoming_amount: total_output,
-            outgoing_amount: target_amount,
-            fee_paid_or_earned: -(total_fee as i64),
-            incoming_contract_txid: None,
-            outgoing_contract_txid: None,
-            funding_txids,
-            recovery_txid: None,
-            timelock: 0,
-            makers_count: Some(makers_count),
-            maker_addresses,
-            maker_fee_info,
-            total_maker_fees,
-            mining_fee,
-            fee_percentage,
-            input_utxos,
-            output_change_amounts,
-            output_swap_amounts,
-            output_change_utxos,
-            output_swap_utxos,
+            recovery_txids: Some(recovery_txids.to_vec()),
+            recovery_duration_seconds: recovery_duration,
+            ..Default::default()
+        });
+
+        report.print();
+        if let Err(e) = report.save_to_disk(data_dir) {
+            log::warn!("Failed to save taker recovery report: {:?}", e);
         }
+        log::info!(
+            "For full details of the failed swap, see the accompanying report in: {}/swap_reports/",
+            data_dir.display()
+        );
     }
 
     /// Save the report to disk as a JSON file.
     ///
-    /// The report is saved to `{data_dir}/swap_reports/{role}_{timestamp}_{swap_id}.json`.
+    /// The report is saved to `{data_dir}/swap_reports/{role}_{status}_{timestamp}_{swap_id}.json`.
     pub fn save_to_disk(&self, data_dir: &Path) -> std::io::Result<()> {
         let reports_dir = data_dir.join("swap_reports");
         std::fs::create_dir_all(&reports_dir)?;
@@ -373,6 +381,13 @@ impl SwapReport {
         let role_prefix = match self.role {
             SwapRole::Taker => "taker",
             SwapRole::Maker => "maker",
+        };
+
+        let status_prefix = match self.status {
+            SwapStatus::Success => "success",
+            SwapStatus::Failed => "failed",
+            SwapStatus::RecoveryHashlock => "recoveryhashlock",
+            SwapStatus::RecoveryTimelock => "recoverytimelock",
         };
 
         let sanitized_swap_id: String = self
@@ -391,11 +406,11 @@ impl SwapReport {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default();
-        let timestamp_ms = now.as_millis();
+        let timestamp = format_unix_timestamp_utc(now);
 
         let filename = format!(
             "{}_{}_{}_{}.json",
-            role_prefix, self.end_timestamp, timestamp_ms, safe_swap_id
+            role_prefix, status_prefix, timestamp, safe_swap_id
         );
         let filepath = reports_dir.join(filename);
 
@@ -424,6 +439,13 @@ impl SwapReport {
             println!(
                 "\x1b[1;37mDuration          :\x1b[0m {:.2} seconds",
                 self.swap_duration_seconds
+            );
+        }
+
+        if self.recovery_duration_seconds > 0.0 {
+            println!(
+                "\x1b[1;37mRecovery Duration :\x1b[0m {:.2} seconds",
+                self.recovery_duration_seconds
             );
         }
 
@@ -502,8 +524,8 @@ impl SwapReport {
                 }
             }
         }
-        if let Some(ref txid) = self.recovery_txid {
-            println!("\x1b[1;37mRecovery Tx       :\x1b[0m {}", txid);
+        if let Some(ref txids) = self.recovery_txids {
+            println!("\x1b[1;37mRecovery Tx       :\x1b[0m {:?}", txids);
         }
 
         if !self.maker_fee_info.is_empty() {


### PR DESCRIPTION
- Generates failed swap reports with corresponding error message. 
- Generates minimal recovery report referencing the accompanying failed swap report in the directory. Added a new field which shows the recovery time. 
- Updated the date & time naming of the swap reports to be in human readable format. Zero-dependency, the format is : `YYYY-MM-DDTHH:MM:SS.sssZ` (Standard Format (ISO 8601) - GMT)
- Consolidated taker_success, taker_failed, taker_recovery into a singular constructor `taker_report` to minimise redundancy.
- Failed Swap reports are of 2 subtypes. 
  - A. Failed Reports -> At least one contract txn has been broadcasted with a maker.
  - B. Quick Failure Reports -> No maker is involved.

### Legacy Taker

| # | Failure Point | Report | Recovery |
|---|---|---|---|
| 1 | `init_first_hop` fails | `generate_swap_report(Failed)` | `recover_from_swap()` |
| 2 | `send_sigs_init_next_hop` fails (loop) | `generate_swap_report(Failed)` | `recover_from_swap()` |
| 3 | `watch_for_txs` fails (loop) | `generate_swap_report(Failed)` | `recover_from_swap()` |
| 4 | `request_sigs_for_incoming_swap` fails | `generate_swap_report(Failed)` | `recover_from_swap()` |
| 5 | `settle_all_swaps` fails | `generate_swap_report(Failed)` | `recover_from_swap()` |
| 6 | `settle_all_swaps` succeeds | `generate_swap_report(Success)` | — |

### Taproot Taker 

| # | Failure Point | Report | Recovery |
|---|---|---|---|
| 1 | `wait_for_tx_confirmation` fails | `generate_swap_report(Failed)` | `recover_from_swap()` |
| 2 | `negotiate_with_makers_and_coordinate_sweep` fails | `generate_swap_report(Failed)` | `recover_from_swap()` |
| 3 | Negotiation succeeds | `generate_swap_report(Success)` | — |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swap reports now include error messages, network, incoming/outgoing contract TXIDs, multiple recovery TXIDs, and recovery duration.
  * Dedicated taker recovery reports added that record recovery status, recovered TXIDs, and duration.
  * Report files now use status-prefixed filenames with UTC timestamps; console output shows recovery duration.

* **Bug Fixes**
  * Failure reporting improved to emit diagnostics on early-error paths before recovery.
  * Fee/hop calculation refined and completed-hop logging clarified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->