### PR TITLE
test: replacing `nostr-rs-relay` crate with github aciton

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,13 +13,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [1,2,3,4,5,6,7,8,9,10]
+        partition: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
+      - name: Start up Nostr Relay
+        uses: hulxv/nostr-relay-action@v1.0.0
+        with:
+          version: "0.9.0"
+          port: "8000"
+          address: "127.0.0.1"
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Cache
         uses: actions/cache@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ crossbeam-channel = "0.5.15"
 [dev-dependencies]
 flate2 = {version = "1.0.35"}
 tar = {version = "0.4.43"}
-nostr-rs-relay = "0.8.12"
 
 #Empty default feature set, (helpful to generalise in github actions)
 [features]

--- a/tests/test_framework/mod.rs
+++ b/tests/test_framework/mod.rs
@@ -29,19 +29,17 @@ macro_rules! assert_in_range {
 
 use bip39::rand;
 use bitcoin::Amount;
-use nostr_rs_relay::{config, server::start_server};
 use std::{
     env,
     fs::{self, create_dir_all, File},
     io::{BufReader, Read},
-    net::TcpStream,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering::Relaxed},
-        mpsc, Arc, Mutex,
+        Arc, Mutex,
     },
     thread::{self, JoinHandle},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use flate2::read::GzDecoder;
@@ -535,8 +533,6 @@ pub struct TestFramework {
     pub(super) bitcoind: BitcoinD,
     pub(super) temp_dir: PathBuf,
     shutdown: AtomicBool,
-    nostr_relay_shutdown: mpsc::Sender<()>,
-    nostr_relay_handle: Option<JoinHandle<()>>,
     block_generation_handle: Mutex<Option<JoinHandle<()>>>,
     makers: Mutex<Option<Vec<Arc<Maker>>>>,
     taproot_makers: Mutex<Option<Vec<Arc<TaprootMaker>>>>, // Added
@@ -575,17 +571,11 @@ impl TestFramework {
 
         let bitcoind = init_bitcoind(&temp_dir, zmq_addr.clone());
 
-        log::info!("🌐 Spawning local nostr relay for tests");
-        let (nostr_relay_shutdown, nostr_relay_handle) = spawn_nostr_relay(&temp_dir);
-        _ = wait_for_relay_healthy();
-
         let shutdown = AtomicBool::new(false);
         let test_framework = Arc::new(Self {
             bitcoind,
             temp_dir: temp_dir.clone(),
             shutdown,
-            nostr_relay_shutdown,
-            nostr_relay_handle: Some(nostr_relay_handle),
             block_generation_handle: Mutex::new(None),
             makers: Mutex::new(None),
             taproot_makers: Mutex::new(None),
@@ -713,16 +703,11 @@ impl TestFramework {
 
         let bitcoind = init_bitcoind(&temp_dir, zmq_addr.clone());
 
-        log::info!("🌐 Spawning local nostr relay for tests");
-        let (nostr_relay_shutdown, nostr_relay_handle) = spawn_nostr_relay(&temp_dir);
-
         let shutdown = AtomicBool::new(false);
         let test_framework = Arc::new(Self {
             bitcoind,
             temp_dir: temp_dir.clone(),
             shutdown,
-            nostr_relay_shutdown,
-            nostr_relay_handle: Some(nostr_relay_handle),
             block_generation_handle: Mutex::new(None),
             makers: Mutex::new(None),
             taproot_makers: Mutex::new(None),
@@ -847,15 +832,6 @@ impl Drop for TestFramework {
         log::info!("Shutting down bitcoind...");
         let _ = self.bitcoind.client.stop().unwrap();
 
-        log::info!("Shutting down nostr relay...");
-        _ = self.nostr_relay_shutdown.send(());
-
-        if let Some(handle) = self.nostr_relay_handle.take() {
-            if let Err(e) = handle.join() {
-                log::error!("Nostr relay thread join failed: {:?}", e);
-            }
-        }
-
         log::info!("Test Framework cleanup complete.");
     }
 }
@@ -871,47 +847,4 @@ impl From<&TestFramework> for RPCConfig {
             ..Default::default()
         }
     }
-}
-
-fn spawn_nostr_relay(temp_dir: &Path) -> (mpsc::Sender<()>, JoinHandle<()>) {
-    let data_dir = temp_dir.join("nostr-relay");
-    std::fs::create_dir_all(&data_dir).unwrap();
-
-    let addr = "127.0.0.1".to_string();
-    let port = 8000;
-
-    let mut settings = config::Settings::default();
-    settings.network.address = addr;
-    settings.network.port = port;
-    settings.database.min_conn = 4;
-    settings.database.max_conn = 8;
-    settings.database.in_memory = true;
-    settings.diagnostics.tracing = true;
-
-    let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
-
-    let handle = thread::spawn(move || {
-        start_server(&settings, shutdown_rx).expect("nostr relay crashed");
-    });
-
-    (shutdown_tx, handle)
-}
-
-fn wait_for_relay_healthy() -> Result<(), String> {
-    let addr = "127.0.0.1:8000".to_string();
-    let timeout = Duration::from_secs(10);
-    let start = Instant::now();
-
-    while start.elapsed() < timeout {
-        if TcpStream::connect(&addr).is_ok() {
-            log::info!("Nostr relay is alive");
-            return Ok(());
-        }
-
-        std::thread::sleep(Duration::from_millis(50));
-    }
-
-    log::error!("Nostr relay not alive");
-
-    Err("nostr relay did not become healthy on port 8000".to_string())
 }


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a clear and concise description of what this PR does and why it is needed. -->
Currently, nostr-rs-relay doesn't have a release on crates.io for 0.9.0, so to bump it, we will use the binary directly and drop the crate from the source code. I worked on a GitHub action for it that contains the binaries of it and able us to run it inside the CI.

## Related Issue(s)
Closes #776
<!-- Add multiple lines if this PR closes multiple issues -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor / performance improvement
- [ ] Documentation update only
- [x] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [x] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [x] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [x] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [ ] All unit tests pass (`cargo test`)
- [ ] Integration tests pass (`cargo test --features integration-test`)
- [ ] Changes were manually tested on **regtest**
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

## How to Test
<!-- Step-by-step instructions so reviewers can verify quickly. -->

```bash
# Standard swap (good baseline)
cargo test --test standard_swap --features integration-test -- --nocapture

# Abort scenarios
cargo test --test abort1 --features integration-test -- --nocapture
cargo test --test taproot_taker_abort1 --features integration-test -- --nocapture

# Malicious behavior & recovery
cargo test --test malice1 --features integration-test -- --nocapture
cargo test --test taproot_timelock_recovery --features integration-test -- --nocapture

# Or run the full suite
cargo test --features integration-test
```

<!-- Add any additional manual steps specific to this PR
     (e.g. regtest node config, docker-setup, specific taker commands): -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified test framework by removing built-in relay startup, supervision, and teardown.

* **Chores**
  * Removed a development-only relay dependency to streamline dev builds.

* **CI**
  * Updated workflow to start an external relay service before checking out the repo, adjusted matrix formatting, and preserved coverage reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->