### PR TITLE
Add `get_tor_hostname(&self)` for MakerRpc trait

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -13,8 +13,8 @@ use crate::{
         Hash160,
     },
     utill::{
-        check_tor_status, get_maker_dir, redeemscript_to_scriptpubkey, BLOCK_DELAY,
-        HEART_BEAT_INTERVAL, REQUIRED_CONFIRMS,
+        check_tor_status, get_maker_dir, get_tor_hostname, redeemscript_to_scriptpubkey,
+        BLOCK_DELAY, HEART_BEAT_INTERVAL, REQUIRED_CONFIRMS,
     },
     wallet::{ffi::SwapReport, RPCConfig, SwapCoin, WalletSwapCoin},
     watch_tower::{
@@ -571,6 +571,14 @@ impl MakerRpc for Maker {
     }
     fn shutdown(&self) -> &AtomicBool {
         &self.shutdown
+    }
+    fn get_tor_hostname(&self) -> Result<String, crate::utill::TorError> {
+        get_tor_hostname(
+            &self.data_dir,
+            self.config.control_port,
+            self.config.network_port,
+            &self.config.tor_auth_password,
+        )
     }
 }
 

--- a/src/maker/api2.rs
+++ b/src/maker/api2.rs
@@ -19,7 +19,7 @@ use crate::{
             generate_partial_signature_compat, get_aggregated_nonce_compat,
         },
     },
-    utill::{check_tor_status, get_maker_dir, HEART_BEAT_INTERVAL, MIN_FEE_RATE},
+    utill::{check_tor_status, get_maker_dir, get_tor_hostname, HEART_BEAT_INTERVAL, MIN_FEE_RATE},
     wallet::{
         ffi::SwapReport, AddressType, Destination, IncomingSwapCoinV2, OutgoingSwapCoinV2,
         RPCConfig, Wallet, WalletError,
@@ -1103,6 +1103,14 @@ impl MakerRpc for Maker {
     }
     fn shutdown(&self) -> &AtomicBool {
         &self.shutdown
+    }
+    fn get_tor_hostname(&self) -> Result<String, crate::utill::TorError> {
+        get_tor_hostname(
+            &self.data_dir,
+            self.config.control_port,
+            self.config.network_port,
+            &self.config.tor_auth_password,
+        )
     }
 }
 

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -14,7 +14,7 @@ use bitcoin::{Address, Amount};
 use super::messages::RpcMsgReq;
 use crate::{
     maker::{config::MakerConfig, error::MakerError, rpc::messages::RpcMsgResp},
-    utill::{get_tor_hostname, read_message, send_message, HEART_BEAT_INTERVAL, UTXO},
+    utill::{read_message, send_message, TorError, HEART_BEAT_INTERVAL, UTXO},
     wallet::{AddressType, Destination, Wallet},
 };
 use std::{path::Path, str::FromStr, sync::RwLock};
@@ -24,6 +24,7 @@ pub trait MakerRpc {
     fn data_dir(&self) -> &Path;
     fn config(&self) -> &MakerConfig;
     fn shutdown(&self) -> &AtomicBool;
+    fn get_tor_hostname(&self) -> Result<String, TorError>;
 }
 
 fn handle_request<M: MakerRpc>(maker: &Arc<M>, socket: &mut TcpStream) -> Result<(), MakerError> {
@@ -115,12 +116,7 @@ fn handle_request<M: MakerRpc>(maker: &Arc<M>, socket: &mut TcpStream) -> Result
             if cfg!(feature = "integration-test") {
                 RpcMsgResp::GetTorAddressResp("Maker is not running on TOR".to_string())
             } else {
-                let hostname = get_tor_hostname(
-                    maker.data_dir(),
-                    maker.config().control_port,
-                    maker.config().network_port,
-                    &maker.config().tor_auth_password,
-                )?;
+                let hostname = maker.get_tor_hostname()?;
                 let address = format!("{}:{}", hostname, maker.config().network_port);
                 RpcMsgResp::GetTorAddressResp(address)
             }

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -4,7 +4,7 @@
 //! The server maintains the thread pool for P2P Connection, Watchtower, Bitcoin Backend, and RPC Client Request.
 //! The server listens at two ports: 6102 for P2P, and 6103 for RPC Client requests.
 
-use crate::protocol::messages::FidelityProof;
+use crate::{maker::rpc::server::MakerRpc, protocol::messages::FidelityProof};
 use bitcoin::{absolute::LockTime, Amount};
 use bitcoind::bitcoincore_rpc::RpcApi;
 
@@ -18,8 +18,6 @@ use std::{
     thread::{self, sleep},
     time::Duration,
 };
-
-use crate::utill::get_tor_hostname;
 
 pub(crate) use super::{api::RPC_PING_INTERVAL, Maker};
 
@@ -53,12 +51,7 @@ fn network_bootstrap(maker: Arc<Maker>) -> Result<String, MakerError> {
             format!("127.0.0.1:{maker_port}")
         } else {
             // Always Tor otherwise
-            let maker_hostname = get_tor_hostname(
-                maker.get_data_dir(),
-                maker.config.control_port,
-                maker_port,
-                &maker.config.tor_auth_password,
-            )?;
+            let maker_hostname = maker.get_tor_hostname()?;
             format!("{maker_hostname}:{maker_port}")
         }
     };

--- a/src/maker/server2.rs
+++ b/src/maker/server2.rs
@@ -26,11 +26,11 @@ use crate::{
         api::FIDELITY_BOND_UPDATE_INTERVAL,
         api2::{check_for_broadcasted_contracts, check_for_idle_states, ConnectionState},
         handlers2::handle_message_taproot,
-        rpc::start_rpc_server,
+        rpc::{server::MakerRpc, start_rpc_server},
     },
     nostr_coinswap::broadcast_bond_on_nostr,
     protocol::messages2::{MakerToTakerMessage, TakerToMakerMessage},
-    utill::{get_tor_hostname, read_message, send_message, HEART_BEAT_INTERVAL, MIN_FEE_RATE},
+    utill::{read_message, send_message, HEART_BEAT_INTERVAL, MIN_FEE_RATE},
     wallet::{AddressType, SwapReport, WalletError},
 };
 
@@ -47,12 +47,7 @@ fn network_bootstrap_taproot(maker: Arc<Maker>) -> Result<String, MakerError> {
         maker_address
     } else {
         // Always Tor in production
-        let maker_hostname = get_tor_hostname(
-            maker.data_dir(),
-            maker.config.control_port,
-            maker_port,
-            &maker.config.tor_auth_password,
-        )?;
+        let maker_hostname = maker.get_tor_hostname()?;
         let maker_address = format!("{maker_hostname}:{maker_port}");
         maker_address
     };


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a clear and concise description of what this PR does and why it is needed. -->

Add a `get_tor_hostname(&self)` as a member for the maker (legacy and taproot) as a wrapper for `get_tor_hostname`. We need it in the maker dashboard.

## Related Issue(s)
Closes #<!-- replace with issue number if applicable -->
<!-- Add multiple lines if this PR closes multiple issues -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [x] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [x] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [x] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [ ] All unit tests pass (`cargo test`)
- [ ] Integration tests pass (`cargo test --features integration-test`)
- [ ] Changes were manually tested on **regtest**
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

## How to Test
<!-- Step-by-step instructions so reviewers can verify quickly. -->

```bash
# Standard swap (good baseline)
cargo test --test standard_swap --features integration-test -- --nocapture

# Abort scenarios
cargo test --test abort1 --features integration-test -- --nocapture
cargo test --test taproot_taker_abort1 --features integration-test -- --nocapture

# Malicious behavior & recovery
cargo test --test malice1 --features integration-test -- --nocapture
cargo test --test taproot_timelock_recovery --features integration-test -- --nocapture

# Or run the full suite
cargo test --features integration-test
```

<!-- Add any additional manual steps specific to this PR
     (e.g. regtest node config, docker-setup, specific taker commands): -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced Maker RPC interface with a dedicated method to retrieve the Tor hostname, improving access to network configuration data through the RPC API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->