### PR TITLE
cleanup: remove redundant network port identifiers from maker logs an…

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -606,14 +606,18 @@ pub(crate) fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), M
                     if transaction_broadcasted {
                         // Something is broadcasted. Report, Recover and Abort.
                         log::warn!(
-                            "Contract txs broadcasted!! txid: {} Recovering from ongoing swaps.",
+                            "[Peer: {}] Contract txs broadcasted!! txid: {} Recovering from ongoing swaps.",
+                            ip,
                             txid
                         );
                         failed_swap_ip.push(ip.clone());
 
                         // Spawn a separate thread to wait for contract maturity and broadcasting timelocked/hashlocked.
                         let maker_clone = maker.clone();
-                        log::info!("Spawning recovery thread after seeing contracts in mempool",);
+                        log::info!(
+                            "[Peer: {}] Spawning recovery thread after seeing contracts in mempool.",
+                            ip
+                        );
 
                         let incomings = connection_state.incoming_swapcoins.clone();
                         let outgoings = connection_state.outgoing_swapcoins.clone();
@@ -688,13 +692,17 @@ pub(crate) fn check_for_idle_states(maker: Arc<Maker>) -> Result<(), MakerError>
 
                 if no_response_since > IDLE_CONNECTION_TIMEOUT {
                     log::error!(
-                        "Potential Dropped Connection from taker. No response since : {} secs. Recovering from swap",
+                        "[Peer: {}] Potential Dropped Connection from taker. No response since : {} secs. Recovering from swap",
+                        ip,
                         no_response_since.as_secs()
                     );
                     bad_ip.push(ip.clone());
                     // Spawn a separate thread to wait for contract maturity and broadcasting timelocked,hashlocked
                     let maker_clone = maker.clone();
-                    log::info!("Spawning recovery thread after Taker dropped",);
+                    log::info!(
+                        "[Peer: {}] Spawning recovery thread after Taker dropped",
+                        ip
+                    );
 
                     let incomings = state.incoming_swapcoins.clone();
                     let outgoings = state.outgoing_swapcoins.clone();
@@ -744,8 +752,14 @@ pub(crate) fn recover_from_swap(
         .map_err(WalletError::Rpc)? as u32;
     let timelock_expiry = start_height.saturating_add(timelock);
 
+    let anchor_txid = outgoing_swapcoins
+        .first()
+        .map(|o| o.contract_tx.compute_txid().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
     log::info!(
-        "recover_from_swap started | height={} timelock_expiry={}",
+        "[Contract: {}] recover_from_swap started | height={} timelock_expiry={}",
+        anchor_txid,
         start_height,
         timelock_expiry
     );
@@ -805,8 +819,14 @@ fn recover_via_hashlock(
             .wallet
             .write()?
             .spend_from_hashlock_contract(&infos, &maker.watch_service)?;
+
+        let anchor_id = incoming
+            .first()
+            .map(|c| c.contract_tx.compute_txid().to_string())
+            .unwrap_or_default();
         log::info!(
-            "Maker hashlock recovery: {}/{} txs broadcasted",
+            "[Contract: {}] Maker hashlock recovery: {}/{} txs broadcasted",
+            anchor_id,
             broadcasted.len(),
             incoming.len()
         );
@@ -859,8 +879,14 @@ fn recover_via_timelock(
             .wallet
             .write()?
             .spend_from_timelock_contract(&infos, &maker.watch_service)?;
+
+        let anchor_id = outgoing
+            .first()
+            .map(|c| c.contract_tx.compute_txid().to_string())
+            .unwrap_or_default();
         log::info!(
-            "Maker timelock recovery: {}/{} txs broadcasted",
+            "[Contract: {}] Maker timelock recovery: {}/{} txs broadcasted",
+            anchor_id,
             broadcasted.len(),
             outgoing.len()
         );

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -818,7 +818,7 @@ fn recover_via_hashlock(
         .first()
         .map(|c| c.contract_tx.compute_txid().to_string())
         .unwrap_or_default();
-        
+
     while !maker.shutdown.load(Relaxed) {
         let broadcasted = maker
             .wallet
@@ -871,15 +871,15 @@ fn recover_via_timelock(
     outgoing: Vec<OutgoingSwapCoin>,
 ) -> Result<(), MakerError> {
     let infos = maker
-    .wallet
-    .write()?
-    .broadcast_outgoing_contracts(outgoing.clone())?;
-    
+        .wallet
+        .write()?
+        .broadcast_outgoing_contracts(outgoing.clone())?;
+
     let anchor_id = outgoing
         .first()
         .map(|c| c.contract_tx.compute_txid().to_string())
         .unwrap_or_default();
-
+        
     while !maker.shutdown.load(Relaxed) {
         let broadcasted = maker
             .wallet

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -814,16 +814,17 @@ fn recover_via_hashlock(
         .write()?
         .broadcast_incoming_contracts(incoming.clone())?;
 
+    let anchor_id = incoming
+        .first()
+        .map(|c| c.contract_tx.compute_txid().to_string())
+        .unwrap_or_default();
+        
     while !maker.shutdown.load(Relaxed) {
         let broadcasted = maker
             .wallet
             .write()?
             .spend_from_hashlock_contract(&infos, &maker.watch_service)?;
 
-        let anchor_id = incoming
-            .first()
-            .map(|c| c.contract_tx.compute_txid().to_string())
-            .unwrap_or_default();
         log::info!(
             "[Contract: {}] Maker hashlock recovery: {}/{} txs broadcasted",
             anchor_id,
@@ -870,9 +871,14 @@ fn recover_via_timelock(
     outgoing: Vec<OutgoingSwapCoin>,
 ) -> Result<(), MakerError> {
     let infos = maker
-        .wallet
-        .write()?
-        .broadcast_outgoing_contracts(outgoing.clone())?;
+    .wallet
+    .write()?
+    .broadcast_outgoing_contracts(outgoing.clone())?;
+    
+    let anchor_id = outgoing
+        .first()
+        .map(|c| c.contract_tx.compute_txid().to_string())
+        .unwrap_or_default();
 
     while !maker.shutdown.load(Relaxed) {
         let broadcasted = maker
@@ -880,10 +886,6 @@ fn recover_via_timelock(
             .write()?
             .spend_from_timelock_contract(&infos, &maker.watch_service)?;
 
-        let anchor_id = outgoing
-            .first()
-            .map(|c| c.contract_tx.compute_txid().to_string())
-            .unwrap_or_default();
         log::info!(
             "[Contract: {}] Maker timelock recovery: {}/{} txs broadcasted",
             anchor_id,

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -175,14 +175,12 @@ pub(crate) struct ConnectionState {
 
 pub(crate) struct ThreadPool {
     pub(crate) threads: Mutex<Vec<JoinHandle<()>>>,
-    pub(crate) port: u16,
 }
 
 impl ThreadPool {
-    pub(crate) fn new(port: u16) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             threads: Mutex::new(Vec::new()),
-            port,
         }
     }
 
@@ -196,31 +194,22 @@ impl ThreadPool {
             .threads
             .lock()
             .map_err(|_| MakerError::General("Failed to lock threads"))?;
-
         log::info!("Joining {} threads", threads.len());
 
         let mut joined_count = 0;
         while let Some(thread) = threads.pop() {
-            let thread_name = thread.thread().name().unwrap().to_string();
-            println!("joining thread: {thread_name}");
-
+            let thread_name = thread.thread().name().unwrap_or("unknown").to_string();
             match thread.join() {
                 Ok(_) => {
-                    log::info!("[{}] Thread {} joined", self.port, thread_name);
+                    log::info!("Thread {} joined", thread_name);
                     joined_count += 1;
                 }
                 Err(e) => {
-                    log::error!(
-                        "[{}] Error {:?} while joining thread {}",
-                        self.port,
-                        e,
-                        thread_name
-                    );
+                    log::error!("Error {:?} while joining thread {}", e, thread_name);
                 }
             }
         }
-
-        log::info!("Successfully joined {joined_count} threads",);
+        log::info!("Successfully joined {joined_count} threads");
         Ok(())
     }
 }
@@ -324,8 +313,6 @@ impl Maker {
         log::info!("Sync at:----Maker init----");
         wallet.sync_and_save()?;
 
-        let network_port = config.network_port;
-
         Ok(Self {
             behavior,
             config,
@@ -335,7 +322,7 @@ impl Maker {
             highest_fidelity_proof: RwLock::new(None),
             is_setup_complete: AtomicBool::new(false),
             data_dir,
-            thread_pool: Arc::new(ThreadPool::new(network_port)),
+            thread_pool: Arc::new(ThreadPool::new()),
             watch_service,
         })
     }
@@ -619,18 +606,14 @@ pub(crate) fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), M
                     if transaction_broadcasted {
                         // Something is broadcasted. Report, Recover and Abort.
                         log::warn!(
-                            "[{}] Contract txs broadcasted!! txid: {} Recovering from ongoing swaps.",
-                            maker.config.network_port,
+                            "Contract txs broadcasted!! txid: {} Recovering from ongoing swaps.",
                             txid
                         );
                         failed_swap_ip.push(ip.clone());
 
                         // Spawn a separate thread to wait for contract maturity and broadcasting timelocked/hashlocked.
                         let maker_clone = maker.clone();
-                        log::info!(
-                            "[{}] Spawning recovery thread after seeing contracts in mempool",
-                            maker.config.network_port
-                        );
+                        log::info!("Spawning recovery thread after seeing contracts in mempool",);
 
                         let incomings = connection_state.incoming_swapcoins.clone();
                         let outgoings = connection_state.outgoing_swapcoins.clone();
@@ -705,17 +688,13 @@ pub(crate) fn check_for_idle_states(maker: Arc<Maker>) -> Result<(), MakerError>
 
                 if no_response_since > IDLE_CONNECTION_TIMEOUT {
                     log::error!(
-                        "[{}] Potential Dropped Connection from taker. No response since : {} secs. Recovering from swap",
-                        maker.config.network_port,
+                        "Potential Dropped Connection from taker. No response since : {} secs. Recovering from swap",
                         no_response_since.as_secs()
                     );
                     bad_ip.push(ip.clone());
                     // Spawn a separate thread to wait for contract maturity and broadcasting timelocked,hashlocked
                     let maker_clone = maker.clone();
-                    log::info!(
-                        "[{}] Spawning recovery thread after Taker dropped",
-                        maker.config.network_port
-                    );
+                    log::info!("Spawning recovery thread after Taker dropped",);
 
                     let incomings = state.incoming_swapcoins.clone();
                     let outgoings = state.outgoing_swapcoins.clone();
@@ -766,8 +745,7 @@ pub(crate) fn recover_from_swap(
     let timelock_expiry = start_height.saturating_add(timelock);
 
     log::info!(
-        "[{}] recover_from_swap started | height={} timelock_expiry={}",
-        maker.config.network_port,
+        "recover_from_swap started | height={} timelock_expiry={}",
         start_height,
         timelock_expiry
     );
@@ -782,8 +760,7 @@ pub(crate) fn recover_from_swap(
 
         if current_height >= timelock_expiry {
             log::info!(
-                "[{}] timelock expired at {} (expiry={}), using timelock path",
-                maker.config.network_port,
+                "timelock expired at {} (expiry={}), using timelock path",
                 current_height,
                 timelock_expiry
             );
@@ -802,8 +779,7 @@ pub(crate) fn recover_from_swap(
 
         if all_preimages_known {
             log::info!(
-                "[{}] all preimages known at height {}, using hashlock path",
-                maker.config.network_port,
+                "all preimages known at height {}, using hashlock path",
                 current_height
             );
             return recover_via_hashlock(maker, incoming_swapcoins);
@@ -830,8 +806,7 @@ fn recover_via_hashlock(
             .write()?
             .spend_from_hashlock_contract(&infos, &maker.watch_service)?;
         log::info!(
-            "[{}] Maker hashlock recovery: {}/{} txs broadcasted",
-            maker.config.network_port,
+            "Maker hashlock recovery: {}/{} txs broadcasted",
             broadcasted.len(),
             incoming.len()
         );
@@ -885,8 +860,7 @@ fn recover_via_timelock(
             .write()?
             .spend_from_timelock_contract(&infos, &maker.watch_service)?;
         log::info!(
-            "[{}] Maker timelock recovery: {}/{} txs broadcasted",
-            maker.config.network_port,
+            "Maker timelock recovery: {}/{} txs broadcasted",
             broadcasted.len(),
             outgoing.len()
         );
@@ -943,11 +917,7 @@ fn check_for_watch_response(
     }
 
     for transaction in responses {
-        log::info!(
-            "[{}] Received WatchResponse with mempool txs: {:?}",
-            maker.config.network_port,
-            transaction
-        );
+        log::info!("Received WatchResponse with mempool txs: {:?}", transaction);
 
         for input in &transaction.input {
             let outpoint = (input.previous_output.txid, input.previous_output.vout);
@@ -1001,8 +971,7 @@ fn update_swapcoins_with_preimages<T: SwapCoin>(
                 let redeemscript = coin.get_multisig_redeemscript();
                 if apply_preimage(&redeemscript, *preimage) {
                     log::info!(
-                        "[{}] Applied preimage for {} swapcoin {:?}",
-                        maker.config.network_port,
+                        "Applied preimage for {} swapcoin {:?}",
                         if is_incoming { "incoming" } else { "outgoing" },
                         redeemscript
                     );

--- a/src/maker/api2.rs
+++ b/src/maker/api2.rs
@@ -182,14 +182,12 @@ impl Clone for ConnectionState {
 
 pub(crate) struct ThreadPool {
     pub(crate) threads: Mutex<Vec<JoinHandle<()>>>,
-    pub(crate) port: u16,
 }
 
 impl ThreadPool {
-    pub(crate) fn new(port: u16) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             threads: Mutex::new(Vec::new()),
-            port,
         }
     }
 
@@ -204,30 +202,22 @@ impl ThreadPool {
             .threads
             .lock()
             .map_err(|_| MakerError::General("Failed to lock threads"))?;
-
         log::info!("Joining {} threads", threads.len());
 
         let mut joined_count = 0;
         while let Some(thread) = threads.pop() {
             let thread_name = thread.thread().name().unwrap_or("unknown").to_string();
-
             match thread.join() {
                 Ok(_) => {
-                    log::info!("[{}] Thread {} joined", self.port, thread_name);
+                    log::info!("Thread {} joined", thread_name);
                     joined_count += 1;
                 }
                 Err(e) => {
-                    log::error!(
-                        "[{}] Error {:?} while joining thread {}",
-                        self.port,
-                        e,
-                        thread_name
-                    );
+                    log::error!("Error {:?} while joining thread {}", e, thread_name);
                 }
             }
         }
-
-        log::info!("Successfully joined {joined_count} threads",);
+        log::info!("Successfully joined {joined_count} threads");
         Ok(())
     }
 }
@@ -327,8 +317,6 @@ impl Maker {
         log::info!("Sync at:----Maker init----");
         wallet.sync_and_save()?;
 
-        let network_port = config.network_port;
-
         Ok(Self {
             config,
             wallet: RwLock::new(wallet),
@@ -337,7 +325,7 @@ impl Maker {
             highest_fidelity_proof: RwLock::new(None),
             is_setup_complete: AtomicBool::new(false),
             data_dir,
-            thread_pool: Arc::new(ThreadPool::new(network_port)),
+            thread_pool: Arc::new(ThreadPool::new()),
             watch_service,
             #[cfg(feature = "integration-test")]
             behavior: behavior.unwrap_or(MakerBehavior::Normal),
@@ -508,11 +496,7 @@ impl Maker {
                 .rpc
                 .lock_unspent(&funding_outpoints)
                 .map_err(WalletError::Rpc)?;
-            log::info!(
-                "[{}] Locked {} funding UTXOs for swap",
-                self.config.network_port,
-                funding_outpoints.len()
-            );
+            log::info!("Locked {} funding UTXOs for swap", funding_outpoints.len());
 
             (outgoing_privkey, selected_utxos)
         };
@@ -736,8 +720,7 @@ impl Maker {
         #[cfg(feature = "integration-test")]
         if self.behavior == MakerBehavior::CloseAtPrivateKeyHandover {
             log::warn!(
-                "[{}] Maker behavior: CloseAtPrivateKeyHandover - Closing connection before sweep",
-                self.config.network_port
+                "Maker behavior: CloseAtPrivateKeyHandover - Closing connection before sweep",
             );
             return Err(MakerError::General(
                 "Maker closing connection before PrivateKeyHandover (test behavior)",
@@ -746,10 +729,7 @@ impl Maker {
 
         // Create the spending transaction if it doesn't exist
         if connection_state.incoming_contract.spending_tx().is_none() {
-            log::info!(
-                "[{}] Creating spending transaction for incoming contract",
-                self.config.network_port
-            );
+            log::info!("Creating spending transaction for incoming contract",);
             let tx = self.create_unsigned_spending_tx(connection_state)?;
             connection_state.incoming_contract.spending_tx = Some(tx);
         }
@@ -884,11 +864,7 @@ impl Maker {
             .send_raw_transaction(completed_tx.raw_hex())
             .map_err(|e| MakerError::Wallet(crate::wallet::WalletError::Rpc(e)))?;
 
-        log::info!(
-            "[{}] Maker sweep transaction broadcasted with txid: {:?}",
-            self.config.network_port,
-            txid
-        );
+        log::info!("Maker sweep transaction broadcasted with txid: {:?}", txid);
 
         // generate and save success report
         let incoming_contract_txid = connection_state
@@ -941,10 +917,7 @@ impl Maker {
         // Check for test behavior: close connection after sweeping
         #[cfg(feature = "integration-test")]
         if self.behavior == MakerBehavior::CloseAfterSweep {
-            log::warn!(
-                "[{}] Maker behavior: CloseAfterSweep - Closing connection after sweep",
-                self.config.network_port
-            );
+            log::warn!("Maker behavior: CloseAfterSweep - Closing connection after sweep",);
             return Err(MakerError::General(
                 "Maker closing connection after sweep (test behavior)",
             ));
@@ -983,8 +956,7 @@ impl Maker {
 
             wallet.remove_incoming_swapcoin_v2(&incoming_txid);
             log::info!(
-                "[{}] Removed incoming swapcoin {} after successful sweep",
-                self.config.network_port,
+                "Removed incoming swapcoin {} after successful sweep",
                 incoming_txid
             );
             // Sync to update utxo_cache with the swept UTXO so it's classified as SweptCoin
@@ -1008,8 +980,7 @@ impl Maker {
         let incoming_contract_txid = connection_state.incoming_contract.contract_txid()?;
 
         log::info!(
-            "[{}] Creating unsigned spending tx for incoming contract: {}",
-            self.config.network_port,
+            "Creating unsigned spending tx for incoming contract: {}",
             incoming_contract_txid
         );
 
@@ -1058,8 +1029,7 @@ impl Maker {
         };
 
         log::info!(
-            "[{}] Created unsigned spending tx with output value: {}",
-            self.config.network_port,
+            "Created unsigned spending tx with output value: {}",
             contract_value - Amount::from_sat(1000)
         );
 
@@ -1165,8 +1135,7 @@ pub(crate) fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), M
 
                 if outgoing_spent {
                     log::warn!(
-                        "[{}] Outgoing contract {} has been SPENT! Triggering recovery for swap {}",
-                        maker.config.network_port,
+                        "Outgoing contract {} has been SPENT! Triggering recovery for swap {}",
                         outgoing_txid,
                         swap_id
                     );
@@ -1176,10 +1145,7 @@ pub(crate) fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), M
                     let outgoing = connection_state.outgoing_contract.clone();
                     let maker_clone = maker.clone();
 
-                    log::info!(
-                        "[{}] Spawning recovery thread after detecting outgoing contract spend",
-                        maker.config.network_port
-                    );
+                    log::info!("Spawning recovery thread after detecting outgoing contract spend",);
 
                     let handle = std::thread::Builder::new()
                         .name("Taproot Contract Recovery Thread".to_string())
@@ -1214,8 +1180,7 @@ pub(crate) fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), M
 
                 if incoming_spent {
                     log::warn!(
-                        "[{}] Incoming contract {} has been SPENT! Triggering recovery for swap with {}",
-                        maker.config.network_port,
+                        "Incoming contract {} has been SPENT! Triggering recovery for swap with {}",
                         incoming_txid,
                         swap_id
                     );
@@ -1225,10 +1190,7 @@ pub(crate) fn check_for_broadcasted_contracts(maker: Arc<Maker>) -> Result<(), M
                     let outgoing = connection_state.outgoing_contract.clone();
                     let maker_clone = maker.clone();
 
-                    log::info!(
-                        "[{}] Spawning recovery thread after detecting incoming contract spend",
-                        maker.config.network_port
-                    );
+                    log::info!("Spawning recovery thread after detecting incoming contract spend",);
 
                     let handle = std::thread::Builder::new()
                         .name("Taproot Contract Recovery Thread".to_string())
@@ -1270,8 +1232,7 @@ pub(crate) fn check_for_idle_states(maker: Arc<Maker>) -> Result<(), MakerError>
             for (swap_id, (state, instant)) in lock_on_state.iter_mut() {
                 if instant.elapsed() > IDLE_CONNECTION_TIMEOUT {
                     log::error!(
-                        "[{}] Potential dropped connection from taker {}. No response since {} secs. Recovering from swap.",
-                        maker.config.network_port,
+                        "Potential dropped connection from taker {}. No response since {} secs. Recovering from swap.",
                         swap_id,
                         instant.elapsed().as_secs()
                     );
@@ -1285,11 +1246,7 @@ pub(crate) fn check_for_idle_states(maker: Arc<Maker>) -> Result<(), MakerError>
                         let outgoing = state.outgoing_contract.clone();
                         let maker_clone = maker.clone();
 
-                        log::info!(
-                            "[{}] Spawning recovery thread after taker {} dropped",
-                            maker.config.network_port,
-                            swap_id
-                        );
+                        log::info!("Spawning recovery thread after taker {} dropped", swap_id);
 
                         // Spawn recovery thread
                         let handle = std::thread::Builder::new()
@@ -1330,8 +1287,7 @@ pub(crate) fn restore_broadcasted_contracts_on_reboot_v2(
         maker.wallet.read()?.find_unfinished_swapcoins_v2();
 
     log::info!(
-        "[{}] Found {} unfinished incoming and {} unfinished outgoing taproot swapcoins on reboot",
-        maker.config.network_port,
+        "Found {} unfinished incoming and {} unfinished outgoing taproot swapcoins on reboot",
         incoming_swapcoins.len(),
         outgoing_swapcoins.len()
     );
@@ -1340,8 +1296,7 @@ pub(crate) fn restore_broadcasted_contracts_on_reboot_v2(
     for incoming in incoming_swapcoins.iter() {
         let Some(ref incoming_swap_id) = incoming.swap_id else {
             log::warn!(
-                "[{}] Incoming swapcoin {} has no swap_id, skipping",
-                maker.config.network_port,
+                "Incoming swapcoin {} has no swap_id, skipping",
                 incoming.contract_tx.compute_txid()
             );
             continue;
@@ -1357,8 +1312,7 @@ pub(crate) fn restore_broadcasted_contracts_on_reboot_v2(
             let incoming_txid = incoming.contract_tx.compute_txid();
 
             log::info!(
-                "[{}] Orphaned incoming swapcoin {} (swap_id={}) has no matching outgoing. Maker has no funds at risk. Cleaning up stale entry.",
-                maker.config.network_port,
+                "Orphaned incoming swapcoin {} (swap_id={}) has no matching outgoing. Maker has no funds at risk. Cleaning up stale entry.",
                 incoming_txid,
                 incoming_swap_id
             );
@@ -1370,8 +1324,7 @@ pub(crate) fn restore_broadcasted_contracts_on_reboot_v2(
         };
 
         log::info!(
-            "[{}] Spawning recovery thread for swap_id={} (incoming={}, outgoing={})",
-            maker.config.network_port,
+            "Spawning recovery thread for swap_id={} (incoming={}, outgoing={})",
             incoming_swap_id,
             incoming.contract_tx.compute_txid(),
             outgoing.contract_tx.compute_txid()
@@ -1412,9 +1365,10 @@ pub(crate) fn recover_from_swap(
 
     let outgoing_contract_txid = outgoing_swapcoin.contract_tx.compute_txid();
 
+    let id = incoming_swapcoin.swap_id.as_deref().unwrap_or("unknown");
     log::info!(
-        "[{}] Taproot recover_from_swap started for outgoing contract {}",
-        maker.config.network_port,
+        "[Swap: {}] Taproot recover_from_swap started for outgoing contract {}",
+        id,
         outgoing_contract_txid
     );
 
@@ -1446,8 +1400,7 @@ pub(crate) fn recover_from_swap(
             // and we already claimed the incoming contract via key-path. No recovery needed.
             if incoming_swapcoin.other_privkey.is_some() {
                 log::info!(
-                    "[{}] Incoming contract {} already spent via key-path (swap succeeded). Recovery not needed.",
-                    maker.config.network_port,
+                    "Incoming contract {} already spent via key-path (swap succeeded). Recovery not needed.",
                     incoming_contract_txid
                 );
                 // Stop watching the outgoing contract
@@ -1458,8 +1411,7 @@ pub(crate) fn recover_from_swap(
             // If we don't have other_privkey, the taker used timelock recovery on the incoming
             // contract. We must recover our funds from the outgoing contract via timelock.
             log::warn!(
-                "[{}] Incoming contract {} was spent by taker via timelock (no key exchange). We must recover our outgoing contract.",
-                maker.config.network_port,
+                "Incoming contract {} was spent by taker via timelock (no key exchange). We must recover our outgoing contract.",
                 incoming_contract_txid
             );
             // Continue to timelock recovery for our outgoing contract below
@@ -1473,18 +1425,12 @@ pub(crate) fn recover_from_swap(
                 ..
             }) = maker.watch_service.poll_event()
             {
-                log::info!(
-                    "[{}] Detected spend of outgoing contract, attempting to extract preimage",
-                    maker.config.network_port
-                );
+                log::info!("Detected spend of outgoing contract, attempting to extract preimage",);
                 // Try to extract preimage from witness
                 if let Some(preimage) =
                     crate::protocol::contract2::extract_preimage_from_spending_tx(&spending_tx)
                 {
-                    log::info!(
-                        "[{}] Successfully extracted preimage from outgoing contract spend",
-                        maker.config.network_port
-                    );
+                    log::info!("Successfully extracted preimage from outgoing contract spend",);
                     incoming_swapcoin.hash_preimage = Some(preimage);
                 }
             }
@@ -1492,10 +1438,7 @@ pub(crate) fn recover_from_swap(
 
         // Check if we have the preimage for hashlock recovery (prioritize this over timelock)
         if incoming_swapcoin.hash_preimage.is_some() {
-            log::info!(
-                "[{}] Preimage available, recovering incoming contract via hashlock",
-                maker.config.network_port
-            );
+            log::info!("Preimage available, recovering incoming contract via hashlock",);
             // Stop watching the outgoing contract before recovery
             maker.watch_service.unwatch(outgoing_outpoint);
             return recover_via_hashlock(maker, incoming_swapcoin);
@@ -1516,8 +1459,7 @@ pub(crate) fn recover_from_swap(
             // The taker may have spent it via hashlock, in which case we should extract preimage
             if incoming_swapcoin.hash_preimage.is_none() {
                 log::info!(
-                    "[{}] Timelock expired, doing final check for outgoing contract spend before timelock recovery",
-                    maker.config.network_port
+                    "Timelock expired, doing final check for outgoing contract spend before timelock recovery",
                 );
 
                 // Check if outgoing contract is spent by checking if the UTXO exists
@@ -1532,8 +1474,7 @@ pub(crate) fn recover_from_swap(
 
                 if outgoing_spent {
                     log::info!(
-                        "[{}] Outgoing contract already spent, attempting to extract preimage from blockchain",
-                        maker.config.network_port
+                        "Outgoing contract already spent, attempting to extract preimage from blockchain",
                     );
 
                     // Try to get spending transaction via watcher
@@ -1549,8 +1490,7 @@ pub(crate) fn recover_from_swap(
                             )
                         {
                             log::info!(
-                                "[{}] Successfully extracted preimage from spent outgoing contract",
-                                maker.config.network_port
+                                "Successfully extracted preimage from spent outgoing contract",
                             );
                             incoming_swapcoin.hash_preimage = Some(preimage);
                             // Stop watching and recover incoming via hashlock
@@ -1562,18 +1502,14 @@ pub(crate) fn recover_from_swap(
                     // If we couldn't extract preimage but outgoing is spent, maker already swept
                     // their incoming during the swap, so they have recovered their funds
                     log::warn!(
-                        "[{}] Outgoing contract spent but couldn't extract preimage. Maker should have already swept incoming.",
-                        maker.config.network_port
+                        "Outgoing contract spent but couldn't extract preimage. Maker should have already swept incoming.",
                     );
                     maker.watch_service.unwatch(outgoing_outpoint);
                     return Ok(());
                 }
             }
 
-            log::info!(
-                "[{}] Timelock matured, recovering outgoing contract via timelock",
-                maker.config.network_port
-            );
+            log::info!("Timelock matured, recovering outgoing contract via timelock",);
             maker.watch_service.unwatch(outgoing_outpoint);
             return recover_via_timelock(maker, outgoing_swapcoin);
         }
@@ -1586,10 +1522,7 @@ pub(crate) fn recover_from_swap(
 
 /// Recover incoming contract via hashlock script-path spend.
 fn recover_via_hashlock(maker: Arc<Maker>, incoming: IncomingSwapCoinV2) -> Result<(), MakerError> {
-    log::info!(
-        "[{}] Starting hashlock recovery for incoming contract",
-        maker.config.network_port
-    );
+    log::info!("Starting hashlock recovery for incoming contract",);
 
     let incoming_contract_txid = incoming.contract_tx.compute_txid();
     let incoming_amount = incoming.funding_amount.to_sat();
@@ -1613,8 +1546,7 @@ fn recover_via_hashlock(maker: Arc<Maker>, incoming: IncomingSwapCoinV2) -> Resu
                 match wallet.spend_via_hashlock_v2(&incoming, &preimage, &maker.watch_service) {
                     Ok(txid) => {
                         log::info!(
-                            "[{}] Maker Successfully recovered incoming contract via hashlock: {}",
-                            maker.config.network_port,
+                            "Maker Successfully recovered incoming contract via hashlock: {}",
                             txid
                         );
 
@@ -1639,19 +1571,12 @@ fn recover_via_hashlock(maker: Arc<Maker>, incoming: IncomingSwapCoinV2) -> Resu
                         Some(Ok(()))
                     }
                     Err(e) => {
-                        log::error!(
-                            "[{}] Failed to recover via hashlock: {:?}",
-                            maker.config.network_port,
-                            e
-                        );
+                        log::error!("Failed to recover via hashlock: {:?}", e);
                         Some(Err(MakerError::Wallet(e)))
                     }
                 }
             } else {
-                log::warn!(
-                    "[{}] Preimage not available yet, waiting...",
-                    maker.config.network_port
-                );
+                log::warn!("Preimage not available yet, waiting...",);
                 None
             }
         };
@@ -1670,10 +1595,7 @@ fn recover_via_hashlock(maker: Arc<Maker>, incoming: IncomingSwapCoinV2) -> Resu
 
 /// Recover outgoing contract via timelock script-path spend.
 fn recover_via_timelock(maker: Arc<Maker>, outgoing: OutgoingSwapCoinV2) -> Result<(), MakerError> {
-    log::info!(
-        "[{}] Starting timelock recovery for outgoing contract",
-        maker.config.network_port
-    );
+    log::info!("Starting timelock recovery for outgoing contract",);
 
     let outgoing_contract_txid = outgoing.contract_tx.compute_txid();
     let outgoing_amount = outgoing.funding_amount.to_sat();
@@ -1696,8 +1618,7 @@ fn recover_via_timelock(maker: Arc<Maker>, outgoing: OutgoingSwapCoinV2) -> Resu
             match wallet.spend_via_timelock_v2(&outgoing, &maker.watch_service) {
                 Ok(txid) => {
                     log::info!(
-                        "[{}] Maker Successfully recovered outgoing contract via timelock: {}",
-                        maker.config.network_port,
+                        "Maker Successfully recovered outgoing contract via timelock: {}",
                         txid
                     );
 
@@ -1721,11 +1642,7 @@ fn recover_via_timelock(maker: Arc<Maker>, outgoing: OutgoingSwapCoinV2) -> Resu
                     Some(Ok(()))
                 }
                 Err(e) => {
-                    log::error!(
-                        "[{}] Failed to recover via timelock: {:?}",
-                        maker.config.network_port,
-                        e
-                    );
+                    log::error!("Failed to recover via timelock: {:?}", e);
                     Some(Err(MakerError::Wallet(e)))
                 }
             }

--- a/src/maker/api2.rs
+++ b/src/maker/api2.rs
@@ -1068,6 +1068,23 @@ impl Maker {
 
         Ok(())
     }
+
+    /// Sweep incoming taproot swapcoins after successful coinswap
+    pub fn sweep_after_successful_coinswap(&self) -> Result<(), MakerError> {
+        let swept_txids = self
+            .wallet
+            .write()?
+            .sweep_incoming_swapcoins(MIN_FEE_RATE)?; 
+            
+        if !swept_txids.is_empty() {
+            log::info!(
+                "Successfully swept {} taproot incoming swap coins: {:?}",
+                swept_txids.len(),
+                swept_txids
+            );
+        }
+        Ok(())
+    }
 }
 
 impl MakerRpc for Maker {

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -54,10 +54,7 @@ pub(crate) fn handle_message(
 ) -> Result<Option<MakerToTakerMessage>, MakerError> {
     // If taker is waiting for funding confirmation, reset the timer.
     if let TakerToMakerMessage::WaitingFundingConfirmation(id) = &message {
-        log::info!(
-            "[{}] Taker is waiting for funding confirmation. Resetting timer.",
-            maker.config.network_port
-        );
+        log::info!("Taker is waiting for funding confirmation. Resetting timer.",);
         maker
             .ongoing_swap_state
             .lock()?
@@ -252,8 +249,7 @@ impl Maker {
         });
 
         log::info!(
-            "[{}] Total Funding Amount = {} | Funding Txids = {:?}",
-            self.config.network_port,
+            "Total Funding Amount = {} | Funding Txids = {:?}",
             Amount::from_sat(total_funding_amount),
             funding_txids
         );
@@ -286,8 +282,7 @@ impl Maker {
                 .collect();
 
             log::debug!(
-                "[{}] Reserved {} UTXOs for swap",
-                self.config.network_port,
+                "Reserved {} UTXOs for swap",
                 connection_state.reserve_utxo.len(),
             );
 
@@ -297,11 +292,7 @@ impl Maker {
             );
         }
 
-        log::info!(
-            "[{}] Inserted state for swap id: {}",
-            self.config.network_port,
-            message.id
-        );
+        log::info!("Inserted state for swap id: {}", message.id);
 
         let max_size = self.wallet.read()?.store.offer_maxsize;
         if total_funding_amount >= self.config.min_swap_amount && total_funding_amount <= max_size {
@@ -333,10 +324,7 @@ impl Maker {
         // Basic verification of ProofOfFunding Message.
         // Check function definition for all the checks performed.
         let hashvalue = self.verify_proof_of_funding(&message)?;
-        log::info!(
-            "[{}] Validated Proof of Funding of receiving swap. Adding Incoming Swaps.",
-            self.config.network_port
-        );
+        log::info!("Validated Proof of Funding of receiving swap. Adding Incoming Swaps.",);
 
         // Import transactions and addresses into Bitcoin core's wallet.
         // Add IncomingSwapcoin to Maker's Wallet
@@ -479,8 +467,7 @@ impl Maker {
             .expect("This should not overflow as we just checked above.");
 
         log::info!(
-            "[{}] Prepared outgoing funding txs: {:?}.",
-            self.config.network_port,
+            "Prepared outgoing funding txs: {:?}.",
             my_funding_txes
                 .iter()
                 .map(|tx| tx.compute_txid())
@@ -488,8 +475,7 @@ impl Maker {
         );
 
         log::info!(
-            "[{}] Incoming Swap Amount = {} | Outgoing Swap Amount = {} | Coinswap Fee = {} |   Refund Tx locktime (blocks) = {} | Total Funding Tx Mining Fees = {}",
-            self.config.network_port,
+            "Incoming Swap Amount = {} | Outgoing Swap Amount = {} | Coinswap Fee = {} |   Refund Tx locktime (blocks) = {} | Total Funding Tx Mining Fees = {}",
             Amount::from_sat(incoming_amount),
             Amount::from_sat(outgoing_amount),
             Amount::from_sat(act_coinswap_fees),
@@ -621,11 +607,7 @@ impl Maker {
             assert_eq!(txid, my_funding_tx.compute_txid());
             my_funding_txids.push(txid);
         }
-        log::info!(
-            "[{}] Broadcasted funding txs: {:?}",
-            self.config.network_port,
-            my_funding_txids
-        );
+        log::info!("Broadcasted funding txs: {:?}", my_funding_txids);
 
         // Update the connection state.
         self.ongoing_swap_state.lock()?.insert(
@@ -687,11 +669,7 @@ impl Maker {
             incoming_swapcoin.hash_preimage = Some(message.preimage);
         }
 
-        log::info!(
-            "[{}] received preimage for hashvalue={}",
-            self.config.network_port,
-            hashvalue
-        );
+        log::info!("received preimage for hashvalue={}", hashvalue);
         let mut swapcoin_private_keys = Vec::<MultisigPrivkey>::new();
 
         // Send our privkey and mark the outgoing swapcoin as "done".

--- a/src/maker/handlers2.rs
+++ b/src/maker/handlers2.rs
@@ -31,13 +31,8 @@ pub(crate) fn handle_message_taproot(
     connection_state: &mut ConnectionState,
     message: TakerToMakerMessage,
 ) -> Result<Option<MakerToTakerMessage>, MakerError> {
-    log::debug!(
-        "[{}] Handling message: {:?}",
-        maker.config.network_port,
-        message
-    );
+    log::debug!("Handling message: {:?}", message);
 
-    // Handle messages based on their type, not on expected state
     match message {
         TakerToMakerMessage::GetOffer(get_offer_msg) => handle_get_offer(maker, get_offer_msg),
         TakerToMakerMessage::SwapDetails(swap_details) => {
@@ -52,35 +47,37 @@ pub(crate) fn handle_message_taproot(
     }
 }
 
-/// Handles GetOffer message and returns an Offer with fidelity proof
 fn handle_get_offer(
     maker: &Arc<Maker>,
     _get_offer: GetOffer,
 ) -> Result<Option<MakerToTakerMessage>, MakerError> {
-    log::info!("[{}] Handling GetOffer request", maker.config.network_port);
-
-    // Create offer using the new api2 implementation
+    log::info!("Handling GetOffer request");
     let offer = maker.create_offer()?;
-
     log::info!(
-        "[{}] Sending offer: min_size={}, max_size={}",
-        maker.config.network_port,
+        "Sending offer: min_size={}, max_size={}",
         offer.min_size,
         offer.max_size
     );
-
     Ok(Some(MakerToTakerMessage::RespOffer(Box::new(offer))))
 }
 
-/// Handles SwapDetails message and validates the swap parameters
+fn handle_privkey_handover(
+    maker: &Arc<Maker>,
+    connection_state: &mut ConnectionState,
+    privkey_handover: PrivateKeyHandover,
+) -> Result<Option<MakerToTakerMessage>, MakerError> {
+    let response = maker.process_private_key_handover(&privkey_handover, connection_state)?;
+    Ok(Some(MakerToTakerMessage::PrivateKeyHandover(response)))
+}
+
 fn handle_swap_details(
     maker: &Arc<Maker>,
     connection_state: &mut ConnectionState,
     swap_details: SwapDetails,
 ) -> Result<Option<MakerToTakerMessage>, MakerError> {
     log::info!(
-        "[{}] Handling SwapDetails: amount={}, timelock={}, tx_count={}",
-        maker.config.network_port,
+        "[Swap: {}] Handling SwapDetails: amount={}, timelock={}, tx_count={}",
+        swap_details.id,
         swap_details.amount,
         swap_details.timelock,
         swap_details.no_of_tx
@@ -90,22 +87,17 @@ fn handle_swap_details(
     connection_state.incoming_contract.my_privkey = Some(privkey);
     connection_state.incoming_contract.my_pubkey = Some(pubkey);
 
-    // Validate swap parameters using api2
     maker.validate_swap_parameters(&swap_details)?;
 
-    // Store swap details in connection state
     connection_state.swap_amount = swap_details.amount;
     connection_state.timelock = swap_details.timelock;
 
-    // Reserve utxo for this swap
-    // Sync wallet to get fresh UTXO state before coin selection
     {
         let mut wallet_write = maker.wallet.write()?;
         wallet_write.sync_and_save()?;
         log::info!("Sync at:----handle_swap_details----");
     }
 
-    // Reserve UTXOs for this swap, This prevents double-spending across concurrent swaps by excluding UTXOs.
     {
         let required_amount = swap_details.amount;
         let mut ongoing_state_lock = maker.ongoing_swap_state.lock()?;
@@ -115,7 +107,7 @@ fn handle_swap_details(
             .filter(|(id, _)| *id != &swap_details.id)
             .flat_map(|(_, (state, _))| state.reserve_utxo.clone())
             .collect();
-        log::info!("Excluded UTXOs {:?}", excluded_utxos);
+
         let wallet = maker.wallet.read()?;
         let selected_utxos =
             wallet.coin_select(required_amount, MIN_FEE_RATE, None, Some(excluded_utxos))?;
@@ -126,8 +118,8 @@ fn handle_swap_details(
             .collect();
 
         log::debug!(
-            "[{}] Reserved {} UTXOs for swap",
-            maker.config.network_port,
+            "[Swap: {}] Reserved {} UTXOs for swap",
+            swap_details.id,
             connection_state.reserve_utxo.len(),
         );
 
@@ -137,36 +129,24 @@ fn handle_swap_details(
         );
     }
 
-    log::info!(
-        "[{}] Inserted state for swap id: {}",
-        maker.config.network_port,
-        swap_details.id
-    );
+    log::info!("Inserted state for swap id: {}", swap_details.id);
 
-    // Track swap start time for reporting
     connection_state.swap_start_time = Some(std::time::Instant::now());
 
-    // Calculate our fee for this swap
     let our_fee = maker.calculate_swap_fee(swap_details.amount, swap_details.timelock);
-    log::info!(
-        "[{}] Calculated fee: {}",
-        maker.config.network_port,
-        our_fee
-    );
+    log::info!("[Swap: {}] Calculated fee: {}", swap_details.id, our_fee);
 
-    // Check for CloseAfterAckResponse behavior
     #[cfg(feature = "integration-test")]
     if maker.behavior == super::api2::MakerBehavior::CloseAfterAckResponse {
         log::warn!(
-            "[{}] Maker behavior: CloseAfterAckResponse - Closing connection after sending Ack Response message to taker",
-            maker.config.network_port
+            "[Swap: {}] Maker behavior: CloseAfterAckResponse - Closing connection",
+            swap_details.id
         );
         return Err(MakerError::General(
             "Maker closing connection after sending AckResponse to taker (test behavior)",
         ));
     }
 
-    // Send acknowledgment
     Ok(Some(MakerToTakerMessage::AckResponse(
         protocol::messages2::AckResponse {
             tweakable_point: Some(pubkey),
@@ -174,35 +154,31 @@ fn handle_swap_details(
     )))
 }
 
-/// Handles SendersContract message and creates our receiver contract
 fn handle_senders_contract(
     maker: &Arc<Maker>,
     connection_state: &mut ConnectionState,
     senders_contract: SendersContract,
 ) -> Result<Option<MakerToTakerMessage>, MakerError> {
     log::info!(
-        "[{}] Handling SendersContract with {} contracts",
-        maker.config.network_port,
+        "[Swap: {}] Handling SendersContract with {} contracts",
+        senders_contract.id,
         senders_contract.contract_txs.len()
     );
 
-    // Check for CloseAtContractSigsExchange behavior (before creating outgoing contract)
     #[cfg(feature = "integration-test")]
     if maker.behavior == super::api2::MakerBehavior::CloseAtContractSigsExchange {
         log::warn!(
-            "[{}] Maker behavior: CloseAtContractSigsExchange - Closing connection after receiving incoming contract",
-            maker.config.network_port
+            "[Swap: {}] Maker behavior: CloseAtContractSigsExchange - Closing connection",
+            senders_contract.id
         );
         return Err(MakerError::General(
             "Maker closing connection at contract exchange (test behavior)",
         ));
     }
 
-    // Process the sender's contract and create our response
     let receiver_contract =
         maker.verify_and_process_senders_contract(&senders_contract, connection_state)?;
 
-    // Generate a unique swap_id to link incoming and outgoing swapcoins
     let swap_id = format!(
         "{}-{}",
         std::time::SystemTime::now()
@@ -217,35 +193,24 @@ fn handle_senders_contract(
     connection_state.incoming_contract.swap_id = Some(swap_id.clone());
     connection_state.outgoing_contract.swap_id = Some(swap_id.clone());
 
-    // Persist both incoming and outgoing swapcoins for recovery
     {
         let mut wallet = maker.wallet().write()?;
         wallet.add_incoming_swapcoin_v2(&connection_state.incoming_contract);
         wallet.add_outgoing_swapcoin_v2(&connection_state.outgoing_contract);
         wallet.save_to_disk()?;
         log::info!(
-            "[{}] Persisted incoming and outgoing swapcoins with swap_id={} to wallet",
-            maker.config.network_port,
+            "Persisted incoming and outgoing swapcoins with swap_id={} to wallet",
             swap_id
         );
     }
 
     log::info!(
-        "[{}] Sending SenderContractFromMaker with {} contracts",
-        maker.config.network_port,
+        "[Swap: {}] Sending SenderContractFromMaker with {} contracts",
+        senders_contract.id,
         receiver_contract.contract_txs.len()
     );
 
     Ok(Some(MakerToTakerMessage::SenderContractFromMaker(
         receiver_contract,
     )))
-}
-
-fn handle_privkey_handover(
-    maker: &Arc<Maker>,
-    connection_state: &mut ConnectionState,
-    privkey_handover: PrivateKeyHandover,
-) -> Result<Option<MakerToTakerMessage>, MakerError> {
-    let response = maker.process_private_key_handover(&privkey_handover, connection_state)?;
-    Ok(Some(MakerToTakerMessage::PrivateKeyHandover(response)))
 }

--- a/src/maker/handlers2.rs
+++ b/src/maker/handlers2.rs
@@ -199,7 +199,8 @@ fn handle_senders_contract(
         wallet.add_outgoing_swapcoin_v2(&connection_state.outgoing_contract);
         wallet.save_to_disk()?;
         log::info!(
-            "Persisted incoming and outgoing swapcoins with swap_id={} to wallet",
+            "[Swap: {}] Persisted to wallet with internal swap_id={}",
+            senders_contract.id,
             swap_id
         );
     }

--- a/src/maker/handlers2.rs
+++ b/src/maker/handlers2.rs
@@ -31,7 +31,12 @@ pub(crate) fn handle_message_taproot(
     connection_state: &mut ConnectionState,
     message: TakerToMakerMessage,
 ) -> Result<Option<MakerToTakerMessage>, MakerError> {
-    log::debug!("Handling message: {:?}", message);
+    match &message {
+        TakerToMakerMessage::PrivateKeyHandover(_) => {
+            log::debug!("Handling message: PrivateKeyHandover [REDACTED]");
+        }
+        _ => log::debug!("Handling message: {:?}", message),
+    }
 
     match message {
         TakerToMakerMessage::GetOffer(get_offer_msg) => handle_get_offer(maker, get_offer_msg),
@@ -67,6 +72,9 @@ fn handle_privkey_handover(
     privkey_handover: PrivateKeyHandover,
 ) -> Result<Option<MakerToTakerMessage>, MakerError> {
     let response = maker.process_private_key_handover(&privkey_handover, connection_state)?;
+    maker.sweep_after_successful_coinswap()?;
+    maker.wallet().write()?.sync_and_save()?;
+
     Ok(Some(MakerToTakerMessage::PrivateKeyHandover(response)))
 }
 

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -156,11 +156,7 @@ pub(crate) fn start_rpc_server<M: MakerRpc>(maker: Arc<M>) -> Result<(), MakerEr
     let rpc_port = maker.config().rpc_port;
     let rpc_socket = format!("127.0.0.1:{rpc_port}");
     let listener = Arc::new(TcpListener::bind(&rpc_socket)?);
-    log::info!(
-        "[{}] RPC socket binding successful at {}",
-        maker.config().network_port,
-        rpc_socket
-    );
+    log::info!("RPC socket binding successful at {}", rpc_socket);
 
     listener.set_nonblocking(true)?;
 

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -330,7 +330,7 @@ fn check_connection_with_core(maker: &Maker) -> Result<(), MakerError> {
 }
 
 /// Handle a single client connection.
-fn handle_client(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(), MakerError> {
+fn handle_client(maker: &Arc<Maker>, stream: &mut TcpStream, addr: std::net::SocketAddr) -> Result<(), MakerError> {
     stream.set_nonblocking(false)?; // Block this thread until message is read.
 
     let mut connection_state = ConnectionState::default();
@@ -342,7 +342,7 @@ fn handle_client(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(), Maker
             Err(e) => {
                 if let NetError::IO(e) = e {
                     if e.kind() == ErrorKind::UnexpectedEof {
-                        log::info!("Connection ended.");
+                        log::info!("[Peer: {}] Connection ended.", addr);
                         break;
                     } else {
                         // For any other errors, report them
@@ -354,14 +354,14 @@ fn handle_client(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(), Maker
         }
         let taker_msg = serde_cbor::from_slice::<TakerToMakerMessage>(&bytes)?;
 
-        log::info!("<=== {}", taker_msg);
+        log::info!("[Peer: {}] <=== {}", addr, taker_msg);
 
         let reply = handle_message(maker, &mut connection_state, taker_msg);
 
         match reply {
             Ok(reply) => {
                 if let Some(message) = reply {
-                    log::info!("===> {}", message);
+                    log::info!("[Peer: {}] ===> {}", addr, message);
                     if let Err(e) = send_message(stream, &message) {
                         log::error!("Closing due to IO error in sending message: {e:?}");
                         continue;
@@ -515,11 +515,11 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
             }
         }
         match listener.accept() {
-            Ok((mut stream, _)) => {
-                log::info!("Received incoming connection");
+            Ok((mut stream, addr)) => {
+                log::info!("[Peer: {}] Received incoming connection", addr);
 
-                if let Err(e) = handle_client(&maker, &mut stream) {
-                    log::error!("Error Handling client request {e:?}");
+                if let Err(e) = handle_client(&maker, &mut stream, addr) {
+                    log::error!("[Peer: {}] Error Handling client request {:?}", addr, e);
                 }
             }
 

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -363,7 +363,7 @@ fn handle_client(maker: &Arc<Maker>, stream: &mut TcpStream, addr: std::net::Soc
                 if let Some(message) = reply {
                     log::info!("[Peer: {}] ===> {}", addr, message);
                     if let Err(e) = send_message(stream, &message) {
-                        log::error!("Closing due to IO error in sending message: {e:?}");
+                        log::error!("[Peer: {}] Closing due to IO error in sending message: {e:?}", addr);
                         continue;
                     }
                 } else {
@@ -373,10 +373,10 @@ fn handle_client(maker: &Arc<Maker>, stream: &mut TcpStream, addr: std::net::Soc
             Err(err) => {
                 match &err {
                     MakerError::SpecialBehaviour(sp) => {
-                        log::error!("Maker Special Behavior Triggered Disconnection : {:?}", sp);
+                        log::error!("[Peer: {}] Maker Special Behavior Triggered Disconnection : {:?}", addr, sp);
                     }
                     e => {
-                        log::error!("Internal message handling error occurred: {:?}", e);
+                        log::error!("[Peer: {}] Internal message handling error occurred: {:?}", addr, e);
                     }
                 }
                 break;

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -236,18 +236,14 @@ fn setup_fidelity_bond(maker: &Maker, maker_address: &str) -> Result<FidelityPro
                         thread::sleep(Duration::from_secs(total_sleep));
                     } else {
                         log::error!(
-                            "[{}] Fidelity Bond Creation failed: {:?}. Shutting Down Maker server",
-                            maker.config.network_port,
+                            "Fidelity Bond Creation failed: {:?}. Shutting Down Maker server",
                             e
                         );
                         return Err(e.into());
                     }
                 }
                 Ok(i) => {
-                    log::info!(
-                        "[{}] Successfully created fidelity bond",
-                        maker.config.network_port
-                    );
+                    log::info!("Successfully created fidelity bond",);
                     let highest_proof = maker
                         .get_wallet()
                         .read()?
@@ -290,8 +286,7 @@ fn check_swap_liquidity(maker: &Maker) -> Result<(), MakerError> {
                 .write()?
                 .get_next_external_address(AddressType::P2WPKH)?;
             log::warn!(
-                "[{}] Low Swap Liquidity | Min: {} sats | Available: {} sats. Add funds to {:?}",
-                maker.config.network_port,
+                "Low Swap Liquidity | Min: {} sats | Available: {} sats. Add funds to {:?}",
                 min_required,
                 offer_max_size,
                 addr,
@@ -302,8 +297,7 @@ fn check_swap_liquidity(maker: &Maker) -> Result<(), MakerError> {
             thread::sleep(Duration::from_secs(sleep_duration));
         } else {
             log::info!(
-                "[{}] Swap Liquidity ready: {} sats | Min: {} sats | Listening for requests.",
-                maker.config.network_port,
+                "Swap Liquidity ready: {} sats | Min: {} sats | Listening for requests.",
                 offer_max_size,
                 min_required
             );
@@ -319,18 +313,11 @@ fn check_connection_with_core(maker: &Maker) -> Result<(), MakerError> {
     let mut rcp_ping_success = true;
     while !maker.shutdown.load(Relaxed) {
         if let Err(e) = maker.wallet.read()?.rpc.get_blockchain_info() {
-            log::error!(
-                "[{}] RPC Connection failed | Error: {} | Reattempting...",
-                maker.config.network_port,
-                e
-            );
+            log::error!("RPC Connection failed | Error: {} | Reattempting...", e);
             rcp_ping_success = false;
         } else {
             if !rcp_ping_success {
-                log::info!(
-                    "[{}] Bitcoin Core RPC connection is live.",
-                    maker.config.network_port
-                );
+                log::info!("Bitcoin Core RPC connection is live.",);
             }
 
             break;
@@ -355,11 +342,11 @@ fn handle_client(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(), Maker
             Err(e) => {
                 if let NetError::IO(e) = e {
                     if e.kind() == ErrorKind::UnexpectedEof {
-                        log::info!("[{}] Connection ended.", maker.config.network_port);
+                        log::info!("Connection ended.");
                         break;
                     } else {
                         // For any other errors, report them
-                        log::error!("[{}] Net Error: {}", maker.config.network_port, e);
+                        log::error!("Net Error: {}", e);
                         continue;
                     }
                 }
@@ -367,14 +354,14 @@ fn handle_client(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(), Maker
         }
         let taker_msg = serde_cbor::from_slice::<TakerToMakerMessage>(&bytes)?;
 
-        log::info!("[{}] <=== {}", maker.config.network_port, taker_msg);
+        log::info!("<=== {}", taker_msg);
 
         let reply = handle_message(maker, &mut connection_state, taker_msg);
 
         match reply {
             Ok(reply) => {
                 if let Some(message) = reply {
-                    log::info!("[{}] ===> {} ", maker.config.network_port, message);
+                    log::info!("===> {}", message);
                     if let Err(e) = send_message(stream, &message) {
                         log::error!("Closing due to IO error in sending message: {e:?}");
                         continue;
@@ -386,18 +373,10 @@ fn handle_client(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(), Maker
             Err(err) => {
                 match &err {
                     MakerError::SpecialBehaviour(sp) => {
-                        log::error!(
-                            "[{}] Maker Special Behavior Triggered Disconnection : {:?}",
-                            maker.config.network_port,
-                            sp
-                        );
+                        log::error!("Maker Special Behavior Triggered Disconnection : {:?}", sp);
                     }
                     e => {
-                        log::error!(
-                            "[{}] Internal message handling error occurred: {:?}",
-                            maker.config.network_port,
-                            e
-                        );
+                        log::error!("Internal message handling error occurred: {:?}", e);
                     }
                 }
                 break;
@@ -437,18 +416,11 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
     // This ensures these functions are not executed twice in quick succession.
     interval_tracker += HEART_BEAT_INTERVAL.as_secs() as u32;
 
-    let network_port = maker.config.network_port;
-
     {
         let wallet = maker.get_wallet().read()?;
+        log::info!("Bitcoin Network: {}", wallet.store.network);
         log::info!(
-            "[{}] Bitcoin Network: {}",
-            network_port,
-            wallet.store.network
-        );
-        log::info!(
-            "[{}] Spendable Wallet Balance: {}",
-            network_port,
+            "Spendable Wallet Balance: {}",
             wallet.get_balances()?.spendable
         );
     }
@@ -465,7 +437,7 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
         let idle_conn_check_thread = thread::Builder::new()
             .name("Idle Client Checker Thread".to_string())
             .spawn(move || {
-                log::info!("[{network_port}] Spawning Client connection status checker thread");
+                log::info!("Spawning Client connection status checker thread");
                 if let Err(e) = check_for_idle_states(maker_clone.clone()) {
                     log::error!("Failed checking client's idle state {e:?}");
                     maker_clone.shutdown.store(true, Relaxed);
@@ -481,7 +453,7 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
         let contract_watcher_thread = thread::Builder::new()
             .name("Contract Watcher Thread".to_string())
             .spawn(move || {
-                log::info!("[{network_port}] Spawning contract-watcher thread");
+                log::info!("Spawning contract-watcher thread");
                 if let Err(e) = check_for_broadcasted_contracts(maker_clone.clone()) {
                     maker_clone.shutdown.store(true, Relaxed);
                     log::error!("Failed checking broadcasted contracts {e:?}");
@@ -495,7 +467,7 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
         let rpc_thread = thread::Builder::new()
             .name("RPC Thread".to_string())
             .spawn(move || {
-                log::info!("[{network_port}] Spawning RPC server thread");
+                log::info!("Spawning RPC server thread");
                 match start_rpc_server(maker_clone.clone()) {
                     Ok(_) => (),
                     Err(e) => {
@@ -517,7 +489,9 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
         }
 
         maker.is_setup_complete.store(true, Relaxed);
-        log::info!("[{}] Server Setup completed!! Use maker-cli to operate the server and the internal wallet.", maker.config.network_port);
+        log::info!(
+            "Server Setup completed!! Use maker-cli to operate the server and the internal wallet."
+        );
     }
 
     while !maker.shutdown.load(Relaxed) {
@@ -542,16 +516,16 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
         }
         match listener.accept() {
             Ok((mut stream, _)) => {
-                log::info!("[{network_port}] Received incoming connection");
+                log::info!("Received incoming connection");
 
                 if let Err(e) = handle_client(&maker, &mut stream) {
-                    log::error!("[{network_port}] Error Handling client request {e:?}");
+                    log::error!("Error Handling client request {e:?}");
                 }
             }
 
             Err(e) => {
                 if e.kind() != ErrorKind::WouldBlock {
-                    log::error!("[{network_port}] Error accepting incoming connection: {e:?}");
+                    log::error!("Error accepting incoming connection: {e:?}");
                 }
             }
         };
@@ -569,7 +543,7 @@ pub fn start_maker_server(maker: Arc<Maker>) -> Result<(), MakerError> {
         sleep(HEART_BEAT_INTERVAL);
     }
 
-    log::info!("[{network_port}] Maker is shutting down.");
+    log::info!("Maker is shutting down.");
 
     maker.watch_service.shutdown();
 

--- a/src/maker/server2.rs
+++ b/src/maker/server2.rs
@@ -163,8 +163,7 @@ fn setup_fidelity_bond_taproot(
         };
 
         log::info!(
-            "[{}] Using existing fidelity bond at outpoint {} | index {} | Amount {:?} sats | Remaining Timelock for expiry : {:?} Blocks | Current Bond Value : {:?} sats",
-            maker.config.network_port,
+            "Using existing fidelity bond at outpoint {} | index {} | Amount {:?} sats | Remaining Timelock for expiry : {:?} Blocks | Current Bond Value : {:?} sats",
             proof_message.bond.outpoint,
             i,
             bond.amount.to_sat(),
@@ -179,18 +178,11 @@ fn setup_fidelity_bond_taproot(
     }
 
     // No active Fidelity Bonds found. Creating one.
-    log::info!(
-        "[{}] No active Fidelity Bonds found. Creating one.",
-        maker.config.network_port
-    );
+    log::info!("No active Fidelity Bonds found. Creating one.",);
 
     let amount = Amount::from_sat(maker.config.fidelity_amount);
 
-    log::info!(
-        "[{}] Fidelity value chosen = {:?} sats",
-        maker.config.network_port,
-        amount.to_sat()
-    );
+    log::info!("Fidelity value chosen = {:?} sats", amount.to_sat());
 
     let current_height = maker
         .wallet()
@@ -213,8 +205,7 @@ fn setup_fidelity_bond_taproot(
         .map_err(WalletError::Locktime)?;
 
     log::info!(
-        "[{}] Fidelity timelock {:?} blocks",
-        maker.config.network_port,
+        "Fidelity timelock {:?} blocks",
         locktime.to_consensus_u32() - current_height
     );
 
@@ -244,38 +235,28 @@ fn setup_fidelity_bond_taproot(
                     required,
                 } = e
                 {
-                    log::warn!(
-                        "[{}] Insufficient fund to create fidelity bond.",
-                        maker.config.network_port
-                    );
+                    log::warn!("Insufficient fund to create fidelity bond.",);
                     let amount = required - available;
                     let addr = maker
                         .wallet()
                         .write()?
                         .get_next_external_address(AddressType::P2TR)?;
 
-                    log::info!("[{}] Send at least {:.8} BTC to {:?} | If you send extra, that will be added to your wallet balance", maker.config.network_port, Amount::from_sat(amount).to_btc(), addr);
+                    log::info!("Send at least {:.8} BTC to {:?} | If you send extra, that will be added to your wallet balance", Amount::from_sat(amount).to_btc(), addr);
 
                     let total_sleep = sleep_increment * sleep_multiplier.min(10 * 60);
-                    log::info!(
-                        "[{}] Next sync in {total_sleep:?} secs",
-                        maker.config.network_port
-                    );
+                    log::info!("Next sync in {total_sleep:?} secs",);
                     thread::sleep(Duration::from_secs(total_sleep));
                 } else {
                     log::error!(
-                        "[{}] Fidelity Bond Creation failed: {:?}. Shutting Down Maker server",
-                        maker.config.network_port,
+                        "Fidelity Bond Creation failed: {:?}. Shutting Down Maker server",
                         e
                     );
                     return Err(e.into());
                 }
             }
             Ok(i) => {
-                log::info!(
-                    "[{}] Successfully created fidelity bond",
-                    maker.config.network_port
-                );
+                log::info!("Successfully created fidelity bond",);
                 let proof_message = maker
                     .wallet()
                     .read()?
@@ -328,24 +309,18 @@ fn check_swap_liquidity_taproot(maker: &Maker) -> Result<(), MakerError> {
                 .write()?
                 .get_next_external_address(AddressType::P2TR)?;
             log::warn!(
-                "[{}] Low taproot swap liquidity | Min: {} sats | Available: {} sats | Add Funds to: {:?}",
-                maker.config.network_port,
+                "Low taproot swap liquidity | Min: {} sats | Available: {} sats | Add Funds to: {:?}",
                 min_required,
                 offer_max_size,
                 funding_addr,
             );
             sleep_duration = (sleep_duration + sleep_incremental).min(10 * 60); // Capped at 1 Block interval
-            log::info!(
-                "[{}] Next liquidity check in {:?} seconds",
-                maker.config.network_port,
-                sleep_duration
-            );
+            log::info!("Next liquidity check in {:?} seconds", sleep_duration);
 
             std::thread::sleep(std::time::Duration::from_secs(sleep_duration));
         } else {
             log::info!(
-                "[{}] Taproot swap liquidity ready: {} sats | Min: {} sats | Listening for requests.",
-                maker.config.network_port,
+                "Taproot swap liquidity ready: {} sats | Min: {} sats | Listening for requests.",
                 offer_max_size,
                 min_required
             );
@@ -361,18 +336,10 @@ fn check_connection_with_core_taproot(maker: &Maker) -> Result<(), MakerError> {
     let wallet_read = maker.wallet().read()?;
     match wallet_read.rpc.get_block_count() {
         Ok(block_count) => {
-            log::debug!(
-                "[{}] Bitcoin Core connection OK, block height: {}",
-                maker.config.network_port,
-                block_count
-            );
+            log::debug!("Bitcoin Core connection OK, block height: {}", block_count);
         }
         Err(e) => {
-            log::error!(
-                "[{}] Bitcoin Core connection failed: {}",
-                maker.config.network_port,
-                e
-            );
+            log::error!("Bitcoin Core connection failed: {}", e);
             return Err(WalletError::Rpc(e).into());
         }
     }
@@ -388,8 +355,7 @@ fn handle_client_taproot(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(
     let ip = peer_addr.ip().to_string();
 
     log::info!(
-        "[{}] New taproot client connected: {} (port {})",
-        maker.config.network_port,
+        "New taproot client connected: {} (port {})",
         ip,
         peer_addr.port()
     );
@@ -397,10 +363,7 @@ fn handle_client_taproot(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(
     loop {
         // Check if we should shutdown
         if maker.shutdown.load(Relaxed) {
-            log::info!(
-                "[{}] Shutdown signal received, closing connection",
-                maker.config.network_port
-            );
+            log::info!("Shutdown signal received, closing connection",);
             break;
         }
 
@@ -410,38 +373,23 @@ fn handle_client_taproot(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(
             Err(e) => {
                 if let NetError::IO(io_err) = &e {
                     if io_err.kind() == ErrorKind::UnexpectedEof {
-                        log::info!("[{}] Client {} disconnected", maker.config.network_port, ip);
+                        log::info!("Client {} disconnected", ip);
                         break;
                     }
                 }
-                log::error!(
-                    "[{}] Failed to read message from {}: {:?}",
-                    maker.config.network_port,
-                    ip,
-                    e
-                );
+                log::error!("Failed to read message from {}: {:?}", ip, e);
                 break;
             }
         };
 
-        log::debug!(
-            "[{}] Received {} bytes from {}",
-            maker.config.network_port,
-            message_bytes.len(),
-            ip
-        );
+        log::debug!("Received {} bytes from {}", message_bytes.len(), ip);
         let message = match serde_cbor::from_slice::<TakerToMakerMessage>(&message_bytes) {
             Ok(msg) => {
-                log::info!("[{}] <=== {}", maker.config.network_port, msg);
+                log::info!("<=== {}", msg);
                 msg
             }
             Err(e) => {
-                log::error!(
-                    "[{}] Failed to deserialize message from {}: {:?}",
-                    maker.config.network_port,
-                    ip,
-                    e
-                );
+                log::error!("Failed to deserialize message from {}: {:?}", ip, e);
                 break;
             }
         };
@@ -460,18 +408,14 @@ fn handle_client_taproot(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(
 
             match &message {
                 TakerToMakerMessage::GetOffer(_) => {
-                    log::info!(
-                        "[{}] Using temporary connection state for GetOffer",
-                        maker.config.network_port,
-                    );
+                    log::info!("Using temporary connection state for GetOffer",);
                     // This connection state won't be persisted
                     ConnectionState::default()
                 }
                 TakerToMakerMessage::SwapDetails(_) => match ongoing_swaps.get(&swap_id) {
                     Some((state, _)) => {
                         log::info!(
-                            "[{}] Protocol Violation: Found existing ConnectionState {:?} for SwapDetails for this SwapId:{},",
-                            maker.config.network_port,
+                            "Protocol Violation: Found existing ConnectionState {:?} for SwapDetails for this SwapId:{},",
                             state,
                             swap_id,
                         );
@@ -480,10 +424,7 @@ fn handle_client_taproot(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(
                         ));
                     }
                     None => {
-                        log::info!(
-                            "[{}] Creating new connection state for SwapDetails",
-                            maker.config.network_port
-                        );
+                        log::info!("Creating new connection state for SwapDetails",);
                         ConnectionState::default()
                     }
                 },
@@ -491,8 +432,7 @@ fn handle_client_taproot(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(
                     Some((state, _)) => state.clone(),
                     None => {
                         log::info!(
-                                "[{}] No connection state found for swap_id={:?}. GetOffer must be sent first.",
-                                maker.config.network_port,
+                                "No connection state found for swap_id={:?}. GetOffer must be sent first.",
                                 &swap_id
                             );
                         return Err(MakerError::General("No connection state found"));
@@ -505,12 +445,7 @@ fn handle_client_taproot(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(
         let response = match handle_message_taproot(maker, &mut connection_state, message) {
             Ok(response) => response,
             Err(e) => {
-                log::error!(
-                    "[{}] Error handling message from {}: {:?}",
-                    maker.config.network_port,
-                    ip,
-                    e
-                );
+                log::error!("Error handling message from {}: {:?}", ip, e);
 
                 if connection_state.swap_amount > Amount::ZERO {
                     let network = maker
@@ -555,10 +490,7 @@ fn handle_client_taproot(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(
                 // Check if this is a behavior-triggered error
                 match &e {
                     MakerError::General(msg) if msg.contains("behavior") => {
-                        log::info!(
-                            "[{}] Behavior-triggered disconnection",
-                            maker.config.network_port
-                        );
+                        log::info!("Behavior-triggered disconnection",);
                     }
                     _ => {}
                 }
@@ -570,8 +502,7 @@ fn handle_client_taproot(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(
         if !matches!(response, Some(MakerToTakerMessage::RespOffer(_))) {
             let mut ongoing_swaps = maker.ongoing_swap_state.lock()?;
             log::info!(
-                "[{}] Persisting connection state for {}: swap_amount={}, my_privkey_is_some={}",
-                maker.config.network_port,
+                "Persisting connection state for {}: swap_amount={}, my_privkey_is_some={}",
                 ip,
                 connection_state.swap_amount,
                 connection_state.incoming_contract.my_privkey.is_some()
@@ -580,29 +511,19 @@ fn handle_client_taproot(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(
         }
         // Send response if we have one (only applies to taker messages)
         if let Some(response_msg) = response {
-            log::info!("[{}] ===> {}", maker.config.network_port, response_msg);
+            log::info!("===> {}", response_msg);
 
             if let Err(e) = send_message(stream, &response_msg) {
-                log::error!(
-                    "[{}] Failed to send response to {}: {:?}",
-                    maker.config.network_port,
-                    ip,
-                    e
-                );
+                log::error!("Failed to send response to {}: {:?}", ip, e);
                 break;
             }
 
-            log::info!(
-                "[{}] Successfully sent response to {}",
-                maker.config.network_port,
-                ip
-            );
+            log::info!("Successfully sent response to {}", ip);
 
             if let MakerToTakerMessage::PrivateKeyHandover(_) = &response_msg {
                 // Swap completed successfully - remove outgoing swapcoin and ongoing swap state
                 log::info!(
-                    "[{}] Swap completed successfully with {}, removing from ongoing swaps",
-                    maker.config.network_port,
+                    "Swap completed successfully with {}, removing from ongoing swaps",
                     ip
                 );
 
@@ -615,8 +536,7 @@ fn handle_client_taproot(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(
                     let mut wallet = maker.wallet.write()?;
                     wallet.remove_outgoing_swapcoin_v2(&outgoing_txid);
                     log::info!(
-                        "[{}] Removed outgoing swapcoin {} after PrivateKeyHandover sent",
-                        maker.config.network_port,
+                        "Removed outgoing swapcoin {} after PrivateKeyHandover sent",
                         outgoing_txid
                     );
                     wallet.save_to_disk()?;
@@ -630,26 +550,19 @@ fn handle_client_taproot(maker: &Arc<Maker>, stream: &mut TcpStream) -> Result<(
         }
     }
 
-    log::info!(
-        "[{}] Client {} session ended",
-        maker.config.network_port,
-        ip
-    );
+    log::info!("Client {} session ended", ip);
     Ok(())
 }
 
 /// Starts the taproot maker server
 pub fn start_maker_server_taproot(maker: Arc<Maker>) -> Result<(), MakerError> {
     let network_port = maker.config.network_port;
-    log::info!("[{network_port}] Starting taproot coinswap maker server",);
+    log::info!("Starting taproot coinswap maker server",);
 
     // Set up network
     let maker_address = network_bootstrap_taproot(maker.clone())?;
 
-    log::info!(
-        "[{network_port}] Taproot maker initialized - Address: {}",
-        maker_address,
-    );
+    log::info!("Taproot maker initialized - Address: {}", maker_address,);
     // Check swap liquidity before spawning the threads
     check_swap_liquidity_taproot(&maker)?;
     // Start idle connection checker thread
@@ -723,10 +636,7 @@ pub fn start_maker_server_taproot(maker: Arc<Maker>) -> Result<(), MakerError> {
                 let check_is_due = counter.is_multiple_of(check_interval);
 
                 if check_is_due && swaps_empty {
-                    log::info!(
-                        "[{}] Running periodic fidelity bond check",
-                        maker_clone_fidelity.config.network_port
-                    );
+                    log::info!("Running periodic fidelity bond check",);
                     if let Err(e) = manage_fidelity_bonds_taproot(
                         maker_clone_fidelity.clone(),
                         &maker_addr_clone,
@@ -786,7 +696,7 @@ pub fn start_maker_server_taproot(maker: Arc<Maker>) -> Result<(), MakerError> {
         let (inc, out) = maker.wallet.read()?.find_unfinished_swapcoins_v2();
         if !inc.is_empty() || !out.is_empty() {
             log::info!(
-                "[{network_port}] Incomplete taproot swaps detected ({} incoming, {} outgoing). Starting recovery.",
+                "Incomplete taproot swaps detected ({} incoming, {} outgoing). Starting recovery.",
                 inc.len(),
                 out.len()
             );
@@ -796,11 +706,11 @@ pub fn start_maker_server_taproot(maker: Arc<Maker>) -> Result<(), MakerError> {
 
     // Mark setup as complete
     maker.is_setup_complete.store(true, Relaxed);
-    log::info!("[{network_port}] Taproot maker setup completed",);
+    log::info!("Taproot maker setup completed",);
 
     // Start listening for P2P connections
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, network_port))?;
-    log::info!("[{network_port}] Taproot maker server listening on port {network_port}",);
+    log::info!("Taproot maker server listening on port {network_port}",);
 
     // Set listener to non-blocking mode to allow periodic shutdown checks
     listener.set_nonblocking(true)?;
@@ -810,13 +720,13 @@ pub fn start_maker_server_taproot(maker: Arc<Maker>) -> Result<(), MakerError> {
         match listener.accept() {
             Ok((mut stream, _)) => {
                 if let Err(e) = handle_client_taproot(&maker, &mut stream) {
-                    log::error!("[{network_port}] Error Handling client request {e:?}");
+                    log::error!("Error Handling client request {e:?}");
                 }
             }
 
             Err(e) => {
                 if e.kind() != ErrorKind::WouldBlock {
-                    log::error!("[{network_port}] Error accepting incoming connection: {e:?}");
+                    log::error!("Error accepting incoming connection: {e:?}");
                 }
             }
         };
@@ -824,10 +734,7 @@ pub fn start_maker_server_taproot(maker: Arc<Maker>) -> Result<(), MakerError> {
         sleep(HEART_BEAT_INTERVAL);
     }
 
-    log::info!(
-        "[{}] Taproot maker server shutting down",
-        maker.config.network_port
-    );
+    log::info!("Taproot maker server shutting down",);
 
     maker.watch_service.shutdown();
 
@@ -836,9 +743,6 @@ pub fn start_maker_server_taproot(maker: Arc<Maker>) -> Result<(), MakerError> {
 
     log::info!("sync at:----Taproot server shutdown----");
     maker.wallet().write()?.sync_and_save()?;
-    log::info!(
-        "[{}] Taproot maker server stopped",
-        maker.config.network_port
-    );
+    log::info!("Taproot maker server stopped",);
     Ok(())
 }


### PR DESCRIPTION
# Pull Request

## Description
Fixed redundant logging identifiers where the network port was used as a prefix. Removed the port field from ThreadPool as it was only used for logging.


Closes #798 
<!-- Add multiple lines if this PR closes multiple issues -->

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Fix Screenshot
**Integration tests passed**
<img width="1213" height="334" alt="Screenshot 2026-03-14 at 3 42 35 PM" src="https://github.com/user-attachments/assets/3060dc5e-2584-4e75-be1e-e4be05fc1ae0" />


## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [x] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [x] All unit tests pass (`cargo test`)
- [x] Integration tests pass (`cargo test --features integration-test`)
- [x] Changes were manually tested on **regtest**
- [x] End-to-end maker ↔ taker swap tested (where applicable)
- [x] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

## How to Test
<!-- Step-by-step instructions so reviewers can verify quickly. -->

```bash
# Standard swap (good baseline)
cargo test --test standard_swap --features integration-test -- --nocapture

# Abort scenarios
cargo test --test abort1 --features integration-test -- --nocapture
cargo test --test taproot_taker_abort1 --features integration-test -- --nocapture

# Malicious behavior & recovery
cargo test --test malice1 --features integration-test -- --nocapture
cargo test --test taproot_timelock_recovery --features integration-test -- --nocapture

# Or run the full suite
cargo test --features integration-test
```

<!-- Add any additional manual steps specific to this PR
     (e.g. regtest node config, docker-setup, specific taker commands): -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized and simplified logs across the maker module: removed per-port prefixes and now show peer, swap, or contract contexts with clearer thread/join messages.

* **New Features**
  * Added private-key handover handling in the maker message flow.
  * Added a sweep action to sweep incoming swapcoins after successful coinswaps.

* **Chores**
  * Startup now logs the Bitcoin network; connection logs include remote peer addresses; minor formatting and verbosity cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->