### PR TITLE
Remove redundant fields from fidelity bond

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -9,14 +9,14 @@
 use crate::{
     protocol::{
         contract::{check_hashvalues_are_equal, read_hashvalue_from_contract},
-        messages::{FidelityProof, ReqContractSigsForSender, PREIMAGE_LEN},
+        messages::{ReqContractSigsForSender, PREIMAGE_LEN},
         Hash160,
     },
     utill::{
         check_tor_status, get_maker_dir, get_tor_hostname, redeemscript_to_scriptpubkey,
         BLOCK_DELAY, HEART_BEAT_INTERVAL, REQUIRED_CONFIRMS,
     },
-    wallet::{ffi::SwapReport, RPCConfig, SwapCoin, WalletSwapCoin},
+    wallet::{ffi::SwapReport, FidelityBond, RPCConfig, SwapCoin, WalletSwapCoin},
     watch_tower::{
         service::{start_maker_watch_service, WatchService},
         watcher::{Role, WatcherEvent},
@@ -237,8 +237,8 @@ pub struct Maker {
     pub shutdown: AtomicBool,
     /// Map of IP address to Connection State + last Connected instant
     pub(crate) ongoing_swap_state: Mutex<HashMap<String, (ConnectionState, Instant)>>,
-    /// Highest Value Fidelity Proof
-    pub(crate) highest_fidelity_proof: RwLock<Option<FidelityProof>>,
+    /// Highest Value Fidelity Bond
+    pub(crate) highest_fidelity_bond: RwLock<Option<FidelityBond>>,
     /// Is setup complete
     pub is_setup_complete: AtomicBool,
     /// Path for the data directory.
@@ -332,7 +332,7 @@ impl Maker {
             wallet: RwLock::new(wallet),
             shutdown: AtomicBool::new(false),
             ongoing_swap_state: Mutex::new(HashMap::new()),
-            highest_fidelity_proof: RwLock::new(None),
+            highest_fidelity_bond: RwLock::new(None),
             is_setup_complete: AtomicBool::new(false),
             data_dir,
             thread_pool: Arc::new(ThreadPool::new(network_port)),
@@ -361,7 +361,7 @@ impl Maker {
                 .fidelity_bond
                 .iter()
                 .filter_map(|(i, bond)| {
-                    if bond.conf_height.is_none() && bond.cert_expiry.is_none() {
+                    if bond.conf_height.is_none() {
                         let conf_height = wallet_read
                             .wait_for_tx_confirmation(bond.outpoint.txid)
                             .unwrap();

--- a/src/maker/api2.rs
+++ b/src/maker/api2.rs
@@ -21,8 +21,8 @@ use crate::{
     },
     utill::{check_tor_status, get_maker_dir, get_tor_hostname, HEART_BEAT_INTERVAL, MIN_FEE_RATE},
     wallet::{
-        ffi::SwapReport, AddressType, Destination, IncomingSwapCoinV2, OutgoingSwapCoinV2,
-        RPCConfig, Wallet, WalletError,
+        ffi::SwapReport, AddressType, Destination, FidelityBond, IncomingSwapCoinV2,
+        OutgoingSwapCoinV2, RPCConfig, Wallet, WalletError,
     },
     watch_tower::{
         service::{start_maker_watch_service, WatchService},
@@ -242,8 +242,8 @@ pub struct Maker {
     pub shutdown: AtomicBool,
     /// Map of IP address to Connection State + last Connected instant
     pub(crate) ongoing_swap_state: Mutex<HashMap<String, (ConnectionState, Instant)>>,
-    /// Highest Value Fidelity Proof
-    pub(crate) highest_fidelity_proof: RwLock<Option<crate::protocol::messages::FidelityProof>>,
+    /// Highest Value Fidelity Bond
+    pub(crate) highest_fidelity_bond: RwLock<Option<FidelityBond>>,
     /// Is setup complete
     pub is_setup_complete: AtomicBool,
     /// Path for the data directory.
@@ -334,7 +334,7 @@ impl Maker {
             wallet: RwLock::new(wallet),
             shutdown: AtomicBool::new(false),
             ongoing_swap_state: Mutex::new(HashMap::new()),
-            highest_fidelity_proof: RwLock::new(None),
+            highest_fidelity_bond: RwLock::new(None),
             is_setup_complete: AtomicBool::new(false),
             data_dir,
             thread_pool: Arc::new(ThreadPool::new(network_port)),
@@ -364,7 +364,7 @@ impl Maker {
         let max_size = balances.spendable;
 
         // Read the cached fidelity proof
-        let fidelity_proof = self.highest_fidelity_proof.read()?;
+        let fidelity_proof = self.highest_fidelity_bond.read()?;
         let fidelity_proof = fidelity_proof
             .as_ref()
             .ok_or_else(|| MakerError::General("No fidelity proof available"))?
@@ -1077,7 +1077,7 @@ impl Maker {
                 .fidelity_bond
                 .iter()
                 .filter_map(|(i, bond)| {
-                    if bond.conf_height.is_none() && bond.cert_expiry.is_none() {
+                    if bond.conf_height.is_none() {
                         let conf_height = wallet_read
                             .wait_for_tx_confirmation(bond.outpoint.txid)
                             .ok()?;

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -101,8 +101,10 @@ pub(crate) fn handle_message(
                     (tweakable_point, max_size)
                 };
                 connection_state.allowed_message = ExpectedMessage::ReqContractSigsForSender;
-                let fidelity = maker.highest_fidelity_proof.read()?;
-                let fidelity = fidelity.as_ref().expect("proof expected");
+                let fidelity = maker.highest_fidelity_bond.read()?;
+                let fidelity = fidelity
+                    .as_ref()
+                    .ok_or(MakerError::General("No fidelity bond available"))?;
                 Some(MakerToTakerMessage::RespOffer(Box::new(Offer {
                     base_fee: maker.config.base_fee,
                     amount_relative_fee_pct: maker.config.amount_relative_fee_pct,

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -4,7 +4,7 @@
 //! The server maintains the thread pool for P2P Connection, Watchtower, Bitcoin Backend, and RPC Client Request.
 //! The server listens at two ports: 6102 for P2P, and 6103 for RPC Client requests.
 
-use crate::{maker::rpc::server::MakerRpc, protocol::messages::FidelityProof};
+use crate::{maker::rpc::server::MakerRpc, wallet::FidelityBond};
 use bitcoin::{absolute::LockTime, Amount};
 use bitcoind::bitcoincore_rpc::RpcApi;
 
@@ -100,10 +100,10 @@ fn spawn_nostr_broadcast_task(maker: Arc<Maker>) -> Result<(), MakerError> {
 
             while !maker_clone.shutdown.load(Ordering::Acquire) {
                 if elapsed >= interval {
-                    let fidelity = match maker_clone.highest_fidelity_proof.read() {
+                    let fidelity = match maker_clone.highest_fidelity_bond.read() {
                         Ok(guard) => guard.clone(),
                         Err(e) => {
-                            log::error!("Failed to read highest_fidelity_proof: {:?}", e);
+                            log::error!("Failed to read highest_fidelity_bond: {:?}", e);
                             return;
                         }
                     };
@@ -139,10 +139,10 @@ fn spawn_nostr_broadcast_task(maker: Arc<Maker>) -> Result<(), MakerError> {
 /// A valid fidelity bond is one that has not expired, been redeemed, or spent.
 ///
 /// ## Returns:
-/// - The highest **FidelityProof**, proving ownership of the highest valid fidelity bond, the maker has.
-fn setup_fidelity_bond(maker: &Maker, maker_address: &str) -> Result<FidelityProof, MakerError> {
+/// - The highest **FidelityBond**, proving ownership of the highest valid fidelity bond, the maker has.
+fn setup_fidelity_bond(maker: &Maker, maker_address: &str) -> Result<FidelityBond, MakerError> {
     let highest_index = maker.get_wallet().read()?.get_highest_fidelity_index()?;
-    let mut proof = maker.highest_fidelity_proof.write()?;
+    let mut proof = maker.highest_fidelity_bond.write()?;
 
     if let Some(i) = highest_index {
         let wallet_read = maker.get_wallet().read()?;
@@ -154,14 +154,11 @@ fn setup_fidelity_bond(maker: &Maker, maker_address: &str) -> Result<FidelityPro
         let bond_value = wallet_read.calculate_bond_value(&bond)?.to_sat();
         drop(wallet_read);
 
-        let highest_proof = maker
-            .get_wallet()
-            .read()?
-            .generate_fidelity_proof(i, maker_address)?;
+        let highest_proof = maker.get_wallet().read()?.fetch_fidelity_bond(i)?;
 
         log::info!(
             "Highest bond at outpoint {} | index {} | Amount {:?} sats | Remaining Timelock for expiry : {:?} Blocks | Current Bond Value : {:?} sats",
-            highest_proof.bond.outpoint,
+            highest_proof.outpoint,
             i,
             bond.amount.to_sat(),
             bond.lock_time.to_consensus_u32() - current_height,
@@ -248,10 +245,7 @@ fn setup_fidelity_bond(maker: &Maker, maker_address: &str) -> Result<FidelityPro
                         "[{}] Successfully created fidelity bond",
                         maker.config.network_port
                     );
-                    let highest_proof = maker
-                        .get_wallet()
-                        .read()?
-                        .generate_fidelity_proof(i, maker_address)?;
+                    let highest_proof = maker.get_wallet().read()?.fetch_fidelity_bond(i)?;
 
                     *proof = Some(highest_proof);
 

--- a/src/maker/server2.rs
+++ b/src/maker/server2.rs
@@ -31,7 +31,7 @@ use crate::{
     nostr_coinswap::broadcast_bond_on_nostr,
     protocol::messages2::{MakerToTakerMessage, TakerToMakerMessage},
     utill::{read_message, send_message, HEART_BEAT_INTERVAL, MIN_FEE_RATE},
-    wallet::{AddressType, SwapReport, WalletError},
+    wallet::{AddressType, FidelityBond, SwapReport, WalletError},
 };
 
 use crate::maker::error::MakerError;
@@ -94,10 +94,10 @@ fn spawn_nostr_broadcast_task(maker: Arc<Maker>) -> Result<(), MakerError> {
 
             while !maker_clone.shutdown.load(Ordering::Acquire) {
                 if elapsed >= interval {
-                    let fidelity = match maker_clone.highest_fidelity_proof.read() {
+                    let fidelity = match maker_clone.highest_fidelity_bond.read() {
                         Ok(guard) => guard.clone(),
                         Err(e) => {
-                            log::error!("Failed to read highest_fidelity_proof: {:?}", e);
+                            log::error!("Failed to read highest_fidelity_bond: {:?}", e);
                             return;
                         }
                     };
@@ -132,7 +132,7 @@ fn spawn_nostr_broadcast_task(maker: Arc<Maker>) -> Result<(), MakerError> {
 fn setup_fidelity_bond_taproot(
     maker: &Maker,
     maker_address: &str,
-) -> Result<crate::protocol::messages::FidelityProof, MakerError> {
+) -> Result<FidelityBond, MakerError> {
     use crate::wallet::WalletError;
     use bitcoin::absolute::LockTime;
     use std::thread;
@@ -149,23 +149,14 @@ fn setup_fidelity_bond_taproot(
         let bond_value = wallet_read.calculate_bond_value(&bond)?.to_sat();
         drop(wallet_read);
 
-        let proof_message = maker
-            .wallet()
-            .read()?
-            .generate_fidelity_proof(i, maker_address)?;
+        let proof_message = maker.wallet().read()?.fetch_fidelity_bond(i)?;
 
-        let highest_proof = crate::protocol::messages::FidelityProof {
-            bond: proof_message.bond.clone(),
-            cert_hash: *bitcoin::hashes::sha256d::Hash::from_bytes_ref(
-                proof_message.cert_hash.as_ref(),
-            ),
-            cert_sig: proof_message.cert_sig,
-        };
+        let highest_proof = proof_message.clone();
 
         log::info!(
             "[{}] Using existing fidelity bond at outpoint {} | index {} | Amount {:?} sats | Remaining Timelock for expiry : {:?} Blocks | Current Bond Value : {:?} sats",
             maker.config.network_port,
-            proof_message.bond.outpoint,
+            proof_message.outpoint,
             i,
             bond.amount.to_sat(),
             bond.lock_time.to_consensus_u32() - current_height,
@@ -173,7 +164,7 @@ fn setup_fidelity_bond_taproot(
         );
 
         // Store the fidelity proof in maker
-        *maker.highest_fidelity_proof.write()? = Some(highest_proof.clone());
+        *maker.highest_fidelity_bond.write()? = Some(highest_proof.clone());
 
         return Ok(highest_proof);
     }
@@ -276,26 +267,16 @@ fn setup_fidelity_bond_taproot(
                     "[{}] Successfully created fidelity bond",
                     maker.config.network_port
                 );
-                let proof_message = maker
-                    .wallet()
-                    .read()?
-                    .generate_fidelity_proof(i, maker_address)?;
+                let proof_message = maker.wallet().read()?.fetch_fidelity_bond(i)?;
 
-                // Convert to messages2::FidelityProof
-                let highest_proof = crate::protocol::messages::FidelityProof {
-                    bond: proof_message.bond,
-                    cert_hash: *bitcoin::hashes::sha256d::Hash::from_bytes_ref(
-                        proof_message.cert_hash.as_ref(),
-                    ),
-                    cert_sig: proof_message.cert_sig,
-                };
+                let highest_proof = proof_message;
 
                 // sync and save the wallet data to disk
                 log::info!("Sync at end:----setup_fidelity_bond----");
                 maker.wallet().write()?.sync_and_save()?;
 
                 // Store the fidelity proof in maker
-                *maker.highest_fidelity_proof.write()? = Some(highest_proof.clone());
+                *maker.highest_fidelity_bond.write()? = Some(highest_proof.clone());
 
                 return Ok(highest_proof);
             }

--- a/src/nostr_coinswap.rs
+++ b/src/nostr_coinswap.rs
@@ -16,7 +16,7 @@ use nostr::{
 };
 use tungstenite::Message;
 
-use crate::{maker::MakerError, protocol::messages::FidelityProof};
+use crate::{maker::MakerError, wallet::FidelityBond};
 
 /// nostr url for coinswap
 #[cfg(not(feature = "integration-test"))]
@@ -31,8 +31,8 @@ pub const COINSWAP_KIND: u16 = 37777;
 const EXPIRATION_SECS: u64 = 86400;
 
 /// Broadcasts a fidelity bond announcement over Nostr.
-pub fn broadcast_bond_on_nostr(fidelity: FidelityProof) -> Result<(), MakerError> {
-    let outpoint = fidelity.bond.outpoint;
+pub fn broadcast_bond_on_nostr(fidelity: FidelityBond) -> Result<(), MakerError> {
+    let outpoint = fidelity.outpoint;
     let content = format!("{}:{}", outpoint.txid, outpoint.vout);
     // Kind 37777 is in the NIP-33 parameterized-replaceable range (30000..39999),
     // so included a stable `d` tag to keep relay handling spec-compliant.
@@ -51,16 +51,13 @@ pub fn broadcast_bond_on_nostr(fidelity: FidelityProof) -> Result<(), MakerError
         + EXPIRATION_SECS;
 
     log::debug!(
-        "Publishing fidelity bond to Nostr | outpoint={} amount_sats={} lock_time={} conf_height={:?} cert_expiry={:?} is_spent={} pubkey={} cert_hash={} cert_sig={:?} content={} d_tag={} expiration_unix={}",
-        fidelity.bond.outpoint,
-        fidelity.bond.amount.to_sat(),
-        fidelity.bond.lock_time.to_consensus_u32(),
-        fidelity.bond.conf_height,
-        fidelity.bond.cert_expiry,
-        fidelity.bond.is_spent,
-        fidelity.bond.pubkey,
-        fidelity.cert_hash,
-        fidelity.cert_sig,
+        "Publishing fidelity bond to Nostr | outpoint={} amount_sats={} lock_time={} conf_height={:?} is_spent={} pubkey={}  content={} d_tag={} expiration_unix={}",
+        fidelity.outpoint,
+        fidelity.amount.to_sat(),
+        fidelity.lock_time.to_consensus_u32(),
+        fidelity.conf_height,
+        fidelity.is_spent,
+        fidelity.pubkey,
         content,
         d_tag,
         expiration

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -57,10 +57,7 @@
 
 use std::fmt::Display;
 
-use bitcoin::{
-    ecdsa::Signature, hashes::sha256d::Hash, secp256k1::SecretKey, Amount, PublicKey, ScriptBuf,
-    Transaction,
-};
+use bitcoin::{ecdsa::Signature, secp256k1::SecretKey, Amount, PublicKey, ScriptBuf, Transaction};
 
 use serde::{Deserialize, Serialize};
 
@@ -235,17 +232,6 @@ pub(crate) struct MakerHello {
     pub(crate) protocol_version_max: u32,
 }
 
-/// Contains proof data related to fidelity bond.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct FidelityProof {
-    /// Details for Fidelity Bond
-    pub bond: FidelityBond,
-    /// Double SHA256 hash of certificate message proving bond ownership and binding to maker address
-    pub cert_hash: Hash,
-    /// ECDSA signature over cert_hash using the bond's private key
-    pub cert_sig: bitcoin::secp256k1::ecdsa::Signature,
-}
-
 /// Represents an offer in the context of the Coinswap protocol.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Offer {
@@ -266,8 +252,8 @@ pub struct Offer {
     /// Displayed public key of makers, for receiving swaps.
     /// Actual swap addresses are derived from this public key using unique nonces per swap.
     pub tweakable_point: PublicKey,
-    /// Cryptographic proof of fidelity bond for Sybil resistance
-    pub fidelity: FidelityProof,
+    /// fidelity bond for Sybil resistance
+    pub fidelity: FidelityBond,
 }
 
 /// Contract Tx signatures provided by a Sender of a Coinswap.

--- a/src/protocol/messages2.rs
+++ b/src/protocol/messages2.rs
@@ -1,9 +1,10 @@
 //! This module defines the messages communicated between the parties(Taker, Maker)
-use crate::protocol::messages::FidelityProof;
 use bitcoin::{Amount, PublicKey, ScriptBuf, Txid};
 use secp256k1::musig::{PartialSignature, PublicNonce};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryInto, fmt::Display};
+
+use crate::wallet::FidelityBond;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 /// Serializable wrapper for secp256k1 PublicNonce
@@ -137,8 +138,8 @@ pub struct Offer {
     pub time_relative_fee: f64,
     /// Minimum time lock duration required by the maker
     pub minimum_locktime: u16,
-    /// Fidelity proof demonstrating the maker's commitment
-    pub fidelity: FidelityProof,
+    /// Fidelity bond demonstrating the maker's commitment
+    pub fidelity: FidelityBond,
     /// Minimum swap amount the maker will accept (in satoshis)
     pub min_size: u64,
     /// Maximum swap amount the maker can handle (in satoshis)

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -2360,7 +2360,7 @@ impl Taker {
             return Ok(header);
         };
 
-        let bond = &offer.fidelity.bond;
+        let bond = &offer.fidelity;
         let bond_value = self.get_wallet().calculate_bond_value(bond)?;
 
         Ok(format!(

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -20,14 +20,13 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use bitcoin::hashes::Hash;
 use serde::{Deserialize, Serialize};
 use socks::Socks5Stream;
 
 use crate::{
     protocol::{
         error::ProtocolError,
-        messages::{FidelityProof, GiveOffer, MakerToTakerMessage, Offer, TakerToMakerMessage},
+        messages::{GiveOffer, MakerToTakerMessage, Offer, TakerToMakerMessage},
         messages2::{self, GetOffer},
     },
     taker::{
@@ -39,7 +38,7 @@ use crate::{
         routines::handshake_maker,
     },
     utill::{read_message, send_message},
-    wallet::verify_fidelity_checks,
+    wallet::{verify_fidelity_checks, FidelityBond},
     watch_tower::{rest_backend::BitcoinRest, service::WatchService, watcher::WatcherEvent},
 };
 
@@ -413,7 +412,7 @@ impl OfferSyncService {
 
             for oa in offers {
                 responded.insert(oa.address.clone());
-                match self.verify_fidelity_proof(&oa.offer.fidelity, &oa.address.to_string()) {
+                match self.verify_fidelity_bond(&oa.offer.fidelity, &oa.address.to_string()) {
                     Ok(_) => {
                         book.mark_success(&oa.address, oa.offer, oa.protocol, now);
                     }
@@ -518,16 +517,16 @@ impl OfferSyncService {
     }
 
     /// do the fidelity proof
-    fn verify_fidelity_proof(
+    fn verify_fidelity_bond(
         &self,
-        proof: &FidelityProof,
+        bond: &FidelityBond,
         onion_addr: &str,
     ) -> Result<(), TakerError> {
-        let txid = proof.bond.outpoint.txid;
+        let txid = bond.outpoint.txid;
         let transaction = self.rest_backend.get_raw_tx(&txid)?;
         let current_height = self.rest_backend.get_block_count()?;
 
-        verify_fidelity_checks(proof, onion_addr, transaction, current_height)
+        verify_fidelity_checks(bond, onion_addr, transaction, current_height)
             .map_err(TakerError::Wallet)
     }
 }
@@ -885,14 +884,7 @@ impl MakerAddress {
             max_size: taproot_offer.max_size,
             min_size: taproot_offer.min_size,
             tweakable_point: taproot_offer.tweakable_point,
-            fidelity: crate::protocol::messages::FidelityProof {
-                bond: taproot_offer.fidelity.bond,
-                cert_hash: bitcoin::hashes::sha256d::Hash::from_slice(
-                    taproot_offer.fidelity.cert_hash.as_ref(),
-                )
-                .unwrap(),
-                cert_sig: taproot_offer.fidelity.cert_sig,
-            },
+            fidelity: taproot_offer.fidelity,
         };
 
         log::info!(
@@ -921,7 +913,7 @@ mod tests {
     use bitcoin::{
         absolute::LockTime,
         hashes::Hash,
-        secp256k1::{Message, Secp256k1, SecretKey},
+        secp256k1::{Secp256k1, SecretKey},
         Amount, OutPoint, Txid,
     };
 
@@ -932,7 +924,7 @@ mod tests {
         })
     }
 
-    fn dummy_offer(maker_addr: &str) -> Offer {
+    fn dummy_offer() -> Offer {
         let secp = Secp256k1::new();
         let secret_key = SecretKey::from_slice(&[1; 32]).expect("valid secret key");
         let secp_pubkey = bitcoin::secp256k1::PublicKey::from_secret_key(&secp, &secret_key);
@@ -947,15 +939,8 @@ mod tests {
             lock_time: LockTime::from_height(1000).expect("valid height locktime"),
             pubkey,
             conf_height: Some(1000),
-            cert_expiry: Some(1),
             is_spent: false,
         };
-
-        let cert_hash = bond
-            .generate_cert_hash(maker_addr)
-            .expect("cert_expiry set");
-        let msg = Message::from_digest_slice(cert_hash.as_byte_array()).expect("32-byte digest");
-        let cert_sig = secp.sign_ecdsa(&msg, &secret_key);
 
         Offer {
             base_fee: 0,
@@ -966,11 +951,7 @@ mod tests {
             max_size: 1,
             min_size: 1,
             tweakable_point: pubkey,
-            fidelity: FidelityProof {
-                bond,
-                cert_hash,
-                cert_sig,
-            },
+            fidelity: bond,
         }
     }
 
@@ -1025,11 +1006,7 @@ mod tests {
             next_offer_check_ts: Some(now_ts + 123),
         };
 
-        candidate.mark_success(
-            dummy_offer(&candidate.address.to_string()),
-            MakerProtocol::Taproot,
-            now_ts,
-        );
+        candidate.mark_success(dummy_offer(), MakerProtocol::Taproot, now_ts);
         assert_eq!(candidate.state, MakerState::Bad);
     }
 

--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -1,15 +1,14 @@
 use crate::{
-    protocol::messages::FidelityProof,
     utill::{redeemscript_to_scriptpubkey, MIN_FEE_RATE},
     wallet::{AddressType, Wallet},
+    watch_tower::utils::process_fidelity,
 };
 use bitcoin::{
     absolute::LockTime,
     bip32::{ChildNumber, DerivationPath},
-    hashes::{sha256d, Hash},
     opcodes::all::{OP_CHECKSIGVERIFY, OP_CLTV},
     script::{Builder, Instruction},
-    secp256k1::{Keypair, Message, Secp256k1},
+    secp256k1::{Keypair, Secp256k1},
     Address, Amount, OutPoint, PublicKey, ScriptBuf, Transaction,
 };
 use bitcoind::bitcoincore_rpc::RpcApi;
@@ -56,11 +55,10 @@ pub enum FidelityError {
     BondDoesNotExist,
     BondAlreadyRedeemed,
     BondLocktimeExpired,
-    CertExpired,
-    InvalidCertHash,
     General(String),
     InvalidBondLocktime,
     BondUncomfirmed,
+    InvalidOpReturn,
 }
 
 impl std::fmt::Display for FidelityError {
@@ -72,12 +70,13 @@ impl std::fmt::Display for FidelityError {
                 write!(f, "Fidelity bond has already been redeemed")
             }
             FidelityError::BondLocktimeExpired => write!(f, "Fidelity bond locktime has expired"),
-            FidelityError::CertExpired => write!(f, "Fidelity certificate has expired"),
-            FidelityError::InvalidCertHash => write!(f, "Invalid fidelity certificate hash"),
             FidelityError::InvalidBondLocktime => {
                 write!(f, "Fidelity bond locktime is outside the acceptable range")
             }
             FidelityError::BondUncomfirmed => write!(f, "Fidelity bond transaction is unconfirmed"),
+            FidelityError::InvalidOpReturn => {
+                write!(f, "Invalid OP_RETURN data in fidelity bond transaction")
+            }
             FidelityError::General(msg) => write!(f, "{}", msg),
         }
     }
@@ -102,17 +101,16 @@ fn fidelity_redeemscript(lock_time: &LockTime, pubkey: &PublicKey) -> ScriptBuf 
 }
 
 /// Verifies a fidelity bond by checking timelock validity,
-/// certificate integrity, redeem script existence, and ECDSA signature correctness.
+/// redeem script existence.
 pub(crate) fn verify_fidelity_checks(
-    proof: &FidelityProof,
-    addr: &str,
+    bond: &FidelityBond,
+    onion_addr: &str,
     tx: Transaction,
     current_height: u64,
 ) -> Result<(), WalletError> {
     // Ensure fidelity bond timelock lies within allowed range
-    let bond_height = proof.bond.lock_time.to_consensus_u32()
-        - proof
-            .bond
+    let bond_height = bond.lock_time.to_consensus_u32()
+        - bond
             .conf_height
             .ok_or(WalletError::Fidelity(FidelityError::BondDoesNotExist))?;
     if !(MIN_FIDELITY_TIMELOCK..=MAX_FIDELITY_TIMELOCK).contains(&bond_height) {
@@ -127,34 +125,34 @@ pub(crate) fn verify_fidelity_checks(
 
     // Check if bond lock time has expired
     let lock_time = LockTime::from_height(current_height as u32)?;
-    if lock_time > proof.bond.lock_time {
+    if lock_time > bond.lock_time {
         return Err(FidelityError::BondLocktimeExpired.into());
     }
 
-    // Verify certificate hash
-    let expected_cert_hash = proof
-        .bond
-        .generate_cert_hash(addr)
-        .ok_or(WalletError::Fidelity(FidelityError::BondUncomfirmed))?;
-    if proof.cert_hash != expected_cert_hash {
-        return Err(FidelityError::InvalidCertHash.into());
+    // Verify OP_RETURN matches the Maker offer
+    match process_fidelity(&tx) {
+        Some(fidelity) => {
+            if fidelity.onion != onion_addr {
+                return Err(FidelityError::General(format!(
+                    "Fidelity OP_RETURN onion address mismatch. Expected: {}, Found: {}",
+                    onion_addr, fidelity.onion
+                ))
+                .into());
+            }
+        }
+        None => return Err(FidelityError::InvalidOpReturn.into()),
     }
 
     // Validate redeem script and corresponding output scriptPubKey
-    let fidelity_redeem_script = fidelity_redeemscript(&proof.bond.lock_time, &proof.bond.pubkey);
+    let fidelity_redeem_script = fidelity_redeemscript(&bond.lock_time, &bond.pubkey);
     let derived_script_pubkey = redeemscript_to_scriptpubkey(&fidelity_redeem_script)?;
     let tx_out = tx
-        .tx_out(proof.bond.outpoint.vout as usize)
+        .tx_out(bond.outpoint.vout as usize)
         .map_err(|_| WalletError::General("Outputs index error".to_string()))?;
 
     if tx_out.script_pubkey != derived_script_pubkey {
         return Err(WalletError::Fidelity(FidelityError::BondDoesNotExist));
     }
-
-    // Verify ECDSA signature
-    let secp = Secp256k1::new();
-    let cert_message = Message::from_digest_slice(proof.cert_hash.as_byte_array())?;
-    secp.verify_ecdsa(&cert_message, &proof.cert_sig, &proof.bond.pubkey.inner)?;
 
     Ok(())
 }
@@ -216,8 +214,6 @@ pub struct FidelityBond {
     pub(crate) pubkey: PublicKey,
     // Height at which the bond was confirmed.
     pub(crate) conf_height: Option<u32>,
-    // Cert expiry denoted in multiple of difficulty adjustment period (2016 blocks)
-    pub(crate) cert_expiry: Option<u32>,
     /// Whether this bond is spent or not.
     pub(crate) is_spent: bool,
 }
@@ -235,28 +231,6 @@ impl FidelityBond {
     /// Get the script_pubkey for this bond.
     pub(crate) fn script_pub_key(&self) -> ScriptBuf {
         redeemscript_to_scriptpubkey(&self.redeem_script()).expect("This can never panic as fidelity redeemscript template is hardcoded in a private function.")
-    }
-
-    /// Generate the bond's certificate hash.
-    pub(crate) fn generate_cert_hash(&self, addr: &str) -> Option<sha256d::Hash> {
-        self.cert_expiry.map(|expiry| {
-            let cert_msg_str = format!(
-                "fidelity-bond-cert|{}|{}|{}|{}|{}|{}",
-                self.outpoint, self.pubkey, expiry, self.lock_time, self.amount, addr
-            );
-            let cert_msg = cert_msg_str.as_bytes();
-            let mut btc_signed_msg = Vec::<u8>::new();
-            btc_signed_msg.extend("\x18Bitcoin Signed Message:\n".as_bytes());
-            btc_signed_msg.push(cert_msg.len() as u8);
-            btc_signed_msg.extend(cert_msg);
-
-            sha256d::Hash::hash(&btc_signed_msg)
-        })
-    }
-
-    /// Calculate the expiry value. This depends on the bond's confirmation height
-    pub(crate) fn get_fidelity_expiry(conf_height: u32) -> u32 {
-        (conf_height + 2) /* safety buffer */ / 2016 + 5
     }
 }
 
@@ -458,9 +432,8 @@ impl Wallet {
                 amount,
                 lock_time: locktime,
                 pubkey: fidelity_pubkey,
-                // `Conf_height` & `cert_expiry` are considered None as they can't be known before the confirmation.
+                // `Conf_height` considered None as they can't be known before the confirmation.
                 conf_height: None,
-                cert_expiry: None,
                 is_spent: false,
             };
             self.store.fidelity_bond.insert(index, bond);
@@ -479,14 +452,12 @@ impl Wallet {
         index: u32,
         conf_height: u32,
     ) -> Result<(), WalletError> {
-        let cert_expiry = FidelityBond::get_fidelity_expiry(conf_height);
         let bond = self
             .store
             .fidelity_bond
             .get_mut(&index)
             .ok_or(FidelityError::BondDoesNotExist)?;
 
-        bond.cert_expiry = Some(cert_expiry);
         bond.conf_height = Some(conf_height);
 
         Ok(())
@@ -519,12 +490,8 @@ impl Wallet {
         })
     }
 
-    /// Generate a [`FidelityProof`] for bond at a given index and a specific onion address.
-    pub(crate) fn generate_fidelity_proof(
-        &self,
-        index: u32,
-        maker_addr: &str,
-    ) -> Result<FidelityProof, WalletError> {
+    /// Gets a [`FidelityBond`] for bond at a given index and check spent
+    pub(crate) fn fetch_fidelity_bond(&self, index: u32) -> Result<FidelityBond, WalletError> {
         // Generate a fidelity bond proof from the fidelity data.
         let bond = self
             .store
@@ -535,23 +502,7 @@ impl Wallet {
             return Err(FidelityError::BondAlreadyRedeemed.into());
         }
 
-        let fidelity_privkey = self.get_fidelity_keypair(index)?.secret_key();
-
-        let cert_hash = bond
-            .generate_cert_hash(maker_addr)
-            .expect("Bond is not yet confirmed");
-
-        let secp = Secp256k1::new();
-        let cert_sig = secp.sign_ecdsa(
-            &Message::from_digest_slice(cert_hash.as_byte_array())?,
-            &fidelity_privkey,
-        );
-
-        Ok(FidelityProof {
-            bond: bond.clone(),
-            cert_hash,
-            cert_sig,
-        })
+        Ok(bond.clone())
     }
 
     fn encode_fidelity_op_return(


### PR DESCRIPTION
## Description

- Removes `FidelityProof` from protocol messages, using `FidelityBond` directly
- Removes `cert_expiry` field from `FidelityBond` as certificate-based verification is no longer needed
- Removes `generate_fidelity_proof()` method, replacing it with simpler `fetch_fidelity_bond()`
- Removes certificate hash verification and ECDSA signature checks from `verify_fidelity_checks()`
- Updates all references from `highest_fidelity_proof` to `highest_fidelity_bond`
- Verify fidelity bond OP_RETURN onion address matches maker address

## Related Issue(s)
Closes #655

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [x] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [x] **makerd** (background daemon)
- [x] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [x] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved fidelity bond handling and OP_RETURN-based validation.
  * Nostr broadcasts now publish fidelity bond details directly.

* **Refactor**
  * Simplified fidelity data model by removing certificate-based fields and flows.
  * Wallet API updated to fetch and track bonds more directly.

* **Bug Fixes**
  * More robust handling when no fidelity bond is present (replaces crash with an error).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->