### PR TITLE
fix: intercept port conflicts before Maker initialization to protect …

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -159,6 +159,44 @@ impl Default for MakerServerConfig {
 }
 
 impl MakerServerConfig {
+    /// Validates that all required ports are available before heavy operations
+    pub(crate) fn validate_ports(
+        &self,
+    ) -> Result<(std::net::TcpListener, std::net::TcpListener), MakerError> {
+        use std::net::TcpListener;
+
+        if self.network_port == self.rpc_port {
+            return Err(MakerError::General(
+                "Network port and RPC port cannot be the same",
+            ));
+        }
+
+        // Check network port
+        let network_listener = match TcpListener::bind(("127.0.0.1", self.network_port)) {
+            Ok(listener) => listener,
+            Err(_) => {
+                let err_msg = format!("Network port {} is already in use", self.network_port);
+                log::error!("{}", err_msg);
+                return Err(MakerError::General(
+                    "Configured network port is already in use",
+                ));
+            }
+        };
+
+        // Check RPC port
+        let rpc_listener = match TcpListener::bind(("127.0.0.1", self.rpc_port)) {
+            Ok(listener) => listener,
+            Err(_) => {
+                let err_msg = format!("RPC port {} is already in use", self.rpc_port);
+                log::error!("{}", err_msg);
+                return Err(MakerError::General(
+                    "Configured RPC port is already in use",
+                ));
+            }
+        };
+
+        Ok((network_listener, rpc_listener))
+    }
     /// Load configuration from a TOML file at the given path.
     ///
     /// If `config_path` is `None`, defaults to `~/.coinswap/maker/config.toml`.
@@ -378,6 +416,10 @@ pub struct MakerServer {
     pub swap_tracker: Mutex<MakerSwapTracker>,
     /// Nostr relay URLs for fidelity bond broadcasting.
     pub nostr_relays: Vec<String>,
+    /// Saved network listener
+    pub(crate) network_listener: Mutex<Option<std::net::TcpListener>>,
+    /// Saved RPC listener
+    pub(crate) rpc_listener: Mutex<Option<std::net::TcpListener>>,
     /// Test-only behavior override.
     #[cfg(feature = "integration-test")]
     pub behavior: MakerBehavior,
@@ -414,6 +456,10 @@ impl MakerServer {
 
         let wallet =
             Wallet::load_or_init_wallet(&wallet_path, &rpc_config, config.password.clone())?;
+
+        // Validate ports are available before heavy initialization
+        let (network_listener, rpc_listener) = config.validate_ports()?;
+        log::info!("All required ports are available");
 
         // Initial wallet sync
         let mut wallet = wallet;
@@ -453,6 +499,8 @@ impl MakerServer {
             data_dir,
             swap_tracker: Mutex::new(swap_tracker),
             nostr_relays,
+            network_listener: Mutex::new(Some(network_listener)),
+            rpc_listener: Mutex::new(Some(rpc_listener)),
             #[cfg(feature = "integration-test")]
             behavior: MakerBehavior::default(),
         })
@@ -1429,5 +1477,8 @@ impl MakerRpc for MakerServer {
             self.config.network_port,
             &self.config.tor_auth_password,
         )
+    }
+    fn take_rpc_listener(&self) -> Option<std::net::TcpListener> {
+        self.rpc_listener.lock().unwrap().take()
     }
 }

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -189,9 +189,7 @@ impl MakerServerConfig {
             Err(_) => {
                 let err_msg = format!("RPC port {} is already in use", self.rpc_port);
                 log::error!("{}", err_msg);
-                return Err(MakerError::General(
-                    "Configured RPC port is already in use",
-                ));
+                return Err(MakerError::General("Configured RPC port is already in use"));
             }
         };
 

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -1,6 +1,6 @@
 use std::{
     io::ErrorKind,
-    net::{TcpListener, TcpStream},
+    net::TcpStream,
     sync::{
         atomic::{AtomicBool, Ordering::Relaxed},
         Arc,
@@ -25,6 +25,7 @@ pub trait MakerRpc {
     fn config(&self) -> &MakerServerConfig;
     fn shutdown(&self) -> &AtomicBool;
     fn get_tor_hostname(&self) -> Result<String, TorError>;
+    fn take_rpc_listener(&self) -> Option<std::net::TcpListener>;
 }
 
 fn handle_request<M: MakerRpc>(maker: &Arc<M>, socket: &mut TcpStream) -> Result<(), MakerError> {
@@ -159,7 +160,10 @@ fn handle_request<M: MakerRpc>(maker: &Arc<M>, socket: &mut TcpStream) -> Result
 pub(crate) fn start_rpc_server<M: MakerRpc>(maker: Arc<M>) -> Result<(), MakerError> {
     let rpc_port = maker.config().rpc_port;
     let rpc_socket = format!("127.0.0.1:{rpc_port}");
-    let listener = Arc::new(TcpListener::bind(&rpc_socket)?);
+    let listener_from_maker = maker
+        .take_rpc_listener()
+        .expect("RPC listener should be reserved");
+    let listener = Arc::new(listener_from_maker);
     log::info!(
         "[{}] RPC socket binding successful at {}",
         maker.config().network_port,

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -2,7 +2,7 @@
 
 use std::{
     io::ErrorKind,
-    net::{Ipv4Addr, TcpListener, TcpStream},
+    net::TcpStream,
     sync::{
         atomic::Ordering::{self, Relaxed},
         Arc,
@@ -112,8 +112,13 @@ pub fn start_server(maker: Arc<MakerServer>) -> Result<(), MakerError> {
         );
     }
 
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, maker.config.network_port))
-        .map_err(MakerError::IO)?;
+    let listener_from_maker = maker
+        .network_listener
+        .lock()
+        .unwrap()
+        .take()
+        .expect("Network listener already consumed or not set");
+    let listener = Arc::new(listener_from_maker);
     listener.set_nonblocking(true).map_err(MakerError::IO)?;
 
     maker.is_setup_complete.store(true, Relaxed);
@@ -731,6 +736,7 @@ fn recover_from_swap(
         r.phase = MakerSwapPhase::Recovering;
         r.recovery.phase = MakerRecoveryPhase::Monitoring;
     });
+
 
     // NOTE: Do NOT re-register outgoing contract outputs here.
     // They were already registered with the watch tower during swap setup

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -737,7 +737,6 @@ fn recover_from_swap(
         r.recovery.phase = MakerRecoveryPhase::Monitoring;
     });
 
-
     // NOTE: Do NOT re-register outgoing contract outputs here.
     // They were already registered with the watch tower during swap setup
     // (in legacy_handlers / taproot_handlers). Re-registering would overwrite


### PR DESCRIPTION

# Pull Request

## Description
This PR is WIP to enhance system boot process.

## Related Issue(s)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [x] Both
- [ ] Neither (infrastructure / tooling only)

## Affected Component(s)
- [x] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ ] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [x] All unit tests pass (`cargo test`)
- [x] Integration tests pass (`cargo test --features integration-test`)
- [ ] Changes were manually tested on **regtest**
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

## How to Test
<!-- Step-by-step instructions so reviewers can verify quickly. -->

```bash
# Standard swap (good baseline)
cargo test --test standard_swap --features integration-test -- --nocapture

# Abort scenarios
cargo test --test abort1 --features integration-test -- --nocapture
cargo test --test taproot_taker_abort1 --features integration-test -- --nocapture

# Malicious behavior & recovery
cargo test --test malice1 --features integration-test -- --nocapture
cargo test --test taproot_timelock_recovery --features integration-test -- --nocapture

# Or run the full suite
cargo test --features integration-test
```

<!-- Add any additional manual steps specific to this PR
     (e.g. regtest node config, docker-setup, specific taker commands): -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server now reserves and pre-binds network and RPC ports at startup to ensure port availability.

* **Bug Fixes**
  * Rejects configurations that assign the same port to both network and RPC.
  * Startup now fails earlier with clearer logging when port reservation/binding cannot succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->