### PR TITLE
Feat(todo): Add list-offers command to taker-cli 

### DIFF
--- a/docs/taker.md
+++ b/docs/taker.md
@@ -95,6 +95,8 @@ SUBCOMMANDS:
             Initiate the coinswap process
     fetch-offers
             Update the offerbook with current market offers and display them
+    list-offers
+            List makers from the locally cached offerbook without triggering a network sync
     get-balances
             Get total wallet balances of different categories. regular: All single signature regular
             wallet coins (seed balance). swap: All 2of2 multisig coins received in swaps. contract:

--- a/docs/taker.md
+++ b/docs/taker.md
@@ -96,7 +96,7 @@ SUBCOMMANDS:
     fetch-offers
             Update the offerbook with current market offers and display them
     list-offers
-            List makers from the locally cached offerbook without triggering a network sync
+            List makers from the locally cached offerbook without requesting a fresh offer sync
     get-balances
             Get total wallet balances of different categories. regular: All single signature regular
             wallet coins (seed balance). swap: All 2of2 multisig coins received in swaps. contract:

--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -106,7 +106,8 @@ enum Commands {
     /// Update the offerbook with current market offers and display them
     FetchOffers,
 
-    // TODO: Also add ListOffers command to just list the current book.
+    /// List makers from the locally cached offerbook without triggering a network sync.
+    ListOffers,
     /// Initiate the coinswap process
     Coinswap {
         /// Sets the Maker count to swap with. Swapping with less than 2 makers is not allowed to maintain client privacy.
@@ -419,6 +420,41 @@ fn main() -> Result<(), TakerError> {
                 good,
                 bad,
                 unresponsive,
+                makers.len()
+            );
+        }
+        Commands::ListOffers => {
+            let offerbook = taker.fetch_offers()?;
+            let makers = offerbook.all_makers();
+
+            if makers.is_empty() {
+                println!(
+                    "No makers in local offerbook. Run `fetch-offers` to sync from the network."
+                );
+                return Ok(());
+            }
+
+            let mut good_maker = 0;
+            let mut bad_maker = 0;
+            let mut unresponsive_maker = 0;
+
+            println!("\n{} makers in local offerbook\n", makers.len());
+
+            for maker in &makers {
+                match maker.state {
+                    MakerState::Good => good_maker += 1,
+                    MakerState::Bad => bad_maker += 1,
+                    MakerState::Unresponsive { .. } => unresponsive_maker += 1,
+                }
+
+                let wallet = taker.get_wallet().read().unwrap();
+                println!("{}", display_offer(&wallet, maker)?);
+            }
+            println!(
+                "\nOfferbook summary → good: {}, bad: {}, unresponsive: {} (total: {})",
+                good_maker,
+                bad_maker,
+                unresponsive_maker,
                 makers.len()
             );
         }

--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -172,6 +172,30 @@ fn parse_protocol(s: &str) -> Result<ProtocolVersion, TakerError> {
     }
 }
 
+/// Display all makers with per-state counts and a summary line.
+fn display_makers_with_summary(
+    wallet: &Wallet,
+    makers: &[MakerOfferCandidate],
+) -> Result<(), TakerError> {
+    let (mut good, mut bad, mut unresponsive) = (0, 0, 0);
+    for maker in makers {
+        match maker.state {
+            MakerState::Good => good += 1,
+            MakerState::Bad => bad += 1,
+            MakerState::Unresponsive { .. } => unresponsive += 1,
+        }
+        println!("{}", display_offer(wallet, maker)?);
+    }
+    println!(
+        "\nOfferbook summary → good: {}, bad: {}, unresponsive: {} (total: {})",
+        good,
+        bad,
+        unresponsive,
+        makers.len()
+    );
+    Ok(())
+}
+
 /// Format a maker offer candidate as a human-readable string.
 fn display_offer(wallet: &Wallet, candidate: &MakerOfferCandidate) -> Result<String, TakerError> {
     let header = format!(
@@ -398,30 +422,10 @@ fn main() -> Result<(), TakerError> {
                 return Ok(());
             }
 
-            let mut good = 0;
-            let mut bad = 0;
-            let mut unresponsive = 0;
-
             println!("\nDiscovered {} makers\n", makers.len());
 
-            for maker in &makers {
-                match maker.state {
-                    MakerState::Good => good += 1,
-                    MakerState::Bad => bad += 1,
-                    MakerState::Unresponsive { .. } => unresponsive += 1,
-                }
-
-                let wallet = taker.get_wallet().read().unwrap();
-                println!("{}", display_offer(&wallet, maker)?);
-            }
-
-            println!(
-                "\nOfferbook summary → good: {}, bad: {}, unresponsive: {} (total: {})",
-                good,
-                bad,
-                unresponsive,
-                makers.len()
-            );
+            let wallet = taker.get_wallet().read().unwrap();
+            display_makers_with_summary(&wallet, &makers)?;
         }
         Commands::ListOffers => {
             let offerbook = taker.fetch_offers()?;
@@ -434,29 +438,10 @@ fn main() -> Result<(), TakerError> {
                 return Ok(());
             }
 
-            let mut good_maker = 0;
-            let mut bad_maker = 0;
-            let mut unresponsive_maker = 0;
-
             println!("\n{} makers in local offerbook\n", makers.len());
 
-            for maker in &makers {
-                match maker.state {
-                    MakerState::Good => good_maker += 1,
-                    MakerState::Bad => bad_maker += 1,
-                    MakerState::Unresponsive { .. } => unresponsive_maker += 1,
-                }
-
-                let wallet = taker.get_wallet().read().unwrap();
-                println!("{}", display_offer(&wallet, maker)?);
-            }
-            println!(
-                "\nOfferbook summary → good: {}, bad: {}, unresponsive: {} (total: {})",
-                good_maker,
-                bad_maker,
-                unresponsive_maker,
-                makers.len()
-            );
+            let wallet = taker.get_wallet().read().unwrap();
+            display_makers_with_summary(&wallet, &makers)?;
         }
         Commands::Coinswap {
             makers,


### PR DESCRIPTION
# Pull Request
While exploring the codebase, i noticed this todo:
https://github.com/citadel-tech/coinswap/blob/e81133c32f98c084fd2abd2eb288908c87cce6ab/src/bin/taker.rs#L109


## Description

This PR adds the mentioned `list-offers` command which fetches the maker offers from locally cached offerbook. It fetches the offers from `fetch_offers()` function call and uses `display_offer()` help to print the output. 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [x] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [x] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [x] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [x] All unit tests pass (`cargo test`)
- [x] Integration tests pass (`cargo test --features integration-test`)
- [x] Changes were manually tested on **signet**
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [x] Relevant files in the `docs/` folder were updated

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

## How to Test
Run `taker list-offers` to get the list of offers. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `list-offers` command to view makers from the local offerbook without performing a network sync.
  * Command shows per-maker details and an aggregated summary of maker counts and states.
  * Improved list output wording and added guidance when the local offerbook is empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->