### PR TITLE
nostr: use network-specific CoinSwap event kinds for publish/discovery

### DIFF
--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -234,7 +234,9 @@ fn spawn_nostr_broadcast_thread(
         .name("nostr-thread".to_string())
         .spawn(move || {
             // Initial broadcast
-            if let Err(e) = broadcast_bond_on_nostr(fidelity.clone(), &relays) {
+            if let Err(e) =
+                broadcast_bond_on_nostr(fidelity.clone(), maker_clone.config.network, &relays)
+            {
                 log::warn!("Initial nostr broadcast failed: {:?}", e);
             }
 
@@ -254,7 +256,9 @@ fn spawn_nostr_broadcast_thread(
 
                 log::debug!("Re-pinging nostr relays with bond announcement");
 
-                if let Err(e) = broadcast_bond_on_nostr(fidelity.clone(), &relays) {
+                if let Err(e) =
+                    broadcast_bond_on_nostr(fidelity.clone(), maker_clone.config.network, &relays)
+                {
                     log::warn!("Nostr re-ping failed: {:?}", e);
                 }
             }
@@ -1002,7 +1006,7 @@ pub fn bind_port_retry(port: u16) -> Result<(TcpListener, u16), MakerError> {
             Ok(l) => return Ok((l, current_port)),
             Err(e) if e.kind() == ErrorKind::AddrInUse => {
                 log::info!("Port {} in use, trying {}", current_port, current_port + 2);
-                current_port += 2;
+                current_port += 2
             }
             Err(e) => {
                 log::error!("Failed to bind port {}: {}", current_port, e);

--- a/src/nostr_coinswap.rs
+++ b/src/nostr_coinswap.rs
@@ -7,6 +7,7 @@
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use bitcoin::Network;
 use nostr::{
     event::{EventBuilder, Kind, Tag, TagStandard},
     key::{Keys, SecretKey},
@@ -25,19 +26,29 @@ pub const NOSTR_RELAYS: &[&str] = &["wss://nos.lol", "wss://relay.damus.io"];
 #[cfg(feature = "integration-test")]
 pub const NOSTR_RELAYS: &[&str] = &["ws://127.0.0.1:8000"];
 
-/// coinswap nostr event kind
-pub const COINSWAP_KIND: u16 = 37778;
+/// Returns the Coinswap Nostr event kind for the given Bitcoin network.
+pub fn coinswap_kind(network: Network) -> u16 {
+    match network {
+        Network::Bitcoin => 37778,
+        Network::Signet => 37779,
+        Network::Regtest => 37780,
+        Network::Testnet => 37781,
+        Network::Testnet4 => 37782,
+    }
+}
 /// Expiration time for noster event (24 hours)
 const EXPIRATION_SECS: u64 = 86400;
 
 /// Broadcasts a fidelity bond announcement over Nostr.
 pub fn broadcast_bond_on_nostr(
     fidelity: FidelityProof,
+    network: Network,
     relays: &[String],
 ) -> Result<(), MakerError> {
     let outpoint = fidelity.bond.outpoint;
     let content = format!("{}:{}", outpoint.txid, outpoint.vout);
-    // Kind 37778 is in the NIP-33 parameterized-replaceable range (30000..39999),
+    let kind = coinswap_kind(network);
+    // Coinswap kinds are in the NIP-33 parameterized-replaceable range (30000..39999),
     // so included a stable `d` tag to keep relay handling spec-compliant.
     let d_tag = format!("fidelity:{}", content);
 
@@ -69,7 +80,7 @@ pub fn broadcast_bond_on_nostr(
         expiration
     );
 
-    let event = EventBuilder::new(Kind::Custom(COINSWAP_KIND), content)
+    let event = EventBuilder::new(Kind::Custom(kind), content)
         .tag(Tag::identifier(d_tag))
         .tag(Tag::from_standardized(TagStandard::Expiration(
             Timestamp::from_secs(expiration),
@@ -82,7 +93,7 @@ pub fn broadcast_bond_on_nostr(
         "Nostr event built | event_id={} pubkey={} kind={} created_at={} tags={:?}",
         event.id,
         event.pubkey,
-        COINSWAP_KIND,
+        kind,
         event.created_at,
         event.tags
     );

--- a/src/watch_tower/nostr_discovery.rs
+++ b/src/watch_tower/nostr_discovery.rs
@@ -1,7 +1,7 @@
 //! Nostr discovery module.
 //!
 //! Handles the discovery of Maker fidelity bonds via Nostr relays. It creates persistent
-//! subscriptions to CoinSwap-related events (kind 37778), validates incoming fidelity
+//! subscriptions to network-specific CoinSwap events, validates incoming fidelity
 //! announcements against the Bitcoin blockchain, and stores verified bonds in the registry.
 
 use std::{
@@ -12,6 +12,7 @@ use std::{
     },
 };
 
+use bitcoin::Network;
 use nostr::{
     event::Kind,
     filter::Filter,
@@ -22,7 +23,7 @@ use nostr::{
 use tungstenite::{stream::MaybeTlsStream, Message};
 
 use crate::{
-    nostr_coinswap::COINSWAP_KIND,
+    nostr_coinswap::coinswap_kind,
     watch_tower::{
         registry_storage::FileRegistry,
         rest_backend::BitcoinRest,
@@ -32,15 +33,18 @@ use crate::{
 };
 
 // ## TODO: Instead of looping over relay's have a connection Pool.
-/// Runs the main discovery routine for maker's fidelity bonds by subscribing to Nostr events (kind 37778).
+/// Runs the main discovery routine for maker's fidelity bonds by subscribing to network-specific Nostr events.
 pub fn run_discovery(
     bitcoin_rpc: BitcoinRest,
+    network: Network,
     registry: FileRegistry,
     shutdown: Arc<AtomicBool>,
     initial_sync_complete: Arc<AtomicBool>,
     relays: &[String],
 ) -> Result<(), WatcherError> {
     log::info!("Starting market discovery via Nostr");
+
+    let kind = Kind::Custom(coinswap_kind(network));
 
     let seen_txid = Arc::new(Mutex::new(SeenTxids::new()));
     let registry = Arc::new(registry);
@@ -59,6 +63,7 @@ pub fn run_discovery(
             .spawn(move || {
                 run_nostr_session_for_relay(
                     &relay.clone(),
+                    kind,
                     registry,
                     shutdown,
                     bitcoin_rpc,
@@ -75,6 +80,7 @@ pub fn run_discovery(
 /// Reconnects automatically until shutdown is requested.
 fn run_nostr_session_for_relay(
     relay_url: &str,
+    kind: Kind,
     registry: Arc<FileRegistry>,
     shutdown: Arc<AtomicBool>,
     bitcoin_rpc: Arc<BitcoinRest>,
@@ -86,6 +92,7 @@ fn run_nostr_session_for_relay(
     while !shutdown.load(Ordering::SeqCst) {
         match connect_and_run_once(
             relay_url,
+            kind,
             registry.clone(),
             shutdown.clone(),
             bitcoin_rpc.clone(),
@@ -111,9 +118,10 @@ fn run_nostr_session_for_relay(
 }
 
 /// Establishes websocket connection to single Nostr relay and processes events until error or shutdown.
-/// Subscribe to Nostr events on Kind (37778).
+/// Subscribe to Nostr events on the Coinswap kind for the active network.
 fn connect_and_run_once(
     relay_url: &str,
+    kind: Kind,
     registry: Arc<FileRegistry>,
     shutdown: Arc<AtomicBool>,
     bitcoin_rpc: Arc<BitcoinRest>,
@@ -124,7 +132,7 @@ fn connect_and_run_once(
 
     let since = registry.load_nostr_cursor(relay_url).map(Timestamp::from);
 
-    let mut filter = Filter::new().kind(Kind::Custom(COINSWAP_KIND));
+    let mut filter = Filter::new().kind(kind);
     if let Some(since) = since {
         filter = filter.since(since);
     }
@@ -144,7 +152,7 @@ fn connect_and_run_once(
     log::info!(
         "Subscribed to fidelity announcements on {} (kind={}, since={:?})",
         relay_url,
-        COINSWAP_KIND,
+        kind,
         since
     );
 
@@ -154,18 +162,21 @@ fn connect_and_run_once(
         shutdown,
         bitcoin_rpc,
         relay_url,
+        kind,
         seen_txid,
         initial_sync_complete,
     )
 }
 
 /// Stream all the events from the Nostr relay and deserialize from json until shutdown
+#[allow(clippy::too_many_arguments)]
 fn read_event_loop(
     registry: Arc<FileRegistry>,
     mut socket: tungstenite::WebSocket<MaybeTlsStream<std::net::TcpStream>>,
     shutdown: Arc<AtomicBool>,
     bitcoin_rpc: Arc<BitcoinRest>,
     relay_url: &str,
+    kind: Kind,
     seen_txid: &Arc<Mutex<SeenTxids>>,
     initial_sync_complete: &Arc<AtomicBool>,
 ) -> Result<(), WatcherError> {
@@ -185,6 +196,7 @@ fn read_event_loop(
             relay_msg,
             bitcoin_rpc.clone(),
             relay_url,
+            kind,
             seen_txid,
             initial_sync_complete,
         )?;
@@ -201,12 +213,13 @@ fn handle_relay_message(
     msg: RelayMessage,
     bitcoin_rpc: Arc<BitcoinRest>,
     relay_url: &str,
+    kind: Kind,
     seen_txid: &Arc<Mutex<SeenTxids>>,
     initial_sync_complete: &Arc<AtomicBool>,
 ) -> Result<(), WatcherError> {
     match msg {
         RelayMessage::Event { event, .. } => {
-            if event.kind != Kind::Custom(COINSWAP_KIND) {
+            if event.kind != kind {
                 return Ok(());
             }
 

--- a/src/watch_tower/watcher.rs
+++ b/src/watch_tower/watcher.rs
@@ -12,7 +12,7 @@ use std::{
     },
 };
 
-use bitcoin::{consensus::deserialize, Block, OutPoint, Transaction};
+use bitcoin::{consensus::deserialize, Block, Network, OutPoint, Transaction};
 use crossbeam_channel::Sender as CbSender;
 
 use crate::{
@@ -114,6 +114,23 @@ impl<R: Role> Watcher<R> {
         log::info!("Watcher initiated");
         let rest_backend_1 = BitcoinRest::new(rpc_config.clone())?;
         let rest_backend_2 = BitcoinRest::new(rpc_config)?;
+        let network = match rest_backend_1
+            .get_blockchain_info()?
+            .chain
+            .to_string()
+            .as_str()
+        {
+            "main" => Network::Bitcoin,
+            "test" => Network::Testnet,
+            "testnet4" => Network::Testnet4,
+            "signet" => Network::Signet,
+            "regtest" => Network::Regtest,
+            unknown => {
+                return Err(WatcherError::General(format!(
+                    "Unsupported Bitcoin network from node: {unknown}"
+                )))
+            }
+        };
 
         if let Err(e) = rest_backend_1.process_mempool(&mut self.registry) {
             log::warn!("Failed to process mempool on startup: {}", e);
@@ -129,6 +146,7 @@ impl<R: Role> Watcher<R> {
                 s.spawn(move || {
                     if let Err(e) = nostr_discovery::run_discovery(
                         rest_backend_1,
+                        network,
                         registry,
                         discovery_shutdown.clone(),
                         initial_sync_complete,


### PR DESCRIPTION
# Pull Request

## Description
Adds different nostr kind events 
## Related Issue(s)
Closes #<!-- replace with issue number if applicable -->

Fixes #819 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [x ] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ x] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [ ]x I ran `cargo +nightly fmt --all` and committed the result
- [ x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x ] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x ] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ x] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [x ] All unit tests pass (`cargo test`)
- [ x] Integration tests pass (`cargo test --features integration-test`)
- [ x] Changes were manually tested on **regtest**
- [ x] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

## How to Test
<!-- Step-by-step instructions so reviewers can verify quickly. -->

```bash
# Standard swap (good baseline)
cargo test --test standard_swap --features integration-test -- --nocapture

# Abort scenarios
cargo test --test abort1 --features integration-test -- --nocapture
cargo test --test taproot_taker_abort1 --features integration-test -- --nocapture

# Malicious behavior & recovery
cargo test --test malice1 --features integration-test -- --nocapture
cargo test --test taproot_timelock_recovery --features integration-test -- --nocapture

# Or run the full suite
cargo test --features integration-test
```

<!-- Add any additional manual steps specific to this PR
     (e.g. regtest node config, docker-setup, specific taker commands): -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Nostr bond broadcasts and subscriptions now derive event kind from the detected Bitcoin network (Main, Testnet, Signet, Regtest, Testnet4).
  * Watch tower discovery auto-detects the node's Bitcoin network and receives network context.

* **Behavior**
  * Watcher now fails early if the node reports an unsupported/unknown chain.

* **Chore**
  * Minor code cleanup in port-retry logic (no runtime behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->