### PR TITLE
Enhancement(nostr): add nostr relay connection pool module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod fee_estimation;
 pub mod maker;
 pub mod nostr_coinswap;
+pub mod nostr_relay_pool;
 pub mod protocol;
 pub mod security;
 pub mod taker;

--- a/src/maker/error.rs
+++ b/src/maker/error.rs
@@ -121,3 +121,11 @@ impl From<WatcherError> for MakerError {
         Self::Watcher(value)
     }
 }
+
+impl From<crate::nostr_relay_pool::RelayPoolError> for MakerError {
+    fn from(value: crate::nostr_relay_pool::RelayPoolError) -> Self {
+        // Convert to WatcherError first, then into MakerError, to reuse
+        // the existing variant mapping without adding a new MakerError variant.
+        Self::Watcher(value.into())
+    }
+}

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -14,6 +14,7 @@ use std::{
 use crate::{
     maker::rpc::server::MakerRpc,
     nostr_coinswap::broadcast_bond_on_nostr,
+    nostr_relay_pool::RelayPool,
     protocol::common_messages::{FidelityProof, MakerToTakerMessage, TakerToMakerMessage},
     wallet::SwapReport,
 };
@@ -235,8 +236,10 @@ fn spawn_nostr_broadcast_thread(
     let handle = thread::Builder::new()
         .name("nostr-thread".to_string())
         .spawn(move || {
+            let pool = RelayPool::new(&relays, Arc::new(std::sync::atomic::AtomicBool::new(false)));
+
             // Initial broadcast
-            if let Err(e) = broadcast_bond_on_nostr(fidelity.clone(), &relays) {
+            if let Err(e) = broadcast_bond_on_nostr(fidelity.clone(), &pool) {
                 log::warn!("Initial nostr broadcast failed: {:?}", e);
             }
 
@@ -256,11 +259,12 @@ fn spawn_nostr_broadcast_thread(
 
                 log::debug!("Re-pinging nostr relays with bond announcement");
 
-                if let Err(e) = broadcast_bond_on_nostr(fidelity.clone(), &relays) {
+                if let Err(e) = broadcast_bond_on_nostr(fidelity.clone(), &pool) {
                     log::warn!("Nostr re-ping failed: {:?}", e);
                 }
             }
 
+            pool.disconnect_all();
             log::info!("Nostr background task stopped");
         })
         .map_err(MakerError::IO)?;

--- a/src/nostr_coinswap.rs
+++ b/src/nostr_coinswap.rs
@@ -12,11 +12,11 @@ use nostr::{
     key::{Keys, SecretKey},
     message::{ClientMessage, RelayMessage},
     types::Timestamp,
-    util::JsonUtil,
 };
-use tungstenite::Message;
 
-use crate::{maker::MakerError, protocol::common_messages::FidelityProof};
+use crate::{
+    maker::MakerError, nostr_relay_pool::RelayPool, protocol::common_messages::FidelityProof,
+};
 
 /// nostr url for coinswap
 #[cfg(not(feature = "integration-test"))]
@@ -30,10 +30,10 @@ pub const COINSWAP_KIND: u16 = 37778;
 /// Expiration time for noster event (24 hours)
 const EXPIRATION_SECS: u64 = 86400;
 
-/// Broadcasts a fidelity bond announcement over Nostr.
+/// Broadcasts a fidelity bond announcement over Nostr using a connection pool.
 pub fn broadcast_bond_on_nostr(
     fidelity: FidelityProof,
-    relays: &[String],
+    pool: &RelayPool,
 ) -> Result<(), MakerError> {
     let outpoint = fidelity.bond.outpoint;
     let content = format!("{}:{}", outpoint.txid, outpoint.vout);
@@ -89,16 +89,14 @@ pub fn broadcast_bond_on_nostr(
 
     let msg = ClientMessage::Event(std::borrow::Cow::Owned(event));
 
-    log::debug!("nostr wire msg: {}", msg.as_json());
-
     const RELAY_DELAY: Duration = Duration::from_secs(2);
     const MAX_RETRIES: usize = 3;
 
     let mut success = false;
 
-    for relay in relays {
+    for relay in pool.relay_urls() {
         for attempt in 1..=MAX_RETRIES {
-            match broadcast_to_relay(relay, &msg) {
+            match broadcast_to_relay(pool, relay, &msg) {
                 Ok(()) => {
                     success = true;
                     break;
@@ -111,6 +109,8 @@ pub fn broadcast_bond_on_nostr(
                         MAX_RETRIES,
                         e
                     );
+                    // On failure, disconnect so next attempt gets a fresh socket.
+                    pool.disconnect(relay);
                     if attempt < MAX_RETRIES {
                         std::thread::sleep(RELAY_DELAY);
                     }
@@ -126,54 +126,43 @@ pub fn broadcast_bond_on_nostr(
     Ok(())
 }
 
-/// Sends a Nostr event to a single relay and waits for confirmation.
-fn broadcast_to_relay(relay: &str, msg: &ClientMessage) -> Result<(), MakerError> {
-    let (mut socket, _) = tungstenite::connect(relay).map_err(|e| {
-        log::warn!("failed to connect to nostr relay {}: {}", relay, e);
-        MakerError::General("failed to connect to nostr relay")
-    })?;
-
-    socket
-        .write(Message::Text(msg.as_json().into()))
-        .map_err(|e| {
-            log::warn!("nostr relay write failed: {}", e);
-            MakerError::General("failed to write to nostr relay")
-        })?;
-    socket.flush().ok();
-
-    match socket.read() {
-        Ok(Message::Text(text)) => {
-            if let Ok(relay_msg) = RelayMessage::from_json(&text) {
-                match relay_msg {
-                    RelayMessage::Ok {
-                        event_id,
-                        status: true,
-                        ..
-                    } => {
-                        log::info!("nostr relay {} accepted event {}", relay, event_id);
-                        return Ok(());
-                    }
-                    RelayMessage::Ok {
-                        event_id,
-                        status: false,
-                        message,
-                    } => {
-                        log::warn!(
-                            "nostr relay {} rejected event {}: {}",
-                            relay,
-                            event_id,
-                            message
-                        );
-                    }
-                    _ => {}
-                }
+/// Sends a Nostr event to a single relay via the pool and waits for confirmation.
+fn broadcast_to_relay(
+    pool: &RelayPool,
+    relay: &str,
+    msg: &ClientMessage,
+) -> Result<(), MakerError> {
+    match pool.send_and_read_response(relay, msg) {
+        Ok(relay_msg) => match relay_msg {
+            RelayMessage::Ok {
+                event_id,
+                status: true,
+                ..
+            } => {
+                log::info!("nostr relay {} accepted event {}", relay, event_id);
+                Ok(())
             }
-        }
-        Ok(_) => {}
+            RelayMessage::Ok {
+                event_id,
+                status: false,
+                message,
+            } => {
+                log::warn!(
+                    "nostr relay {} rejected event {}: {}",
+                    relay,
+                    event_id,
+                    message
+                );
+                Err(MakerError::General("nostr relay rejected event"))
+            }
+            _ => {
+                log::warn!("nostr relay {} did not confirm event", relay);
+                Err(MakerError::General("nostr relay did not confirm event"))
+            }
+        },
         Err(e) => {
-            log::warn!("nostr relay {} read error: {}", relay, e);
+            log::warn!("nostr relay {} error: {}", relay, e);
+            Err(e.into())
         }
     }
-    log::warn!("nostr relay {} did not confirm event", relay);
-    Err(MakerError::General("nostr relay did not confirm event"))
 }

--- a/src/nostr_relay_pool.rs
+++ b/src/nostr_relay_pool.rs
@@ -1,0 +1,325 @@
+//! Nostr relay connection pool.
+//!
+//! Provides a shared, reusable pool of WebSocket connections to Nostr relays.
+//! Connections are created lazily on first use and transparently reconnected
+//! when they fail. Each relay has its own lock so operations on different
+//! relays never block each other.
+
+use std::{
+    collections::HashMap,
+    io::ErrorKind,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex, MutexGuard,
+    },
+    time::Duration,
+};
+
+use nostr::{
+    message::{ClientMessage, RelayMessage},
+    util::JsonUtil,
+};
+use tungstenite::{stream::MaybeTlsStream, Message, WebSocket};
+
+/// Read timeout applied to every relay socket so blocking reads
+/// can be interrupted periodically to check for shutdown.
+const SOCKET_READ_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Errors originating from the relay connection pool.
+#[derive(Debug)]
+pub enum RelayPoolError {
+    /// WebSocket-level error (connect, read, write).
+    WebSocket(tungstenite::Error),
+    /// Nostr message could not be parsed.
+    NostrParsing(nostr::message::MessageHandleError),
+    /// UTF-8 decoding failed on a binary frame.
+    Utf8(std::string::FromUtf8Error),
+    /// The relay URL is not registered in this pool.
+    UnknownRelay(String),
+    /// The shutdown flag was set.
+    Shutdown,
+}
+
+impl std::fmt::Display for RelayPoolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::WebSocket(e) => write!(f, "websocket: {e}"),
+            Self::NostrParsing(e) => write!(f, "nostr parse: {e}"),
+            Self::Utf8(e) => write!(f, "utf8: {e}"),
+            Self::UnknownRelay(url) => write!(f, "unknown relay: {url}"),
+            Self::Shutdown => write!(f, "shutdown"),
+        }
+    }
+}
+
+impl From<tungstenite::Error> for RelayPoolError {
+    fn from(e: tungstenite::Error) -> Self {
+        Self::WebSocket(e)
+    }
+}
+
+impl From<nostr::message::MessageHandleError> for RelayPoolError {
+    fn from(e: nostr::message::MessageHandleError) -> Self {
+        Self::NostrParsing(e)
+    }
+}
+
+impl From<std::string::FromUtf8Error> for RelayPoolError {
+    fn from(e: std::string::FromUtf8Error) -> Self {
+        Self::Utf8(e)
+    }
+}
+
+/// Returns `true` when the I/O error is a harmless read timeout
+/// (the socket is still healthy).
+fn is_timeout(e: &tungstenite::Error) -> bool {
+    if let tungstenite::Error::Io(io) = e {
+        matches!(io.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut)
+    } else {
+        false
+    }
+}
+
+/// Per-relay connection state, protected by its own mutex.
+struct RelayEntry {
+    url: String,
+    socket: Mutex<Option<WebSocket<MaybeTlsStream<std::net::TcpStream>>>>,
+}
+
+/// A pool of persistent WebSocket connections to Nostr relays.
+///
+/// The relay map is built at construction time and never modified,
+/// so lookups are lock-free. Only individual relay sockets are behind
+/// a `Mutex`, ensuring that operations on different relays are fully
+/// independent.
+pub struct RelayPool {
+    relays: HashMap<String, Arc<RelayEntry>>,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl RelayPool {
+    /// Creates a new pool for the given relay URLs.
+    /// Connections are established lazily on first use.
+    pub fn new(relay_urls: &[String], shutdown: Arc<AtomicBool>) -> Self {
+        let relays = relay_urls
+            .iter()
+            .map(|url| {
+                let entry = Arc::new(RelayEntry {
+                    url: url.clone(),
+                    socket: Mutex::new(None),
+                });
+                (url.clone(), entry)
+            })
+            .collect();
+        Self { relays, shutdown }
+    }
+
+    /// Returns the list of relay URLs registered in this pool.
+    pub fn relay_urls(&self) -> Vec<&str> {
+        self.relays.keys().map(|s| s.as_str()).collect()
+    }
+
+    /// Sends a Nostr client message to a single relay.
+    ///
+    /// Reconnects transparently if the socket is absent or broken.
+    /// On a real write error the socket is marked dead for the next call.
+    pub fn send(&self, relay_url: &str, msg: &ClientMessage) -> Result<(), RelayPoolError> {
+        if self.shutdown.load(Ordering::Acquire) {
+            return Err(RelayPoolError::Shutdown);
+        }
+
+        let entry = self
+            .relays
+            .get(relay_url)
+            .ok_or_else(|| RelayPoolError::UnknownRelay(relay_url.to_string()))?;
+
+        let mut guard = Self::lock_entry(entry)?;
+        let socket = Self::ensure_connected(&mut guard, &entry.url)?;
+
+        match socket.write(Message::Text(msg.as_json().into())) {
+            Ok(()) => {
+                socket.flush().ok();
+                Ok(())
+            }
+            Err(e) => {
+                *guard = None; // mark dead
+                Err(RelayPoolError::WebSocket(e))
+            }
+        }
+    }
+
+    /// Reads the next Nostr relay message from a single relay.
+    ///
+    /// Blocks until a message arrives or the read timeout fires.
+    /// Returns `Err(RelayPoolError::Shutdown)` when shutdown is requested
+    /// and the read timed out. On a real read error the socket is marked dead.
+    pub fn read(&self, relay_url: &str) -> Result<RelayMessage<'_>, RelayPoolError> {
+        if self.shutdown.load(Ordering::Acquire) {
+            return Err(RelayPoolError::Shutdown);
+        }
+
+        let entry = self
+            .relays
+            .get(relay_url)
+            .ok_or_else(|| RelayPoolError::UnknownRelay(relay_url.to_string()))?;
+
+        let mut guard = Self::lock_entry(entry)?;
+        let socket = Self::ensure_connected(&mut guard, &entry.url)?;
+
+        match socket.read() {
+            Ok(msg) => {
+                // Release the lock before parsing.
+                let text = match msg {
+                    Message::Text(t) => t,
+                    Message::Binary(b) => String::from_utf8(b.to_vec())?.into(),
+                    _ => {
+                        // ping/pong/close frames — re-check shutdown
+                        drop(guard);
+                        if self.shutdown.load(Ordering::Acquire) {
+                            return Err(RelayPoolError::Shutdown);
+                        }
+                        return Err(RelayPoolError::WebSocket(tungstenite::Error::Protocol(
+                            tungstenite::error::ProtocolError::ResetWithoutClosingHandshake,
+                        )));
+                    }
+                };
+                drop(guard);
+                Ok(RelayMessage::from_json(&text)?)
+            }
+            Err(e) if is_timeout(&e) => {
+                // Socket is healthy, just no data yet.
+                drop(guard);
+                if self.shutdown.load(Ordering::Acquire) {
+                    return Err(RelayPoolError::Shutdown);
+                }
+                Err(RelayPoolError::WebSocket(e))
+            }
+            Err(e) => {
+                *guard = None; // mark dead
+                Err(RelayPoolError::WebSocket(e))
+            }
+        }
+    }
+
+    /// Sends a message and reads one response. Convenience for the broadcast path.
+    pub fn send_and_read_response(
+        &self,
+        relay_url: &str,
+        msg: &ClientMessage,
+    ) -> Result<RelayMessage<'_>, RelayPoolError> {
+        if self.shutdown.load(Ordering::Acquire) {
+            return Err(RelayPoolError::Shutdown);
+        }
+
+        let entry = self
+            .relays
+            .get(relay_url)
+            .ok_or_else(|| RelayPoolError::UnknownRelay(relay_url.to_string()))?;
+
+        let mut guard = Self::lock_entry(entry)?;
+        let socket = Self::ensure_connected(&mut guard, &entry.url)?;
+
+        // Write
+        if let Err(e) = socket.write(Message::Text(msg.as_json().into())) {
+            *guard = None;
+            return Err(RelayPoolError::WebSocket(e));
+        }
+        socket.flush().ok();
+
+        // Read one response
+        match socket.read() {
+            Ok(Message::Text(text)) => {
+                drop(guard);
+                Ok(RelayMessage::from_json(&text)?)
+            }
+            Ok(_) => {
+                drop(guard);
+                Err(RelayPoolError::WebSocket(tungstenite::Error::Protocol(
+                    tungstenite::error::ProtocolError::ResetWithoutClosingHandshake,
+                )))
+            }
+            Err(e) if is_timeout(&e) => {
+                // Timeout waiting for relay confirmation — not fatal to socket but
+                // caller should treat as "relay did not confirm".
+                drop(guard);
+                Err(RelayPoolError::WebSocket(e))
+            }
+            Err(e) => {
+                *guard = None;
+                Err(RelayPoolError::WebSocket(e))
+            }
+        }
+    }
+
+    /// Drops the connection for a single relay (it will reconnect lazily).
+    pub fn disconnect(&self, relay_url: &str) {
+        if let Some(entry) = self.relays.get(relay_url) {
+            if let Ok(mut guard) = entry.socket.lock() {
+                *guard = None;
+            }
+        }
+    }
+
+    /// Drops all connections.
+    pub fn disconnect_all(&self) {
+        for entry in self.relays.values() {
+            if let Ok(mut guard) = entry.socket.lock() {
+                *guard = None;
+            }
+        }
+    }
+
+    // -- private helpers --
+
+    /// Locks the relay entry, recovering from mutex poisoning by
+    /// resetting the socket to `None`.
+    fn lock_entry(
+        entry: &RelayEntry,
+    ) -> Result<
+        MutexGuard<'_, Option<WebSocket<MaybeTlsStream<std::net::TcpStream>>>>,
+        RelayPoolError,
+    > {
+        match entry.socket.lock() {
+            Ok(guard) => Ok(guard),
+            Err(poisoned) => {
+                // Recover: take the guard and reset to disconnected.
+                let mut guard = poisoned.into_inner();
+                *guard = None;
+                Ok(guard)
+            }
+        }
+    }
+
+    /// Ensures the guarded socket is connected. If it is `None`, opens
+    /// a new WebSocket and sets a read timeout on the underlying TCP stream.
+    fn ensure_connected<'a>(
+        guard: &'a mut MutexGuard<'_, Option<WebSocket<MaybeTlsStream<std::net::TcpStream>>>>,
+        url: &str,
+    ) -> Result<&'a mut WebSocket<MaybeTlsStream<std::net::TcpStream>>, RelayPoolError> {
+        if guard.is_none() {
+            log::debug!("Connecting to relay {}", url);
+            let (socket, _) = tungstenite::connect(url)?;
+
+            // Set read timeout so blocking reads can be interrupted for shutdown checks.
+            Self::set_read_timeout(&socket);
+
+            **guard = Some(socket);
+        }
+        Ok(guard.as_mut().expect("just ensured Some"))
+    }
+
+    /// Applies a read timeout on the underlying TCP stream, regardless of
+    /// whether the connection is plain or TLS-wrapped.
+    fn set_read_timeout(socket: &WebSocket<MaybeTlsStream<std::net::TcpStream>>) {
+        let timeout = Some(SOCKET_READ_TIMEOUT);
+        match socket.get_ref() {
+            MaybeTlsStream::Plain(tcp) => {
+                tcp.set_read_timeout(timeout).ok();
+            }
+            MaybeTlsStream::NativeTls(tls) => {
+                tls.get_ref().set_read_timeout(timeout).ok();
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/watch_tower/nostr_discovery.rs
+++ b/src/watch_tower/nostr_discovery.rs
@@ -17,12 +17,11 @@ use nostr::{
     filter::Filter,
     message::{ClientMessage, RelayMessage, SubscriptionId},
     types::Timestamp,
-    util::JsonUtil,
 };
-use tungstenite::{stream::MaybeTlsStream, Message};
 
 use crate::{
     nostr_coinswap::COINSWAP_KIND,
+    nostr_relay_pool::RelayPool,
     watch_tower::{
         registry_storage::FileRegistry,
         rest_backend::BitcoinRest,
@@ -31,14 +30,13 @@ use crate::{
     },
 };
 
-// ## TODO: Instead of looping over relay's have a connection Pool.
-/// Runs the main discovery routine for maker's fidelity bonds by subscribing to Nostr events (kind 37778).
+/// Runs the main discovery routine for maker's fidelity bonds by subscribing to Nostr events (kind 37777).
 pub fn run_discovery(
     bitcoin_rpc: BitcoinRest,
     registry: FileRegistry,
     shutdown: Arc<AtomicBool>,
     initial_sync_complete: Arc<AtomicBool>,
-    relays: &[String],
+    pool: Arc<RelayPool>,
 ) -> Result<(), WatcherError> {
     log::info!("Starting market discovery via Nostr");
 
@@ -46,24 +44,28 @@ pub fn run_discovery(
     let registry = Arc::new(registry);
     let bitcoin_rpc = Arc::new(bitcoin_rpc);
 
-    for relay in relays {
+    let relay_urls: Vec<String> = pool.relay_urls().into_iter().map(String::from).collect();
+
+    for relay in &relay_urls {
         let relay = relay.to_string();
         let shutdown = shutdown.clone();
         let registry = Arc::clone(&registry);
         let bitcoin_rpc = Arc::clone(&bitcoin_rpc);
         let seen_txid = Arc::clone(&seen_txid);
         let initial_sync_complete = initial_sync_complete.clone();
+        let pool = Arc::clone(&pool);
 
         std::thread::Builder::new()
             .name(format!("nostr-session-{}", relay))
             .spawn(move || {
                 run_nostr_session_for_relay(
-                    &relay.clone(),
+                    &relay,
                     registry,
                     shutdown,
                     bitcoin_rpc,
                     &seen_txid,
                     &initial_sync_complete,
+                    &pool,
                 );
             })?;
     }
@@ -80,17 +82,19 @@ fn run_nostr_session_for_relay(
     bitcoin_rpc: Arc<BitcoinRest>,
     seen_txid: &Arc<Mutex<SeenTxids>>,
     initial_sync_complete: &Arc<AtomicBool>,
+    pool: &RelayPool,
 ) {
     log::info!("Starting Nostr session for relay {}", relay_url);
 
     while !shutdown.load(Ordering::SeqCst) {
-        match connect_and_run_once(
+        match subscribe_and_read(
             relay_url,
             registry.clone(),
             shutdown.clone(),
             bitcoin_rpc.clone(),
             seen_txid,
             initial_sync_complete,
+            pool,
         ) {
             Ok(()) => {
                 // Likely exited due to shutdown
@@ -102,6 +106,8 @@ fn run_nostr_session_for_relay(
                     relay_url,
                     e
                 );
+                // Drop the broken connection so the pool reconnects on next use.
+                pool.disconnect(relay_url);
                 std::thread::sleep(std::time::Duration::from_secs(5));
             }
         }
@@ -110,18 +116,16 @@ fn run_nostr_session_for_relay(
     log::info!("Stopped Nostr session for relay {}", relay_url);
 }
 
-/// Establishes websocket connection to single Nostr relay and processes events until error or shutdown.
-/// Subscribe to Nostr events on Kind (37778).
-fn connect_and_run_once(
+/// Subscribes to Nostr events on a single relay and reads events until error or shutdown.
+fn subscribe_and_read(
     relay_url: &str,
     registry: Arc<FileRegistry>,
     shutdown: Arc<AtomicBool>,
     bitcoin_rpc: Arc<BitcoinRest>,
     seen_txid: &Arc<Mutex<SeenTxids>>,
     initial_sync_complete: &Arc<AtomicBool>,
+    pool: &RelayPool,
 ) -> Result<(), WatcherError> {
-    let (mut socket, _) = tungstenite::connect(relay_url)?;
-
     let since = registry.load_nostr_cursor(relay_url).map(Timestamp::from);
 
     let mut filter = Filter::new().kind(Kind::Custom(COINSWAP_KIND));
@@ -137,9 +141,7 @@ fn connect_and_run_once(
         filters: vec![Cow::Owned(filter)],
     };
 
-    socket.write(Message::Text(req.as_json().into()))?;
-
-    socket.flush()?;
+    pool.send(relay_url, &req)?;
 
     log::info!(
         "Subscribed to fidelity announcements on {} (kind={}, since={:?})",
@@ -148,37 +150,19 @@ fn connect_and_run_once(
         since
     );
 
-    read_event_loop(
-        registry,
-        socket,
-        shutdown,
-        bitcoin_rpc,
-        relay_url,
-        seen_txid,
-        initial_sync_complete,
-    )
-}
-
-/// Stream all the events from the Nostr relay and deserialize from json until shutdown
-fn read_event_loop(
-    registry: Arc<FileRegistry>,
-    mut socket: tungstenite::WebSocket<MaybeTlsStream<std::net::TcpStream>>,
-    shutdown: Arc<AtomicBool>,
-    bitcoin_rpc: Arc<BitcoinRest>,
-    relay_url: &str,
-    seen_txid: &Arc<Mutex<SeenTxids>>,
-    initial_sync_complete: &Arc<AtomicBool>,
-) -> Result<(), WatcherError> {
+    // Read event loop — the pool returns parsed RelayMessages directly.
     while !shutdown.load(Ordering::SeqCst) {
-        let msg = socket.read()?;
-
-        let text = match msg {
-            Message::Text(t) => t,
-            Message::Binary(b) => String::from_utf8(b.to_vec())?.into(),
-            _ => continue,
+        let relay_msg = match pool.read(relay_url) {
+            Ok(msg) => msg,
+            Err(crate::nostr_relay_pool::RelayPoolError::Shutdown) => break,
+            Err(crate::nostr_relay_pool::RelayPoolError::WebSocket(ref e))
+                if is_timeout_error(e) =>
+            {
+                // Read timed out — socket is healthy, loop back to check shutdown.
+                continue;
+            }
+            Err(e) => return Err(e.into()),
         };
-
-        let relay_msg = RelayMessage::from_json(&text)?;
 
         handle_relay_message(
             registry.clone(),
@@ -191,6 +175,18 @@ fn read_event_loop(
     }
 
     Ok(())
+}
+
+/// Returns true if the tungstenite error is a harmless read timeout.
+fn is_timeout_error(e: &tungstenite::Error) -> bool {
+    if let tungstenite::Error::Io(io) = e {
+        matches!(
+            io.kind(),
+            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+        )
+    } else {
+        false
+    }
 }
 
 /// filter events based on kind and tags

--- a/src/watch_tower/watcher.rs
+++ b/src/watch_tower/watcher.rs
@@ -16,6 +16,7 @@ use bitcoin::{consensus::deserialize, Block, OutPoint, Transaction};
 use crossbeam_channel::Sender as CbSender;
 
 use crate::{
+    nostr_relay_pool::RelayPool,
     wallet::RPCConfig,
     watch_tower::{
         nostr_discovery,
@@ -125,6 +126,7 @@ impl<R: Role> Watcher<R> {
         std::thread::scope(move |s| {
             let discovery_clone = discovery_shutdown.clone();
             if R::RUN_DISCOVERY {
+                let pool = Arc::new(RelayPool::new(&nostr_relays, discovery_shutdown.clone()));
                 let initial_sync_complete = initial_sync_complete.clone();
                 s.spawn(move || {
                     if let Err(e) = nostr_discovery::run_discovery(
@@ -132,7 +134,7 @@ impl<R: Role> Watcher<R> {
                         registry,
                         discovery_shutdown.clone(),
                         initial_sync_complete,
-                        &nostr_relays,
+                        pool,
                     ) {
                         log::error!("Discovery thread failed: {:?}", e);
                     }

--- a/src/watch_tower/watcher_error.rs
+++ b/src/watch_tower/watcher_error.rs
@@ -110,6 +110,22 @@ impl<'a, T> From<PoisonError<MutexGuard<'a, T>>> for WatcherError {
     }
 }
 
+impl From<crate::nostr_relay_pool::RelayPoolError> for WatcherError {
+    fn from(value: crate::nostr_relay_pool::RelayPoolError) -> Self {
+        match value {
+            crate::nostr_relay_pool::RelayPoolError::WebSocket(e) => WatcherError::WebSocket(e),
+            crate::nostr_relay_pool::RelayPoolError::NostrParsing(e) => {
+                WatcherError::NostrParsingError(e)
+            }
+            crate::nostr_relay_pool::RelayPoolError::Utf8(_) => WatcherError::ParsingError,
+            crate::nostr_relay_pool::RelayPoolError::UnknownRelay(msg) => {
+                WatcherError::General(msg)
+            }
+            crate::nostr_relay_pool::RelayPoolError::Shutdown => WatcherError::Shutdown,
+        }
+    }
+}
+
 impl WatcherError {
     /// Returns the underlying `ErrorKind` if the error wraps an I/O failure.
     pub fn io_error_kind(&self) -> Option<std::io::ErrorKind> {


### PR DESCRIPTION
# Pull Request

## Description
This WIP PR adds a `RelayPool` abstraction for managing persistent, reusable WebSocket connections to nostr relays. Currently, both the discovery path (watchtower) and the broadcast path (maker) open fresh connections on every interaction. The pool holds connections keyed by relay URL with per-relay locking, lazy connection establishment, and transparent reconnection on failure.

Resolves the TODO at src/watch_tower/nostr_discovery.rs:34:

// ## TODO: Instead of looping over relay's have a connection Pool.

## Related Issue(s)
Closes #<!-- replace with issue number if applicable -->
<!-- Add multiple lines if this PR closes multiple issues -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [x] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [x] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [x] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ ] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [x] All unit tests pass (`cargo test`)
- [ ] Integration tests pass (`cargo test --features integration-test`)
- [ ] Changes were manually tested on **regtest**
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [x] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [x] Complex logic is commented

### Security & Privacy (Critical)
- [x] This change preserves **trustlessness** and **atomic swap guarantees**
- [x] No regression in **sybil resistance** or **fidelity bond** logic
- [x] Tor anonymity and P2P message flow were reviewed
- [x] No new attack vectors or trust assumptions introduced
- [x] Edge cases and error handling considered
- [x] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [x] `integration-test` feature flag is not reachable in production code paths

## How to Test
<!-- Step-by-step instructions so reviewers can verify quickly. -->

```bash
# Standard swap (good baseline)
cargo test --test standard_swap --features integration-test -- --nocapture

# Abort scenarios
cargo test --test abort1 --features integration-test -- --nocapture
cargo test --test taproot_taker_abort1 --features integration-test -- --nocapture

# Malicious behavior & recovery
cargo test --test malice1 --features integration-test -- --nocapture
cargo test --test taproot_timelock_recovery --features integration-test -- --nocapture

# Or run the full suite
cargo test --features integration-test
```

<!-- Add any additional manual steps specific to this PR
     (e.g. regtest node config, docker-setup, specific taker commands): -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced relay pool functionality to manage WebSocket connections to multiple Nostr relays with automatic reconnection on failures.
  * Enhanced error handling with relay-specific error types for improved diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->