### PR TITLE
Replace broken matrix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit
 
 ## Community
 
-Dev community: [Matrix](https://matrix.to/#/#citadel-foss:matrix.org)
+Dev community: [Matrix(Element)](https://app.element.io/#/room/#coinswap:matrix.org)
 
 Dev discussions predominantly happen via FOSS best practices, and by using Github as the major community forum.
 


### PR DESCRIPTION
# Pull Request

## Description
The Matrix link in the README points to a non-existent room.
<img width="1565" height="948" alt="image" src="https://github.com/user-attachments/assets/f0776daa-64a7-4f06-a5e5-513b3607b6b2" />
This PR replaces it to the correct Element link, consistent with the one used on the project's website.


## Related Issue(s)
Closes #809 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [x] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [x] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [ ] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [ ] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [ ] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ ] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [ ] All unit tests pass (`cargo test`)
- [ ] Integration tests pass (`cargo test --features integration-test`)
- [x] Changes were manually tested
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the dev community link in the README to use the Element app URL for direct access to the community room.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->