### PR TITLE
feat(nostr): route relay connections through Tor SOCKS5 proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ sha2 = "0.10.9"
 rust-coinselect = "0.1.6"
 crossterm = "0.29.0"
 zmq = "0.10.0"
-tungstenite = { version = "0.28.0", features = ["native-tls"]}
+tungstenite = { version = "0.28.0", features = ["rustls-tls-webpki-roots"]}
 nostr = "0.44.2"
 crossbeam-channel = "0.5.15"
 

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -229,14 +229,25 @@ fn spawn_nostr_broadcast_thread(
 
     let maker_clone = Arc::clone(maker);
     let relays = maker.nostr_relays.clone();
+    let network = maker
+        .wallet
+        .read()
+        .map(|wallet| wallet.store.network)
+        .unwrap_or(maker.config.network);
+    let socks_port = maker.config.socks_port;
+    let tor_auth_password = maker.config.tor_auth_password.clone();
 
     let handle = thread::Builder::new()
         .name("nostr-thread".to_string())
         .spawn(move || {
             // Initial broadcast
-            if let Err(e) =
-                broadcast_bond_on_nostr(fidelity.clone(), maker_clone.config.network, &relays)
-            {
+            if let Err(e) = broadcast_bond_on_nostr(
+                fidelity.clone(),
+                network,
+                &relays,
+                socks_port,
+                &tor_auth_password,
+            ) {
                 log::warn!("Initial nostr broadcast failed: {:?}", e);
             }
 
@@ -256,9 +267,13 @@ fn spawn_nostr_broadcast_thread(
 
                 log::debug!("Re-pinging nostr relays with bond announcement");
 
-                if let Err(e) =
-                    broadcast_bond_on_nostr(fidelity.clone(), maker_clone.config.network, &relays)
-                {
+                if let Err(e) = broadcast_bond_on_nostr(
+                    fidelity.clone(),
+                    network,
+                    &relays,
+                    socks_port,
+                    &tor_auth_password,
+                ) {
                     log::warn!("Nostr re-ping failed: {:?}", e);
                 }
             }

--- a/src/nostr_coinswap.rs
+++ b/src/nostr_coinswap.rs
@@ -5,7 +5,11 @@
 //! fidelity bond information and other coordination signals required
 //! by the Coinswap protocol.
 
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{
+    io,
+    net::TcpStream,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use bitcoin::Network;
 use nostr::{
@@ -15,7 +19,8 @@ use nostr::{
     types::Timestamp,
     util::JsonUtil,
 };
-use tungstenite::Message;
+use socks::Socks5Stream;
+use tungstenite::{http::Uri, stream::MaybeTlsStream, Message, WebSocket};
 
 use crate::{maker::MakerError, protocol::common_messages::FidelityProof};
 
@@ -39,11 +44,71 @@ pub fn coinswap_kind(network: Network) -> u16 {
 /// Expiration time for noster event (24 hours)
 pub(crate) const EXPIRATION_SECS: u64 = 86400;
 
+/// Connects to a Nostr relay: through Tor in production, directly in integration tests.
+///
+/// When `tor_auth_password` is set, the relay host is passed as the SOCKS5 username
+/// to give each relay its own Tor circuit-isolation key.
+pub(crate) fn connect_nostr_websocket(
+    relay_url: &str,
+    socks_port: u16,
+    tor_auth_password: &str,
+) -> Result<WebSocket<MaybeTlsStream<TcpStream>>, tungstenite::Error> {
+    if cfg!(feature = "integration-test") {
+        return tungstenite::connect(relay_url).map(|(ws, _)| ws);
+    }
+
+    let invalid_relay = || io::Error::new(io::ErrorKind::InvalidInput, "invalid relay url");
+    let uri: Uri = relay_url.parse().map_err(|_| invalid_relay())?;
+    let scheme = uri.scheme_str().ok_or_else(invalid_relay)?;
+    if scheme != "ws" && scheme != "wss" {
+        return Err(invalid_relay().into());
+    }
+
+    let authority = uri.authority().ok_or_else(invalid_relay)?;
+    let host = authority.host();
+    if host.is_empty()
+        || host.len() > u8::MAX as usize
+        || host.contains(':')
+        || authority.as_str().contains('@')
+    {
+        return Err(invalid_relay().into());
+    }
+
+    let port = authority
+        .port_u16()
+        .unwrap_or(if scheme == "wss" { 443 } else { 80 });
+
+    let socks_addr = format!("127.0.0.1:{socks_port}");
+    let target = format!("{host}:{port}");
+    let tcp = if tor_auth_password.is_empty() {
+        Socks5Stream::connect(socks_addr.as_str(), target.as_str())
+    } else {
+        Socks5Stream::connect_with_password(
+            socks_addr.as_str(),
+            target.as_str(),
+            host,
+            tor_auth_password,
+        )
+    }
+    .map_err(|e| io::Error::other(e.to_string()))?
+    .into_inner();
+
+    match tungstenite::client_tls_with_config(relay_url, tcp, None, None) {
+        Ok((ws, _)) => Ok(ws),
+        Err(tungstenite::HandshakeError::Failure(e)) => Err(e),
+        Err(tungstenite::HandshakeError::Interrupted(_)) => {
+            Err(io::Error::other("tls handshake interrupted").into())
+        }
+    }
+}
+
 /// Broadcasts a fidelity bond announcement over Nostr.
 pub fn broadcast_bond_on_nostr(
     fidelity: FidelityProof,
     network: Network,
     relays: &[String],
+    socks_port: u16,
+    tor_auth_password: &str,
 ) -> Result<(), MakerError> {
     let outpoint = fidelity.bond.outpoint;
     let content = format!("{}:{}", outpoint.txid, outpoint.vout);
@@ -109,7 +174,7 @@ pub fn broadcast_bond_on_nostr(
 
     for relay in relays {
         for attempt in 1..=MAX_RETRIES {
-            match broadcast_to_relay(relay, &msg) {
+            match broadcast_to_relay(relay, &msg, socks_port, tor_auth_password) {
                 Ok(()) => {
                     success = true;
                     break;
@@ -138,11 +203,17 @@ pub fn broadcast_bond_on_nostr(
 }
 
 /// Sends a Nostr event to a single relay and waits for confirmation.
-fn broadcast_to_relay(relay: &str, msg: &ClientMessage) -> Result<(), MakerError> {
-    let (mut socket, _) = tungstenite::connect(relay).map_err(|e| {
-        log::warn!("failed to connect to nostr relay {}: {}", relay, e);
-        MakerError::General("failed to connect to nostr relay")
-    })?;
+fn broadcast_to_relay(
+    relay: &str,
+    msg: &ClientMessage,
+    socks_port: u16,
+    tor_auth_password: &str,
+) -> Result<(), MakerError> {
+    let mut socket =
+        connect_nostr_websocket(relay, socks_port, tor_auth_password).map_err(|e| {
+            log::warn!("failed to connect to nostr relay {}: {}", relay, e);
+            MakerError::General("failed to connect to nostr relay")
+        })?;
 
     socket
         .write(Message::Text(msg.as_json().into()))

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -500,9 +500,13 @@ impl Taker {
         std::fs::create_dir_all(&data_dir)?;
 
         let (wallet, rpc_config) = Self::init_wallet(&config, &data_dir)?;
-        let (watch_service, initial_discovery_complete) =
-            Self::init_watch_service(&config, &rpc_config, &data_dir)?;
-        Self::init_taker_config(&config, &data_dir)?;
+        let taker_config = Self::init_taker_config(&config, &data_dir)?;
+        let (watch_service, initial_discovery_complete) = Self::init_watch_service(
+            &config,
+            &rpc_config,
+            &data_dir,
+            taker_config.tor_auth_password.clone(),
+        )?;
         let offerbook = OfferBookHandle::load_or_create(&data_dir)?;
         let offer_sync_handle = Self::init_offer_sync(
             &offerbook,
@@ -615,6 +619,7 @@ impl Taker {
         config: &TakerInitConfig,
         rpc_config: &RPCConfig,
         data_dir: &std::path::Path,
+        tor_auth_password: String,
     ) -> Result<(WatchService, Arc<AtomicBool>), TakerError> {
         let backend = ZmqBackend::new(&config.zmq_addr);
         let rpc_backend = BitcoinRest::new(rpc_config.clone())?;
@@ -632,8 +637,14 @@ impl Taker {
         let initial_sync_clone = initial_sync_complete.clone();
 
         let nostr_relays = config.nostr_relays.clone();
-        let mut watcher =
-            Watcher::<Taker>::new(backend, registry, rx_requests, tx_events, nostr_relays);
+        let mut watcher = Watcher::<Taker>::new(
+            backend,
+            registry,
+            rx_requests,
+            tx_events,
+            nostr_relays,
+            Some((config.socks_port, tor_auth_password)),
+        );
         let _ = thread::Builder::new()
             .name("Watcher thread".to_string())
             .spawn(move || watcher.run(rpc_config_watcher, initial_sync_clone));
@@ -648,7 +659,7 @@ impl Taker {
     fn init_taker_config(
         config: &TakerInitConfig,
         data_dir: &std::path::Path,
-    ) -> Result<(), TakerError> {
+    ) -> Result<TakerConfig, TakerError> {
         let mut taker_config = TakerConfig::new(Some(&data_dir.join("config.toml")))?;
 
         if let Some(control_port) = config.control_port {
@@ -667,7 +678,7 @@ impl Taker {
         }
 
         taker_config.write_to_file(&data_dir.join("config.toml"))?;
-        Ok(())
+        Ok(taker_config)
     }
 
     /// Start the background offer sync service.

--- a/src/watch_tower/nostr_discovery.rs
+++ b/src/watch_tower/nostr_discovery.rs
@@ -6,6 +6,7 @@
 
 use std::{
     borrow::Cow,
+    net::TcpStream,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
@@ -23,7 +24,7 @@ use nostr::{
 use tungstenite::{stream::MaybeTlsStream, Message};
 
 use crate::{
-    nostr_coinswap::{coinswap_kind, EXPIRATION_SECS},
+    nostr_coinswap::{coinswap_kind, connect_nostr_websocket, EXPIRATION_SECS},
     watch_tower::{
         registry_storage::FileRegistry,
         rest_backend::BitcoinRest,
@@ -34,6 +35,7 @@ use crate::{
 
 // ## TODO: Instead of looping over relay's have a connection Pool.
 /// Runs the main discovery routine for maker's fidelity bonds by subscribing to network-specific Nostr events.
+#[allow(clippy::too_many_arguments)]
 pub fn run_discovery(
     bitcoin_rpc: BitcoinRest,
     network: Network,
@@ -41,6 +43,8 @@ pub fn run_discovery(
     shutdown: Arc<AtomicBool>,
     initial_sync_complete: Arc<AtomicBool>,
     relays: &[String],
+    socks_port: u16,
+    tor_auth_password: String,
 ) -> Result<(), WatcherError> {
     log::info!("Starting market discovery via Nostr");
 
@@ -57,18 +61,21 @@ pub fn run_discovery(
         let bitcoin_rpc = Arc::clone(&bitcoin_rpc);
         let seen_txid = Arc::clone(&seen_txid);
         let initial_sync_complete = initial_sync_complete.clone();
+        let tor_auth_password = tor_auth_password.clone();
 
         std::thread::Builder::new()
             .name(format!("nostr-session-{}", relay))
             .spawn(move || {
                 run_nostr_session_for_relay(
-                    &relay.clone(),
+                    &relay,
                     kind,
                     registry,
                     shutdown,
                     bitcoin_rpc,
                     &seen_txid,
                     &initial_sync_complete,
+                    socks_port,
+                    &tor_auth_password,
                 );
             })?;
     }
@@ -78,6 +85,7 @@ pub fn run_discovery(
 
 /// Runs a long-lived Nostr session for a single relay.
 /// Reconnects automatically until shutdown is requested.
+#[allow(clippy::too_many_arguments)]
 fn run_nostr_session_for_relay(
     relay_url: &str,
     kind: Kind,
@@ -86,6 +94,8 @@ fn run_nostr_session_for_relay(
     bitcoin_rpc: Arc<BitcoinRest>,
     seen_txid: &Arc<Mutex<SeenTxids>>,
     initial_sync_complete: &Arc<AtomicBool>,
+    socks_port: u16,
+    tor_auth_password: &str,
 ) {
     log::info!("Starting Nostr session for relay {}", relay_url);
 
@@ -98,6 +108,8 @@ fn run_nostr_session_for_relay(
             bitcoin_rpc.clone(),
             seen_txid,
             initial_sync_complete,
+            socks_port,
+            tor_auth_password,
         ) {
             Ok(()) => {
                 // Likely exited due to shutdown
@@ -119,6 +131,7 @@ fn run_nostr_session_for_relay(
 
 /// Establishes websocket connection to single Nostr relay and processes events until error or shutdown.
 /// Subscribe to Nostr events on the Coinswap kind for the active network.
+#[allow(clippy::too_many_arguments)]
 fn connect_and_run_once(
     relay_url: &str,
     kind: Kind,
@@ -127,8 +140,10 @@ fn connect_and_run_once(
     bitcoin_rpc: Arc<BitcoinRest>,
     seen_txid: &Arc<Mutex<SeenTxids>>,
     initial_sync_complete: &Arc<AtomicBool>,
+    socks_port: u16,
+    tor_auth_password: &str,
 ) -> Result<(), WatcherError> {
-    let (mut socket, _) = tungstenite::connect(relay_url)?;
+    let mut socket = connect_nostr_websocket(relay_url, socks_port, tor_auth_password)?;
 
     let since = registry.load_nostr_cursor(relay_url).map(Timestamp::from);
 
@@ -146,7 +161,6 @@ fn connect_and_run_once(
     };
 
     socket.write(Message::Text(req.as_json().into()))?;
-
     socket.flush()?;
 
     log::info!(
@@ -172,7 +186,7 @@ fn connect_and_run_once(
 #[allow(clippy::too_many_arguments)]
 fn read_event_loop(
     registry: Arc<FileRegistry>,
-    mut socket: tungstenite::WebSocket<MaybeTlsStream<std::net::TcpStream>>,
+    mut socket: tungstenite::WebSocket<MaybeTlsStream<TcpStream>>,
     shutdown: Arc<AtomicBool>,
     bitcoin_rpc: Arc<BitcoinRest>,
     relay_url: &str,

--- a/src/watch_tower/service.rs
+++ b/src/watch_tower/service.rs
@@ -107,7 +107,7 @@ pub fn start_maker_watch_service(
     // Watcher
     let rpc_config_watcher = rpc_config.clone();
     let mut watcher =
-        Watcher::<MakerRole>::new(backend, registry, rx_requests, tx_events, Vec::new());
+        Watcher::<MakerRole>::new(backend, registry, rx_requests, tx_events, Vec::new(), None);
 
     // Makers don't run discovery, so pass an already-complete flag.
     thread::Builder::new()

--- a/src/watch_tower/watcher.rs
+++ b/src/watch_tower/watcher.rs
@@ -40,6 +40,7 @@ pub struct Watcher<R: Role> {
     rx_requests: StdReceiver<WatcherCommand>,
     tx_events: CbSender<WatcherEvent>,
     nostr_relays: Vec<String>,
+    nostr_tor_config: Option<(u16, String)>,
     _role: PhantomData<R>,
 }
 
@@ -94,6 +95,7 @@ impl<R: Role> Watcher<R> {
         rx_requests: StdReceiver<WatcherCommand>,
         tx_events: CbSender<WatcherEvent>,
         nostr_relays: Vec<String>,
+        nostr_tor_config: Option<(u16, String)>,
     ) -> Self {
         Self {
             backend,
@@ -101,6 +103,7 @@ impl<R: Role> Watcher<R> {
             rx_requests,
             tx_events,
             nostr_relays,
+            nostr_tor_config,
             _role: PhantomData,
         }
     }
@@ -139,25 +142,28 @@ impl<R: Role> Watcher<R> {
         let discovery_shutdown = Arc::new(AtomicBool::new(false));
         let registry = self.registry.clone();
         let nostr_relays = self.nostr_relays.clone();
+        let nostr_tor_config = self.nostr_tor_config.clone();
         std::thread::scope(move |s| {
             let discovery_clone = discovery_shutdown.clone();
-            if R::RUN_DISCOVERY {
-                let initial_sync_complete = initial_sync_complete.clone();
-                s.spawn(move || {
-                    if let Err(e) = nostr_discovery::run_discovery(
-                        rest_backend_1,
-                        network,
-                        registry,
-                        discovery_shutdown.clone(),
-                        initial_sync_complete,
-                        &nostr_relays,
-                    ) {
-                        log::error!("Discovery thread failed: {:?}", e);
-                    }
-                });
-            } else {
-                // No discovery — mark initial sync as trivially complete.
-                initial_sync_complete.store(true, Ordering::SeqCst);
+            match (R::RUN_DISCOVERY, nostr_tor_config) {
+                (true, Some((socks_port, tor_auth_password))) => {
+                    let initial_sync_complete = initial_sync_complete.clone();
+                    s.spawn(move || {
+                        if let Err(e) = nostr_discovery::run_discovery(
+                            rest_backend_1,
+                            network,
+                            registry,
+                            discovery_shutdown.clone(),
+                            initial_sync_complete,
+                            &nostr_relays,
+                            socks_port,
+                            tor_auth_password,
+                        ) {
+                            log::error!("Discovery thread failed: {:?}", e);
+                        }
+                    });
+                }
+                _ => initial_sync_complete.store(true, Ordering::SeqCst),
             }
             loop {
                 match self.rx_requests.try_recv() {


### PR DESCRIPTION
## Description

Nostr relay connections (`tungstenite::connect()`) currently go straight to clearnet, leaking the maker's IP. This routes them through the existing Tor SOCKS5 proxy instead.

Both the maker broadcast path (`nostr_coinswap.rs`) and the watchtower discovery path (`nostr_discovery.rs`) now use the shared Nostr websocket helper, which routes production relay connections through the configured Tor SOCKS5 proxy. Integration-test mode still connects directly so local test relays keep working.

## Related Issue(s)
Fixes #696

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [x] Neither (infrastructure / tooling only)

## Affected Component(s)
- [x] **makerd** (background daemon)
- [x] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [x] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings

### Testing
- [x] All unit tests pass (`cargo test`)
- [x] Integration tests pass (`cargo test --features integration-test`)
- [ ] Changes were manually tested on **regtest**
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [x] Test-only code is gated behind `cfg!(feature = "integration-test")` (matches existing codebase convention)

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [x] Complex logic is commented

### Security & Privacy (Critical)
- [x] This change preserves **trustlessness** and **atomic swap guarantees**
- [x] No regression in **sybil resistance** or **fidelity bond** logic
- [x] Tor anonymity and P2P message flow were reviewed
- [x] No new attack vectors or trust assumptions introduced
- [x] Edge cases and error handling considered
- [x] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [x] `integration-test` feature flag is not reachable in production code paths

## How to Test

Build check for both modes:
```bash
cargo check
cargo check --features integration-test
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tor SOCKS5 support for Nostr relay connections, enabling proxy-based connectivity for bond broadcasts and discovery operations.

* **Bug Fixes**
  * Improved error handling for WebSocket operations with dedicated error types and better failure reporting.
  * Enhanced connection timeout handling for relay synchronization.

* **Chores**
  * Updated TLS dependency to use Rustls instead of native TLS for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->