### PR TITLE
Hardcode CoinSwap virtual Tor port to 21

### DIFF
--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -124,8 +124,7 @@ fn handle_request<M: MakerRpc>(maker: &Arc<M>, socket: &mut TcpStream) -> Result
                 RpcMsgResp::GetTorAddressResp("Maker is not running on TOR".to_string())
             } else {
                 let hostname = maker.get_tor_hostname()?;
-                let address = format!("{}:{}", hostname, maker.config().network_port);
-                RpcMsgResp::GetTorAddressResp(address)
+                RpcMsgResp::GetTorAddressResp(hostname)
             }
         }
         RpcMsgReq::Stop => {

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -60,12 +60,10 @@ pub fn start_server(maker: Arc<MakerServer>) -> Result<(), MakerError> {
     };
     listener.set_nonblocking(true).map_err(MakerError::IO)?;
 
-    let maker_port = maker.config.network_port;
     let maker_address = if cfg!(feature = "integration-test") {
-        format!("127.0.0.1:{maker_port}")
+        format!("127.0.0.1:{}", maker.config.network_port)
     } else {
-        let maker_hostname = maker.get_tor_hostname()?;
-        format!("{maker_hostname}:{maker_port}")
+        maker.get_tor_hostname()?
     };
 
     log::info!(

--- a/src/protocol/common_messages.rs
+++ b/src/protocol/common_messages.rs
@@ -13,6 +13,9 @@ use super::{
 };
 use crate::wallet::FidelityBond;
 
+/// Well-known virtual port for the CoinSwap protocol over Tor.
+pub const COINSWAP_PORT: u16 = 21;
+
 /// Hash preimage type used in HTLC contracts.
 pub type Preimage = [u8; 32];
 

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -1643,6 +1643,8 @@ impl Taker {
 
     /// Connect to a maker using either direct connection or Tor proxy.
     pub(crate) fn net_connect(&self, address: &str) -> Result<TcpStream, TakerError> {
+        use crate::protocol::common_messages::COINSWAP_PORT;
+
         log::debug!("Connecting to maker at {}", address);
         let timeout = Duration::from_secs(CONNECT_TIMEOUT_SECS);
 
@@ -1658,7 +1660,8 @@ impl Taker {
             })?,
             ConnectionType::Tor => {
                 let socks_addr = format!("127.0.0.1:{}", self.config.socks_port);
-                Socks5Stream::connect(socks_addr.as_str(), address)
+                let tor_target = format!("{}:{}", address, COINSWAP_PORT);
+                Socks5Stream::connect(socks_addr.as_str(), tor_target.as_str())
                     .map_err(|e| {
                         TakerError::General(format!(
                             "Failed to connect to {} via Tor: {}",

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -78,7 +78,7 @@ const DISCOVERY_WAIT_MAX: Duration = Duration::from_secs(150);
 pub struct OfferAndAddress {
     /// Details for Maker Offer
     pub offer: Offer,
-    /// Maker Address: onion_addr:port
+    /// Maker address (hostname)
     pub address: MakerAddress,
     /// Current state of maker
     pub state: MakerState,
@@ -90,7 +90,7 @@ pub struct OfferAndAddress {
 /// A maker may or may not currently have an offer.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MakerOfferCandidate {
-    /// Maker Address: onion_addr:port
+    /// Maker address (hostname)
     pub address: MakerAddress,
 
     /// Latest offer, if successfully fetched
@@ -197,19 +197,14 @@ impl fmt::Display for MakerProtocol {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct OnionAddress {
-    port: String,
-    onion_addr: String,
-}
-
-/// Enum representing maker addresses.
+/// Maker address: just the hostname (e.g. `"xyz.onion"`).
+/// In integration tests (clearnet), this is `"ip:port"`.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
-pub struct MakerAddress(OnionAddress);
+pub struct MakerAddress(String);
 
 impl fmt::Display for MakerAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}:{}", self.0.onion_addr, self.0.port)
+        f.write_str(&self.0)
     }
 }
 
@@ -217,10 +212,11 @@ impl TryFrom<&mut TcpStream> for MakerAddress {
     type Error = std::io::Error;
     fn try_from(value: &mut TcpStream) -> Result<Self, Self::Error> {
         let socket_addr = value.peer_addr()?;
-        Ok(MakerAddress(OnionAddress {
-            port: socket_addr.port().to_string(),
-            onion_addr: socket_addr.ip().to_string(),
-        }))
+        Ok(MakerAddress(format!(
+            "{}:{}",
+            socket_addr.ip(),
+            socket_addr.port()
+        )))
     }
 }
 
@@ -616,9 +612,8 @@ impl OfferBook {
     /// Gets all active (good) offers for a given protocol.
     /// Makers are included for both Legacy and Taproot requests.
     fn active_makers(&self, protocol: &MakerProtocol) -> Vec<OfferAndAddress> {
-        let mut makers = self.makers.clone();
-        makers.sort_by(|a, b| a.address.0.port.cmp(&b.address.0.port));
-        makers
+        let mut result: Vec<_> = self
+            .makers
             .iter()
             .filter(|m| m.state == MakerState::Good)
             .filter(|m| {
@@ -628,7 +623,9 @@ impl OfferBook {
                     .unwrap_or(false)
             })
             .filter_map(|m| m.as_offer_and_address())
-            .collect()
+            .collect();
+        result.sort_by(|a, b| a.address.cmp(&b.address));
+        result
     }
 
     fn good_makers(&self) -> Vec<OfferAndAddress> {
@@ -647,9 +644,8 @@ impl OfferBook {
     /// Gets the list of bad makers.
     /// Makers are included for both Legacy and Taproot requests.
     fn get_bad_makers(&self, protocol: &MakerProtocol) -> Vec<OfferAndAddress> {
-        let mut makers = self.makers.clone();
-        makers.sort_by(|a, b| a.address.0.port.len().cmp(&b.address.0.port.len()));
-        makers
+        let mut result: Vec<_> = self
+            .makers
             .iter()
             .filter(|m| m.state == MakerState::Bad)
             .filter(|m| {
@@ -659,7 +655,9 @@ impl OfferBook {
                     .unwrap_or(false)
             })
             .filter_map(|m| m.as_offer_and_address())
-            .collect()
+            .collect();
+        result.sort_by(|a, b| a.address.cmp(&b.address));
+        result
     }
 
     /// Load existing file, updates it, writes it back (create if path doesn't exist).
@@ -759,28 +757,34 @@ pub(crate) fn fetch_offer_from_makers(
     Ok(offers)
 }
 
-impl TryFrom<String> for OnionAddress {
-    type Error = &'static str;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        let mut parts = value.splitn(2, ':');
-        let onion_addr = parts.next().ok_or("Missing onion address")?.to_string();
-        let port = parts.next().ok_or("Missing port")?.to_string();
-
-        if onion_addr.is_empty() || port.is_empty() {
-            return Err("Empty onion address or port");
-        }
-
-        Ok(OnionAddress { onion_addr, port })
-    }
-}
-
 impl TryFrom<String> for MakerAddress {
     type Error = &'static str;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        let onion = OnionAddress::try_from(value)?;
-        Ok(MakerAddress(onion))
+        if value.is_empty() {
+            return Err("Empty address");
+        }
+
+        #[cfg(feature = "integration-test")]
+        {
+            // Integration tests use "ip:port" format
+            let mut parts = value.splitn(2, ':');
+            let ip = parts.next().ok_or("Missing IP")?;
+            let port = parts.next().ok_or("Missing port")?;
+            if ip.is_empty() || port.is_empty() {
+                return Err("Empty IP or port");
+            }
+        }
+
+        #[cfg(not(feature = "integration-test"))]
+        {
+            // Production: value is just a hostname like "xyz.onion"
+            if !value.ends_with(".onion") {
+                return Err("Not a valid .onion hostname");
+            }
+        }
+
+        Ok(MakerAddress(value))
     }
 }
 
@@ -819,17 +823,18 @@ impl MakerAddress {
 
     /// Download a single offer from a maker.
     fn fetch_offer(&self, socks_port: u16) -> Result<(Offer, MakerProtocol), TakerError> {
-        let maker_addr = self.to_string();
-        log::debug!("Downloading offer from maker: {}", maker_addr);
+        use crate::protocol::common_messages::COINSWAP_PORT;
+
+        log::debug!("Downloading offer from maker: {}", self);
 
         let mut socket = if cfg!(feature = "integration-test") {
-            TcpStream::connect(&maker_addr)?
+            // Integration test: self.0 is "ip:port"
+            TcpStream::connect(self.to_string())?
         } else {
-            Socks5Stream::connect(
-                format!("127.0.0.1:{socks_port}").as_str(),
-                maker_addr.as_ref(),
-            )?
-            .into_inner()
+            // Production: self.0 is a .onion hostname, append the well-known port
+            let addr = format!("{}:{}", self.0, COINSWAP_PORT);
+            Socks5Stream::connect(format!("127.0.0.1:{socks_port}").as_str(), addr.as_ref())?
+                .into_inner()
         };
 
         socket.set_read_timeout(Some(Duration::from_secs(FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC)))?;
@@ -894,7 +899,7 @@ impl MakerAddress {
 
         log::info!(
             "Successfully downloaded offer from maker: {} (protocol: Unified)",
-            maker_addr
+            self
         );
 
         Ok((offer, MakerProtocol::Unified))
@@ -922,11 +927,8 @@ mod tests {
         Amount, OutPoint, Txid,
     };
 
-    fn addr(port: &str) -> MakerAddress {
-        MakerAddress(OnionAddress {
-            port: port.to_string(),
-            onion_addr: "testonionaddress.onion".to_string(),
-        })
+    fn addr(id: &str) -> MakerAddress {
+        MakerAddress(format!("testmaker{id}.onion"))
     }
 
     fn dummy_offer(maker_addr: &str) -> Offer {

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -591,11 +591,12 @@ pub fn prompt_password(message: String) -> io::Result<String> {
 
 pub(crate) fn get_emphemeral_address(
     control_port: u16,
-    target_port: u16,
+    local_port: u16,
     password: &str,
     private_key_data: Option<&str>,
     service_id_data: Option<&str>,
 ) -> Result<(String, String), TorError> {
+    use crate::protocol::common_messages::COINSWAP_PORT;
     use std::io::BufRead;
     let mut stream = TcpStream::connect(format!("127.0.0.1:{control_port}"))?;
     let mut reader = BufReader::new(stream.try_clone()?);
@@ -609,10 +610,10 @@ pub(crate) fn get_emphemeral_address(
         stream.write_all(remove_command.as_bytes())?;
     }
     let mut add_onion_command =
-        format!("ADD_ONION NEW:BEST Flags=Detach Port={target_port},127.0.0.1:{target_port}\r\n");
+        format!("ADD_ONION NEW:BEST Flags=Detach Port={COINSWAP_PORT},127.0.0.1:{local_port}\r\n");
     if let Some(pk) = private_key_data {
         add_onion_command =
-            format!("ADD_ONION {pk} Flags=Detach Port={target_port},127.0.0.1:{target_port}\r\n");
+            format!("ADD_ONION {pk} Flags=Detach Port={COINSWAP_PORT},127.0.0.1:{local_port}\r\n");
         private_key = pk.to_string();
     }
     stream.write_all(add_onion_command.as_bytes())?;
@@ -647,7 +648,7 @@ pub(crate) fn get_emphemeral_address(
 pub(crate) fn get_tor_hostname(
     data_dir: &Path,
     control_port: u16,
-    target_port: u16,
+    local_port: u16,
     password: &str,
 ) -> Result<String, TorError> {
     let tor_config_path = data_dir.join("tor/hostname");
@@ -661,7 +662,7 @@ pub(crate) fn get_tor_hostname(
 
             let (hostname, private_key) = get_emphemeral_address(
                 control_port,
-                target_port,
+                local_port,
                 password,
                 Some(private_key_data),
                 Some(hostname_data.replace(".onion", "").as_str()),
@@ -677,7 +678,7 @@ pub(crate) fn get_tor_hostname(
     }
 
     let (hostname, private_key) =
-        get_emphemeral_address(control_port, target_port, password, None, None)?;
+        get_emphemeral_address(control_port, local_port, password, None, None)?;
 
     if let Some(parent) = tor_config_path.parent() {
         fs::create_dir_all(parent)?;

--- a/src/watch_tower/utils.rs
+++ b/src/watch_tower/utils.rs
@@ -53,16 +53,7 @@ fn extract_op_return_data(script: &[u8]) -> Option<&[u8]> {
 
 #[cfg(not(feature = "integration-test"))]
 fn is_valid_onion_address(s: &str) -> bool {
-    let parts: Vec<&str> = s.split(':').collect();
-    if parts.len() != 2 {
-        return false;
-    }
-    let domain = parts[0];
-    let port = parts[1];
-    if !domain.ends_with(".onion") {
-        return false;
-    }
-    matches!(port.parse::<u16>(), Ok(p) if p > 0)
+    s.ends_with(".onion") && s.len() > ".onion".len()
 }
 
 #[cfg(feature = "integration-test")]
@@ -215,7 +206,7 @@ mod tests {
     use bitcoind::tempfile::TempDir;
 
     #[cfg(not(feature = "integration-test"))]
-    const TEST_ADDR: &[u8] = b"aslkdfjbiakdsfn.onion:9050#500";
+    const TEST_ADDR: &[u8] = b"aslkdfjbiakdsfn.onion#500";
     #[cfg(feature = "integration-test")]
     const TEST_ADDR: &[u8] = b"127.0.0.1:9050#500";
 
@@ -261,7 +252,7 @@ mod tests {
         let ann = process_fidelity(&tx).expect("expected valid fidelity announcement");
 
         #[cfg(not(feature = "integration-test"))]
-        assert_eq!(ann.onion, "aslkdfjbiakdsfn.onion:9050");
+        assert_eq!(ann.onion, "aslkdfjbiakdsfn.onion");
         #[cfg(feature = "integration-test")]
         assert_eq!(ann.onion, "127.0.0.1:9050");
         assert_eq!(ann.expires_at_height, 500);
@@ -300,7 +291,7 @@ mod tests {
         );
         assert!(process_fidelity(&tx_no).is_none());
 
-        let bad = op_return(b"aslkdfjbiakdsfn.onion:9050");
+        let bad = op_return(b"aslkdfjbiakdsfn.onion");
         let tx_bad = tx(
             1,
             vec![OutPoint::null()],
@@ -308,7 +299,7 @@ mod tests {
         );
         assert!(process_fidelity(&tx_bad).is_none());
 
-        let bad2 = op_return(b"aslkdfjbiakdsfn.onion:9050#abc");
+        let bad2 = op_return(b"aslkdfjbiakdsfn.onion#abc");
         let tx_bad2 = tx(
             1,
             vec![OutPoint::null()],


### PR DESCRIPTION
Decouple the Tor virtual port from the local TCP bind port by introducing a well-known protocol constant COINSWAP_PORT (21).

- Add COINSWAP_PORT constant in protocol/common_messages.rs
- Use COINSWAP_PORT as the Tor virtual port in ADD_ONION commands while forwarding to the local bind port
- Simplify MakerAddress to a newtype over String (just the hostname), removing the OnionAddress struct and broken sort-by-port logic
- Append COINSWAP_PORT when connecting over Tor (fetch_offer, net_connect)
- Drop port from maker address in server.rs and RPC responses
- Update watchtower OP_RETURN parsing to expect hostname-only format
- Update fidelity bond encoding (port no longer included in OP_RETURN)

Each .onion hostname is unique, so a well-known virtual port simplifies addressing, saves OP_RETURN space, and allows multiple makers on the same machine to share the same virtual port.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized Tor address port handling across maker and taker connections using a fixed service port.
  * Simplified onion address representation and validation logic.
  * Updated Tor connection configuration to consistently apply the designated service port for ephemeral onion services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->