### PR TITLE
fix: persist swapcoins before funding broadcast

### DIFF
--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -124,6 +124,12 @@ enum Commands {
         /// When set, these makers are used directly instead of auto-discovery.
         #[clap(long = "maker-address")]
         maker_addresses: Vec<String>,
+        /// Automatically select UTXOs instead of interactive picker.
+        #[clap(long)]
+        auto_select: bool,
+        /// Skip the confirmation prompt and proceed immediately.
+        #[clap(long, short = 'y')]
+        yes: bool,
     },
     /// Recover from all failed swaps
     Recover,
@@ -448,24 +454,27 @@ fn main() -> Result<(), TakerError> {
             amount,
             protocol,
             maker_addresses,
+            auto_select,
+            yes,
         } => {
             let protocol_version = parse_protocol(protocol)?;
 
-            let manually_selected_outpoints = if cfg!(not(feature = "integration-test")) {
-                let target_amount = Amount::from_sat(*amount);
-                let wallet = taker.get_wallet().read().unwrap();
-                Some(
-                    coinswap::utill::interactive_select(
-                        wallet.list_all_utxo_spend_info(),
-                        target_amount,
-                    )?
-                    .iter()
-                    .map(|(utxo, _)| bitcoin::OutPoint::new(utxo.txid, utxo.vout))
-                    .collect::<Vec<_>>(),
-                )
-            } else {
-                None
-            };
+            let manually_selected_outpoints =
+                if !auto_select && cfg!(not(feature = "integration-test")) {
+                    let target_amount = Amount::from_sat(*amount);
+                    let wallet = taker.get_wallet().read().unwrap();
+                    Some(
+                        coinswap::utill::interactive_select(
+                            wallet.list_all_utxo_spend_info(),
+                            target_amount,
+                        )?
+                        .iter()
+                        .map(|(utxo, _)| bitcoin::OutPoint::new(utxo.txid, utxo.vout))
+                        .collect::<Vec<_>>(),
+                    )
+                } else {
+                    None
+                };
 
             let mut swap_params =
                 SwapParams::new(protocol_version, Amount::from_sat(*amount), *makers);
@@ -499,7 +508,7 @@ fn main() -> Result<(), TakerError> {
             println!("==================================\n");
 
             // In integration tests, skip the confirmation prompt.
-            if cfg!(not(feature = "integration-test")) {
+            if !yes && cfg!(not(feature = "integration-test")) {
                 print!("Proceed with this swap? [y/N] ");
                 use std::io::{self, Write};
                 io::stdout().flush().unwrap();

--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -451,6 +451,17 @@ fn process_resp_contract_sigs_for_recvr_and_sender<M: Maker>(
         }
     }
 
+    // Persist swapcoins (now carrying contract signatures) to the wallet
+    // store BEFORE broadcasting funding txs. Without this, a crash after
+    // broadcast leaves the wallet with no record of these swapcoins,
+    // making timelock recovery impossible.
+    for incoming in &state.incoming_swapcoins {
+        maker.save_incoming_swapcoin(incoming)?;
+    }
+    for outgoing in &state.outgoing_swapcoins {
+        maker.save_outgoing_swapcoin(outgoing)?;
+    }
+
     log::info!(
         "[{}] SECURITY: Broadcasting {} funding txs after receiving signatures",
         maker.network_port(),
@@ -466,12 +477,7 @@ fn process_resp_contract_sigs_for_recvr_and_sender<M: Maker>(
     state.funding_broadcast = true;
     state.phase = SwapPhase::AwaitingPrivateKeyHandover;
 
-    for incoming in &state.incoming_swapcoins {
-        maker.save_incoming_swapcoin(incoming)?;
-    }
     for outgoing in &state.outgoing_swapcoins {
-        maker.save_outgoing_swapcoin(outgoing)?;
-
         // Register outgoing contract output with watchtower EARLY so it can
         // detect hashlock spends by the taker before recovery starts.
         let contract_txid = outgoing.contract_tx.compute_txid();

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -186,7 +186,7 @@ fn process_taproot_contract<M: Maker>(
         .map_err(|e| MakerError::General(format!("Failed to add timelock leaf: {:?}", e).leak()))?;
 
     let mut ordered_pubkeys = [outgoing_pubkey, data.next_hop_point];
-    ordered_pubkeys.sort_by(|a, b| a.inner.serialize().cmp(&b.inner.serialize()));
+    ordered_pubkeys.sort_by_key(|a| a.inner.serialize());
     let internal_key = crate::protocol::musig_interface::get_aggregated_pubkey_compat(
         ordered_pubkeys[0].inner,
         ordered_pubkeys[1].inner,

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -262,11 +262,7 @@ impl Taker {
                     outgoing_locktime,
                 )?;
                 let swap = self.swap_state_mut()?;
-                for (swapcoin, sig) in swap
-                    .outgoing_swapcoins
-                    .iter_mut()
-                    .zip(sender_sigs.into_iter())
-                {
+                for (swapcoin, sig) in swap.outgoing_swapcoins.iter_mut().zip(sender_sigs) {
                     swapcoin.others_contract_sig = Some(sig);
                 }
                 let exch = self.swap_state_mut()?.makers[maker_idx].legacy_exchange_mut()?;
@@ -280,12 +276,13 @@ impl Taker {
                     let mut wallet = self.write_wallet()?;
 
                     // Persist the outgoing swapcoins (now carrying the maker's
-                    // contract signatures) before broadcasting the funding txs.
+                    // contract signatures) to disk BEFORE broadcasting the funding txs.
                     // Without this, a crash after broadcast leaves the wallet
                     // store missing `others_contract_sig`, blocking timelock recovery.
                     for swapcoin in &self.swap_state()?.outgoing_swapcoins {
                         wallet.add_outgoing_swapcoin(swapcoin);
                     }
+                    wallet.save_to_disk()?;
 
                     for swapcoin in &self.swap_state()?.outgoing_swapcoins {
                         let funding_tx = swapcoin.funding_tx.as_ref().ok_or_else(|| {

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -277,7 +277,15 @@ impl Taker {
             if is_first_peer && !taker_funding_broadcast {
                 log::info!("Broadcasting funding transactions and waiting for confirmation");
                 {
-                    let wallet = self.write_wallet()?;
+                    let mut wallet = self.write_wallet()?;
+
+                    // Persist the outgoing swapcoins (now carrying the maker's
+                    // contract signatures) before broadcasting the funding txs.
+                    // Without this, a crash after broadcast leaves the wallet
+                    // store missing `others_contract_sig`, blocking timelock recovery.
+                    for swapcoin in &self.swap_state()?.outgoing_swapcoins {
+                        wallet.add_outgoing_swapcoin(swapcoin);
+                    }
 
                     for swapcoin in &self.swap_state()?.outgoing_swapcoins {
                         let funding_tx = swapcoin.funding_tx.as_ref().ok_or_else(|| {

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -115,7 +115,7 @@ impl Taker {
             // Create aggregated MuSig2 pubkey for internal key (allows cooperative key-path spend)
             // Order pubkeys lexicographically to match signing order
             let mut ordered_pubkeys = [my_pubkey, *multisig_pubkey];
-            ordered_pubkeys.sort_by(|a, b| a.inner.serialize().cmp(&b.inner.serialize()));
+            ordered_pubkeys.sort_by_key(|a| a.inner.serialize());
             let internal_key = crate::protocol::musig_interface::get_aggregated_pubkey_compat(
                 ordered_pubkeys[0].inner,
                 ordered_pubkeys[1].inner,

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -878,37 +878,33 @@ pub fn interactive_select(
 
     loop {
         match read()? {
-            Event::Mouse(mouse_event) => {
-                if mouse_event.kind == MouseEventKind::Down(MouseButton::Left) {
-                    let click_row = mouse_event.row;
-                    let click_col = mouse_event.column;
+            Event::Mouse(mouse_event)
+                if mouse_event.kind == MouseEventKind::Down(MouseButton::Left) =>
+            {
+                let click_row = mouse_event.row;
+                let click_col = mouse_event.column;
 
-                    if click_row >= HEADER_LINES as u16 {
-                        let display_row = (click_row - HEADER_LINES as u16) / LINES_PER_ROW as u16;
-                        let actual_row = scroll_offset + display_row as usize;
-                        let box_col = click_col / COL_SPACING as u16;
-                        let i = actual_row * cols + box_col as usize;
+                if click_row >= HEADER_LINES as u16 {
+                    let display_row = (click_row - HEADER_LINES as u16) / LINES_PER_ROW as u16;
+                    let actual_row = scroll_offset + display_row as usize;
+                    let box_col = click_col / COL_SPACING as u16;
+                    let i = actual_row * cols + box_col as usize;
 
-                        if i < choices.len() {
-                            selected[i] = !selected[i];
+                    if i < choices.len() {
+                        selected[i] = !selected[i];
 
-                            render_utxo_grid(&mut stdout, &choices, &selected, scroll_offset)?;
-                        }
+                        render_utxo_grid(&mut stdout, &choices, &selected, scroll_offset)?;
                     }
                 }
             }
             Event::Key(key_event) => match key_event.code {
-                KeyCode::PageUp => {
-                    if scroll_offset > 0 {
-                        scroll_offset -= 1;
-                        render_utxo_grid(&mut stdout, &choices, &selected, scroll_offset)?;
-                    }
+                KeyCode::PageUp if scroll_offset > 0 => {
+                    scroll_offset -= 1;
+                    render_utxo_grid(&mut stdout, &choices, &selected, scroll_offset)?;
                 }
-                KeyCode::PageDown => {
-                    if scroll_offset < max_scroll {
-                        scroll_offset += 1;
-                        render_utxo_grid(&mut stdout, &choices, &selected, scroll_offset)?;
-                    }
+                KeyCode::PageDown if scroll_offset < max_scroll => {
+                    scroll_offset += 1;
+                    render_utxo_grid(&mut stdout, &choices, &selected, scroll_offset)?;
                 }
                 // Numlock your keyboard, key 3 is PageDown and key 9 is PageUp
                 KeyCode::Up => {

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -1689,9 +1689,7 @@ impl Wallet {
             })
             .collect();
 
-        for (ix, (input, input_info)) in
-            tx.input.iter_mut().zip(inputs_info.into_iter()).enumerate()
-        {
+        for (ix, (input, input_info)) in tx.input.iter_mut().zip(inputs_info).enumerate() {
             match input_info {
                 UTXOSpendInfo::OutgoingSwapCoin { .. } => {
                     return Err(WalletError::General(


### PR DESCRIPTION
Outgoing swapcoins were saved to the wallet store before contract signatures were received. If the process crashed after funding broadcast, the persisted swapcoin was missing `others_contract_sig`, making timelock recovery impossible.

Move save calls to before funding broadcast on both taker and maker sides. Also add `--auto-select` and `--yes` flags to taker CLI for non-interactive swap execution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--auto-select` and `--yes` flags to the Coinswap CLI for optional automated, non-interactive swaps.

* **Bug Fixes**
  * Made swapcoin persistence more timely to reduce duplication and improve swap reliability.
  * Pre-broadcast persistence of outgoing swapcoins to ensure wallet state consistency.

* **Refactor**
  * Deterministic ordering and iterator/flow tweaks for modest performance and maintainability gains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->