### PR TITLE
fix: implement Merkle proof verification for legacy funding txs

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -1202,6 +1202,8 @@ impl MakerTrait for MakerServer {
                 .ok_or(MakerError::General("Funding output not found"))?
                 as u32;
 
+            let funding_txid = funding_info.funding_tx.compute_txid();
+
             // Check the funding_tx is confirmed to required depth
             let wallet_read = self
                 .wallet
@@ -1210,11 +1212,7 @@ impl MakerTrait for MakerServer {
 
             if let Some(txout) = wallet_read
                 .rpc
-                .get_tx_out(
-                    &funding_info.funding_tx.compute_txid(),
-                    funding_output_index,
-                    None,
-                )
+                .get_tx_out(&funding_txid, funding_output_index, None)
                 .map_err(WalletError::Rpc)?
             {
                 if txout.confirmations < REQUIRED_CONFIRMS {
@@ -1225,6 +1223,9 @@ impl MakerTrait for MakerServer {
             } else {
                 return Err(MakerError::General("Funding tx output doesn't exist"));
             }
+
+            // Verify the taker-provided SPV proof commits to this funding transaction.
+            wallet_read.verify_tx_out_proof(&funding_txid, &funding_info.funding_tx_merkleproof)?;
 
             check_reedemscript_is_multisig(&funding_info.multisig_redeemscript)?;
 
@@ -1247,7 +1248,7 @@ impl MakerTrait for MakerServer {
 
             if !wallet_read.does_prevout_match_cached_contract(
                 &OutPoint {
-                    txid: funding_info.funding_tx.compute_txid(),
+                    txid: funding_txid,
                     vout: funding_output_index,
                 },
                 &contract_spk,

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -4,9 +4,11 @@ use std::{net::TcpStream, time::Duration};
 
 use bitcoin::{
     hashes::{hash160::Hash as Hash160, Hash},
+    hex::DisplayHex,
     secp256k1::{self, rand::rngs::OsRng, Secp256k1, SecretKey},
     Amount, Network, OutPoint, PublicKey, ScriptBuf, Transaction, Txid,
 };
+use bitcoind::bitcoincore_rpc::RpcApi;
 
 use crate::{
     protocol::{
@@ -24,7 +26,7 @@ use crate::{
     utill::{generate_keypair, generate_maker_keys, read_message, send_message, MIN_FEE_RATE},
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin, WatchOnlySwapCoin},
-        Wallet,
+        Wallet, WalletError,
     },
 };
 
@@ -871,25 +873,36 @@ impl Taker {
         next_hashlock_nonces: &[SecretKey],
         refund_locktime: u16,
     ) -> Result<(Vec<Transaction>, Vec<SenderContractTxInfo>), TakerError> {
-        let confirmed_funding_txes: Vec<FundingTxInfo> = funding_txs
-            .iter()
-            .zip(multisig_redeemscripts.iter())
-            .zip(contract_redeemscripts.iter())
-            .zip(multisig_nonces.iter())
-            .zip(hashlock_nonces.iter())
-            .map(
-                |((((funding_tx, multisig_rs), contract_rs), &multisig_nonce), &hashlock_nonce)| {
-                    FundingTxInfo {
-                        funding_tx: funding_tx.clone(),
-                        funding_tx_merkleproof: String::new(), // TODO: Get actual merkle proof
-                        multisig_redeemscript: multisig_rs.clone(),
-                        multisig_nonce,
-                        contract_redeemscript: contract_rs.clone(),
-                        hashlock_nonce,
-                    }
-                },
-            )
-            .collect();
+        let confirmed_funding_txes: Vec<FundingTxInfo> = {
+            let wallet = self.read_wallet()?;
+            funding_txs
+                .iter()
+                .zip(multisig_redeemscripts.iter())
+                .zip(contract_redeemscripts.iter())
+                .zip(multisig_nonces.iter())
+                .zip(hashlock_nonces.iter())
+                .map(
+                    |(
+                        (((funding_tx, multisig_rs), contract_rs), &multisig_nonce),
+                        &hashlock_nonce,
+                    )| {
+                        let txids = [funding_tx.compute_txid()];
+                        let merkle_proof = wallet
+                            .rpc
+                            .get_tx_out_proof(&txids, None)
+                            .map_err(WalletError::Rpc)?;
+                        Ok(FundingTxInfo {
+                            funding_tx: funding_tx.clone(),
+                            funding_tx_merkleproof: merkle_proof.to_lower_hex_string(),
+                            multisig_redeemscript: multisig_rs.clone(),
+                            multisig_nonce,
+                            contract_redeemscript: contract_rs.clone(),
+                            hashlock_nonce,
+                        })
+                    },
+                )
+                .collect::<Result<Vec<_>, TakerError>>()?
+        };
 
         let next_coinswap_info: Vec<NextHopInfo> = next_multisig_pubkeys
             .iter()

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -45,6 +45,17 @@ pub enum WalletError {
     /// Use this variant for errors that do not fall under any specific category.
     General(String),
 
+    /// Represents an invalid Merkle proof for a transaction.
+    ///
+    /// `got` contains the txids returned by `verifytxoutproof`, which may be
+    /// empty if the proof failed SPV verification or is not in the best chain.
+    MerkleProofInvalid {
+        /// The txid the proof was expected to commit to.
+        expected: bitcoin::Txid,
+        /// The txids actually returned by `verifytxoutproof`.
+        got: Vec<bitcoin::Txid>,
+    },
+
     /// Represents an error related to protocol violations or unexpected protocol behavior.
     Protocol(ProtocolError),
 
@@ -205,6 +216,13 @@ impl std::fmt::Display for WalletError {
             WalletError::BIP32(e) => write!(f, "BIP32 error: {}", e),
             WalletError::BIP39(e) => write!(f, "BIP39 error: {}", e),
             WalletError::General(msg) => write!(f, "{}", msg),
+            WalletError::MerkleProofInvalid { expected, got } => {
+                write!(
+                    f,
+                    "MerkleProofInvalid | expected: {} | got: {:?}",
+                    expected, got
+                )
+            }
             WalletError::Protocol(e) => write!(f, "Protocol error: {}", e),
             WalletError::Fidelity(e) => write!(f, "Fidelity error: {}", e),
             WalletError::Locktime(e) => write!(f, "Locktime conversion error: {}", e),

--- a/src/wallet/rpc.rs
+++ b/src/wallet/rpc.rs
@@ -237,4 +237,25 @@ impl Wallet {
         let _res: Vec<Value> = self.rpc.call("importdescriptors", &[import_requests])?;
         Ok(())
     }
+
+    /// Verify the SPV proof for a transaction.
+    pub fn verify_tx_out_proof(
+        &self,
+        expected_txid: &bitcoin::Txid,
+        proof_hex: &str,
+    ) -> Result<(), WalletError> {
+        let proof_txids: Vec<bitcoin::Txid> = self
+            .rpc
+            .call("verifytxoutproof", &[json!(proof_hex)])
+            .map_err(WalletError::Rpc)?;
+
+        if proof_txids != vec![*expected_txid] {
+            return Err(WalletError::MerkleProofInvalid {
+                expected: *expected_txid,
+                got: proof_txids,
+            });
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a clear and concise description of what this PR does and why it is needed. -->
Resolves the `TODO` in `legacy_swap.rs` regarding missing Merkle proof validation.

Prior to this change, the Taker was populating the `funding_tx_merkleproof` field with an empty string, and the Maker was accepting it without cryptographically verifying the funding transaction's existence on the blockchain.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [x] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [ ] Neither (infrastructure / tooling only)

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [x] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [x] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [x] All unit tests pass (`cargo test`)
- [x] Integration tests pass (`cargo test --features integration-test`)
- [ ] Changes were manually tested on **regtest**
- [x] End-to-end maker ↔ taker swap tested (where applicable)
- [x] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [x] Complex logic is commented

### Security & Privacy (Critical)
- [x] This change preserves **trustlessness** and **atomic swap guarantees**
- [x] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [x] No new attack vectors or trust assumptions introduced
- [x] Edge cases and error handling considered
- [x] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [x] `integration-test` feature flag is not reachable in production code paths

## How to Test
<!-- Step-by-step instructions so reviewers can verify quickly. -->

```bash
CFLAGS="-Wno-int-conversion" cargo test --features integration-test
```

<!-- Add any additional manual steps specific to this PR
     (e.g. regtest node config, docker-setup, specific taker commands): -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-chain merkle-proof verification for submitted funding transactions: proofs are fetched from the connected wallet and verified before swaps proceed.
  * Verification now retries for a short period with pauses to allow proofs to appear on-chain.
  * Wallet-backed verification enforces strict matching of the proved transaction.

* **Bug Fixes**
  * Proof validation fails fast on missing, empty, or mismatched proofs, preventing unverified funding from progressing.
  * Retrieval errors during proof collection now propagate immediately, eliminating placeholder proofs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->