### PR TITLE
Add transport negotiation groundwork

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -17,7 +17,7 @@ use bitcoind::bitcoincore_rpc::RpcApi;
 
 use crate::{
     nostr_coinswap::NOSTR_RELAYS,
-    protocol::common_messages::{FidelityProof, ProtocolVersion, SwapDetails},
+    protocol::common_messages::{FidelityProof, ProtocolVersion, SwapDetails, TransportMode},
     utill::{get_maker_dir, parse_field, parse_toml, MIN_FEE_RATE},
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin},
@@ -107,6 +107,8 @@ pub struct MakerServerConfig {
     pub required_confirms: u32,
     /// Supported protocol versions.
     pub supported_protocols: Vec<ProtocolVersion>,
+    /// Supported transport modes.
+    pub supported_transports: Vec<TransportMode>,
     /// ZMQ address for transaction monitoring.
     pub zmq_addr: String,
     /// Fidelity bond amount in satoshis.
@@ -143,6 +145,7 @@ impl Default for MakerServerConfig {
             min_swap_amount: 10_000,
             required_confirms: 1,
             supported_protocols: vec![ProtocolVersion::Legacy, ProtocolVersion::Taproot],
+            supported_transports: vec![TransportMode::Plaintext],
             zmq_addr: "tcp://127.0.0.1:28332".to_string(),
             fidelity_amount: 10_000,   // 0.05 BTC
             fidelity_timelock: 15_000, // ~6 months (MAX_FIDELITY_TIMELOCK)
@@ -246,6 +249,7 @@ impl MakerServerConfig {
             zmq_addr: default_config.zmq_addr,
             password: default_config.password,
             supported_protocols: default_config.supported_protocols,
+            supported_transports: default_config.supported_transports,
             nostr_relays: default_config.nostr_relays,
         })
     }
@@ -791,6 +795,7 @@ impl MakerTrait for MakerServer {
                 .unwrap_or(u64::MAX),
             required_confirms: self.config.required_confirms,
             supported_protocols: self.config.supported_protocols.clone(),
+            supported_transports: self.config.supported_transports.clone(),
         }
     }
 

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -9,7 +9,7 @@ use crate::{
     protocol::{
         common_messages::{
             AckSwapDetails, FidelityProof, GetOffer, MakerHello, MakerToTakerMessage, Offer,
-            ProtocolVersion, SwapDetails, TakerHello, TakerToMakerMessage,
+            ProtocolVersion, SwapDetails, TakerHello, TakerToMakerMessage, TransportMode,
         },
         legacy_messages::LegacyTakerMessage,
         taproot_messages::TaprootTakerMessage,
@@ -309,6 +309,8 @@ pub struct MakerConfig {
     pub required_confirms: u32,
     /// Supported protocol versions.
     pub supported_protocols: Vec<ProtocolVersion>,
+    /// Supported transport modes.
+    pub supported_transports: Vec<TransportMode>,
 }
 
 /// Message handler
@@ -379,7 +381,7 @@ pub fn handle_message<M: Maker>(
 fn handle_taker_hello<M: Maker>(
     maker: &Arc<M>,
     state: &mut ConnectionState,
-    _hello: TakerHello,
+    hello: TakerHello,
 ) -> Result<Option<MakerToTakerMessage>, MakerError> {
     state.expect_phase(&[SwapPhase::AwaitingHello])?;
 
@@ -389,6 +391,14 @@ fn handle_taker_hello<M: Maker>(
     );
 
     let config = maker.get_config();
+    if !config.supported_transports.contains(&hello.requested_transport) {
+        return Err(MakerError::General(format!(
+            "Unsupported transport requested: {:?}. Supported: {:?}",
+            hello.requested_transport, config.supported_transports
+        )
+        .leak()));
+    }
+
     state.phase = SwapPhase::AwaitingOfferRequest;
 
     log::info!(
@@ -399,6 +409,7 @@ fn handle_taker_hello<M: Maker>(
 
     Ok(Some(MakerToTakerMessage::MakerHello(MakerHello {
         supported_protocols: config.supported_protocols,
+        supported_transports: config.supported_transports,
     })))
 }
 

--- a/src/protocol/common_messages.rs
+++ b/src/protocol/common_messages.rs
@@ -40,15 +40,36 @@ pub enum ProtocolVersion {
     Taproot,
 }
 
+/// Transport mode for maker/taker protocol messages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub enum TransportMode {
+    /// Current transport: plaintext length-prefixed CBOR over TCP/Tor.
+    #[default]
+    Plaintext,
+    /// Target transport: BIP324 v1 encrypted transport.
+    Bip324V1,
+}
+
+fn default_supported_transports() -> Vec<TransportMode> {
+    vec![TransportMode::Plaintext]
+}
+
 /// Initial handshake from Taker to Maker.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
-pub struct TakerHello;
+pub struct TakerHello {
+    /// Preferred transport mode requested by the taker.
+    #[serde(default)]
+    pub requested_transport: TransportMode,
+}
 
 /// Handshake response from Maker to Taker.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MakerHello {
     /// Protocol versions this maker supports.
     pub supported_protocols: Vec<ProtocolVersion>,
+    /// Transport modes this maker supports.
+    #[serde(default = "default_supported_transports")]
+    pub supported_transports: Vec<TransportMode>,
 }
 
 /// Request for offer from Taker to Maker.

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -34,7 +34,7 @@ use crate::{
     protocol::{
         common_messages::{
             GetOffer, MakerToTakerMessage, Offer, PrivateKeyHandover, ProtocolVersion, SwapDetails,
-            SwapPrivkey, TakerHello, TakerToMakerMessage,
+            SwapPrivkey, TakerHello, TakerToMakerMessage, TransportMode,
         },
         contract::calculate_pubkey_from_nonce,
     },
@@ -138,6 +138,8 @@ pub struct TakerInitConfig {
     pub password: Option<String>,
     /// Connection type (Tor or Clearnet).
     pub connection_type: ConnectionType,
+    /// Preferred transport mode for maker/taker traffic.
+    pub transport_mode: TransportMode,
     /// Nostr relay URLs for maker discovery.
     pub nostr_relays: Vec<String>,
 }
@@ -154,6 +156,7 @@ impl Default for TakerInitConfig {
             zmq_addr: "tcp://127.0.0.1:28332".to_string(),
             password: None,
             connection_type: ConnectionType::Tor,
+            transport_mode: TransportMode::Plaintext,
             nostr_relays: NOSTR_RELAYS.iter().map(|s| s.to_string()).collect(),
         }
     }
@@ -187,6 +190,12 @@ impl TakerInitConfig {
     /// Set the Nostr relay URLs.
     pub fn with_nostr_relays(mut self, relays: Vec<String>) -> Self {
         self.nostr_relays = relays;
+        self
+    }
+
+    /// Set preferred transport mode.
+    pub fn with_transport_mode(mut self, mode: TransportMode) -> Self {
+        self.transport_mode = mode;
         self
     }
 }
@@ -508,6 +517,7 @@ impl Taker {
             &offerbook,
             &watch_service,
             config.socks_port,
+            config.transport_mode,
             rpc_config,
             initial_discovery_complete,
         )?;
@@ -675,6 +685,7 @@ impl Taker {
         offerbook: &OfferBookHandle,
         watch_service: &WatchService,
         socks_port: u16,
+        transport_mode: TransportMode,
         rpc_config: RPCConfig,
         initial_discovery_complete: Arc<AtomicBool>,
     ) -> Result<OfferSyncHandle, TakerError> {
@@ -683,6 +694,7 @@ impl Taker {
             offerbook.clone(),
             watch_service.clone(),
             socks_port,
+            transport_mode,
             rest_backend,
             initial_discovery_complete,
         )
@@ -1613,18 +1625,55 @@ impl Taker {
     }
 
     /// Perform handshake with a maker and verify protocol support.
+    fn validate_requested_transport(
+        requested_transport: TransportMode,
+        supported_transports: &[TransportMode],
+    ) -> Result<(), TakerError> {
+        if !supported_transports.contains(&requested_transport) {
+            return Err(TakerError::General(format!(
+                "Maker does not support {:?} transport. Supported: {:?}",
+                requested_transport, supported_transports
+            )));
+        }
+
+        if requested_transport != TransportMode::Plaintext {
+            return Err(TakerError::General(
+                "Encrypted transport negotiation is not enabled yet".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Perform handshake with a maker and verify protocol support.
     pub(crate) fn net_handshake(
         &self,
         stream: &mut TcpStream,
     ) -> Result<ProtocolVersion, TakerError> {
+        let requested_transport = if cfg!(feature = "integration-test") {
+            TransportMode::Plaintext
+        } else {
+            self.config.transport_mode
+        };
+
         // Send TakerHello
-        send_message(stream, &TakerToMakerMessage::TakerHello(TakerHello))?;
+        send_message(
+            stream,
+            &TakerToMakerMessage::TakerHello(TakerHello {
+                requested_transport,
+            }),
+        )?;
 
         let msg_bytes = read_message(stream)?;
         let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
 
         match msg {
             MakerToTakerMessage::MakerHello(maker_hello) => {
+                Self::validate_requested_transport(
+                    requested_transport,
+                    &maker_hello.supported_transports,
+                )?;
+
                 let desired = self.swap_state()?.params.protocol;
                 if maker_hello.supported_protocols.contains(&desired) {
                     Ok(desired)
@@ -2477,4 +2526,19 @@ pub enum TakerBehavior {
     CloseAtSendersContract,
     /// Close connection when receiving maker's contract data response (taproot taker abort).
     CloseAtSendersContractFromMaker,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Taker, TakerError, TransportMode};
+
+    #[test]
+    fn rejects_non_plaintext_transport_even_if_advertised() {
+        let result = Taker::validate_requested_transport(
+            TransportMode::Bip324V1,
+            &[TransportMode::Bip324V1],
+        );
+
+        assert!(matches!(result, Err(TakerError::General(_))));
+    }
 }

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -346,6 +346,7 @@ pub struct OfferSyncService {
     offerbook: OfferBookHandle,
     watch_service: WatchService,
     socks_port: u16,
+    transport_mode: crate::protocol::common_messages::TransportMode,
     rest_backend: BitcoinRest,
     /// Set to `true` by Nostr discovery after the first EOSE is received.
     initial_discovery_complete: Arc<AtomicBool>,
@@ -383,6 +384,7 @@ impl OfferSyncService {
         offerbook: OfferBookHandle,
         watch_service: WatchService,
         socks_port: u16,
+        transport_mode: crate::protocol::common_messages::TransportMode,
         rest_backend: BitcoinRest,
         initial_discovery_complete: Arc<AtomicBool>,
     ) -> Self {
@@ -390,6 +392,7 @@ impl OfferSyncService {
             offerbook,
             watch_service,
             socks_port,
+            transport_mode,
             rest_backend,
             initial_discovery_complete,
         }
@@ -421,7 +424,11 @@ impl OfferSyncService {
             return Ok(());
         }
 
-        let offers = fetch_offer_from_makers(to_poll.clone(), self.socks_port)?;
+        let offers = fetch_offer_from_makers(
+            to_poll.clone(),
+            self.socks_port,
+            self.transport_mode,
+        )?;
 
         let mut responded = HashSet::with_capacity(offers.len());
 
@@ -693,6 +700,7 @@ impl OfferBook {
 pub(crate) fn fetch_offer_from_makers(
     maker_addresses: Vec<MakerAddress>,
     socks_port: u16,
+    transport_mode: crate::protocol::common_messages::TransportMode,
 ) -> Result<Vec<OfferAndAddress>, TakerError> {
     // Limit workers to CPU cores to avoid thread overhead
     let workers = std::thread::available_parallelism()
@@ -720,7 +728,9 @@ pub(crate) fn fetch_offer_from_makers(
                     };
 
                     let Some(addr) = addr_opt else { break };
-                    if let Some(offer) = addr.download_offer_with_retries(socks_port) {
+                    if let Some(offer) =
+                        addr.download_offer_with_retries(socks_port, transport_mode)
+                    {
                         let _ = tx.send(offer);
                     }
                 }
@@ -794,9 +804,13 @@ impl TryFrom<String> for MakerAddress {
 }
 
 impl MakerAddress {
-    fn download_offer_with_retries(self, socks_port: u16) -> Option<OfferAndAddress> {
+    fn download_offer_with_retries(
+        self,
+        socks_port: u16,
+        transport_mode: crate::protocol::common_messages::TransportMode,
+    ) -> Option<OfferAndAddress> {
         for attempt in 1..=FIRST_CONNECT_ATTEMPTS {
-            match self.clone().download_offer_auto(socks_port) {
+            match self.clone().download_offer_auto(socks_port, transport_mode) {
                 Ok(offer) => return Some(offer),
                 Err(e) if attempt < FIRST_CONNECT_ATTEMPTS => {
                     log::debug!(
@@ -816,8 +830,12 @@ impl MakerAddress {
         None
     }
 
-    fn download_offer_auto(self, socks_port: u16) -> Result<OfferAndAddress, TakerError> {
-        let (offer, protocol) = self.fetch_offer(socks_port)?;
+    fn download_offer_auto(
+        self,
+        socks_port: u16,
+        transport_mode: crate::protocol::common_messages::TransportMode,
+    ) -> Result<OfferAndAddress, TakerError> {
+        let (offer, protocol) = self.fetch_offer(socks_port, transport_mode)?;
         Ok(OfferAndAddress {
             offer,
             address: self,
@@ -827,7 +845,11 @@ impl MakerAddress {
     }
 
     /// Download a single offer from a maker.
-    fn fetch_offer(&self, socks_port: u16) -> Result<(Offer, MakerProtocol), TakerError> {
+    fn fetch_offer(
+        &self,
+        socks_port: u16,
+        transport_mode: crate::protocol::common_messages::TransportMode,
+    ) -> Result<(Offer, MakerProtocol), TakerError> {
         use crate::protocol::common_messages::COINSWAP_PORT;
 
         log::debug!("Downloading offer from maker: {}", self);
@@ -846,7 +868,9 @@ impl MakerAddress {
         socket.set_write_timeout(Some(Duration::from_secs(FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC)))?;
 
         // Send TakerHello
-        let taker_hello = RouterTakerToMakerMessage::TakerHello(RouterTakerHello);
+        let taker_hello = RouterTakerToMakerMessage::TakerHello(RouterTakerHello {
+            requested_transport: transport_mode,
+        });
         send_message(&mut socket, &taker_hello)?;
 
         // Read MakerHello

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -965,7 +965,9 @@ mod tests {
         PubkeyHash,
     };
 
-    use crate::protocol::common_messages::{MakerHello, MakerToTakerMessage, ProtocolVersion};
+    use crate::protocol::common_messages::{
+        MakerHello, MakerToTakerMessage, ProtocolVersion, TakerHello, TransportMode,
+    };
 
     use super::*;
 
@@ -976,6 +978,7 @@ mod tests {
 
         let message = MakerToTakerMessage::MakerHello(MakerHello {
             supported_protocols: vec![ProtocolVersion::Legacy, ProtocolVersion::Taproot],
+            supported_transports: vec![TransportMode::Plaintext],
         });
 
         thread::spawn(move || {
@@ -989,6 +992,10 @@ mod tests {
                 assert!(hello
                     .supported_protocols
                     .contains(&ProtocolVersion::Taproot));
+                assert_eq!(hello.supported_transports.len(), 1);
+                assert!(hello
+                    .supported_transports
+                    .contains(&TransportMode::Plaintext));
             } else {
                 panic!(
                     "Received Wrong Message: Expected MakerHello variant, Got: {:?}",
@@ -999,6 +1006,22 @@ mod tests {
 
         let mut stream = TcpStream::connect(address).unwrap();
         send_message(&mut stream, &message).unwrap();
+    }
+
+    #[test]
+    fn test_deserialize_missing_transport_fields() {
+        let taker = TakerHello::default();
+        let taker_bytes = serde_cbor::to_vec(&taker).unwrap();
+        let decoded_taker: TakerHello = serde_cbor::from_slice(&taker_bytes).unwrap();
+        assert_eq!(decoded_taker.requested_transport, TransportMode::Plaintext);
+
+        let maker = MakerHello {
+            supported_protocols: vec![ProtocolVersion::Legacy],
+            supported_transports: vec![TransportMode::Plaintext],
+        };
+        let maker_bytes = serde_cbor::to_vec(&maker).unwrap();
+        let decoded_maker: MakerHello = serde_cbor::from_slice(&maker_bytes).unwrap();
+        assert_eq!(decoded_maker.supported_transports, vec![TransportMode::Plaintext]);
     }
 
     #[test]


### PR DESCRIPTION
This PR adds a small handshake-layer scaffold for the SoB 2026 BIP324 proposal.

What changed:
- Added a transport mode field to maker/taker hello messages.
- Added a transport preference to taker configuration.
- Made the maker advertise supported transports.
- Added an early rejection when the requested transport is unsupported.

Why this is small on purpose:
- It gives us a clean negotiation seam before touching the wire format.
- It keeps the review surface narrow.
- It compiles cleanly and does not change the default behavior yet.

Next step in the proposal track:
- Swap the current TcpStream framing for a transport wrapper that can host BIP324.
- Add peer-identity binding and production no-plaintext rules in a follow-up patch.
#801
