### PR TITLE
docs(utill): correct send_message wire format comment

### DIFF
--- a/src/utill.rs
+++ b/src/utill.rs
@@ -183,8 +183,10 @@ pub fn setup_logger(filter: LevelFilter, data_dir: Option<PathBuf>) {
     });
 }
 
-/// Send a length-appended Protocol or RPC Message through a stream.
-/// The first byte sent is the length of the actual message.
+/// Sends a protocol or RPC message through a stream.
+///
+/// The wire format is a 4-byte big-endian u32 length prefix followed
+/// by the CBOR-serialized message payload.
 pub fn send_message(
     socket_writer: &mut TcpStream,
     message: &impl serde::Serialize,


### PR DESCRIPTION
## Summary

The doc comment on `send_message` in `src/utill.rs` incorrectly stated:

> The first byte sent is the length of the actual message.

The implementation uses `(msg_bytes.len() as u32).to_be_bytes()`, so the
frame is actually a 4-byte big-endian `u32` length prefix followed by the
CBOR-serialized payload. The old wording suggests a single-byte length and
implies a 255-byte payload cap that does not exist, which is misleading for
anyone reasoning about the protocol or implementing an alternative client.

This PR rewrites the doc comment to describe the real wire format, matching
what `read_message` decodes directly below.

## Changes

- `src/utill.rs`: reword the doc comment on `send_message` to state:
  - 4-byte big-endian `u32` length prefix
  - followed by the CBOR-serialized message payload

## Non-changes

- No behaviour change
- No signature change
- No new dependencies
- No other files touched

## Verification

All gates from `CONTRIBUTING.md` pass locally:

- `cargo +nightly fmt --all --check` - clean
- `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` - clean
- `cargo +stable clippy --examples -- -D warnings` - clean
- `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` - clean
- `cargo test` - 73 passed, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation to clarify technical specifications. No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->