### PR TITLE
Skip old events

### DIFF
--- a/src/nostr_coinswap.rs
+++ b/src/nostr_coinswap.rs
@@ -37,7 +37,7 @@ pub fn coinswap_kind(network: Network) -> u16 {
     }
 }
 /// Expiration time for noster event (24 hours)
-const EXPIRATION_SECS: u64 = 86400;
+pub(crate) const EXPIRATION_SECS: u64 = 86400;
 
 /// Broadcasts a fidelity bond announcement over Nostr.
 pub fn broadcast_bond_on_nostr(

--- a/src/watch_tower/nostr_discovery.rs
+++ b/src/watch_tower/nostr_discovery.rs
@@ -23,7 +23,7 @@ use nostr::{
 use tungstenite::{stream::MaybeTlsStream, Message};
 
 use crate::{
-    nostr_coinswap::coinswap_kind,
+    nostr_coinswap::{coinswap_kind, EXPIRATION_SECS},
     watch_tower::{
         registry_storage::FileRegistry,
         rest_backend::BitcoinRest,
@@ -227,6 +227,18 @@ fn handle_relay_message(
                 log::debug!(
                     "Ignoring expired event or event without expiration tag from {}",
                     relay_url
+                );
+                return Ok(());
+            }
+
+            if Timestamp::now()
+                .as_secs()
+                .saturating_sub(event.created_at.as_secs())
+                > EXPIRATION_SECS
+            {
+                log::debug!(
+                    "Skipping stale event from {relay_url} older than {} hours",
+                    EXPIRATION_SECS / 3600
                 );
                 return Ok(());
             }


### PR DESCRIPTION
# Pull Request
Skip events older than 24hr
## Description
if stament that skips (current time - event create time) > 24hr
## Related Issue(s)
Closes #846 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [x] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [x] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Nostr event handling to filter out stale/expired events based on the configured expiration window, reducing processing of outdated data.
  * Added debug logging when events are skipped due to age, aiding diagnosis of filtered events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->