### PR TITLE
unify reports into a single json file

### DIFF
--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -18,7 +18,7 @@ use crate::{
         legacy_messages::{FundingTxInfo, LegacyTakerMessage},
     },
     utill::redeemscript_to_scriptpubkey,
-    wallet::{swapcoin::IncomingSwapCoin, SwapReport},
+    wallet::{swapcoin::IncomingSwapCoin, MakerReport},
 };
 
 /// Handle a Legacy protocol message.
@@ -760,7 +760,7 @@ fn emit_maker_success_report<M: Maker>(maker: &Arc<M>, state: &ConnectionState, 
         .unwrap_or(0);
     let network = maker.network().to_string();
 
-    let report = SwapReport::maker_success(
+    let report = MakerReport::success(
         swap_id.to_string(),
         state.swap_start_time,
         incoming_total,
@@ -771,7 +771,7 @@ fn emit_maker_success_report<M: Maker>(maker: &Arc<M>, state: &ConnectionState, 
         network,
     );
     report.print();
-    if let Err(e) = report.save_to_disk(maker.data_dir()) {
+    if let Err(e) = report.save(maker.data_dir()) {
         log::warn!("Failed to save maker success report: {:?}", e);
     }
 }

--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -767,7 +767,7 @@ fn emit_maker_success_report<M: Maker>(maker: &Arc<M>, state: &ConnectionState, 
         outgoing_total,
         incoming_txid,
         outgoing_txid,
-        timelock as u16,
+        timelock,
         network,
     );
     report.print();

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -15,7 +15,7 @@ use crate::{
     maker::rpc::server::MakerRpc,
     nostr_coinswap::broadcast_bond_on_nostr,
     protocol::common_messages::{FidelityProof, MakerToTakerMessage, TakerToMakerMessage},
-    wallet::SwapReport,
+    wallet::RecoveryReport,
 };
 
 use super::{
@@ -826,26 +826,18 @@ fn recover_from_swap(
                     .read()
                     .map(|w| w.store.network.to_string())
                     .unwrap_or_default();
-                for (contract_txid, spending_txid) in &swept.resolved {
-                    let amount = incoming_swapcoins
-                        .iter()
-                        .find(|s| s.contract_tx.compute_txid() == *contract_txid)
-                        .map(|s| s.funding_amount.to_sat())
-                        .unwrap_or(0);
-                    let report = SwapReport::maker_recovery(
-                        format!("recovery_hashlock_{}", contract_txid),
-                        "hashlock",
-                        amount,
-                        0,
-                        contract_txid.to_string(),
-                        "N/A".to_string(),
-                        spending_txid.to_string(),
-                        0,
-                        network.clone(),
-                    );
-                    report.print();
-                    let _ = report.save_to_disk(&maker.data_dir);
-                }
+                let recovery_txids: Vec<String> = swept
+                    .resolved
+                    .iter()
+                    .map(|(_, spending_txid)| spending_txid.to_string())
+                    .collect();
+                RecoveryReport::emit_maker(
+                    &maker.data_dir,
+                    swap_id.clone(),
+                    network.clone(),
+                    "hashlock".to_string(),
+                    recovery_txids,
+                );
 
                 #[cfg(feature = "integration-test")]
                 maker.shutdown.store(true, Relaxed);
@@ -915,26 +907,18 @@ fn recover_from_swap(
                     .read()
                     .map(|w| w.store.network.to_string())
                     .unwrap_or_default();
-                for (contract_txid, spending_txid) in &recovered.resolved {
-                    let out = outgoing_swapcoins
-                        .iter()
-                        .find(|s| s.contract_tx.compute_txid() == *contract_txid);
-                    let amount = out.map(|s| s.funding_amount.to_sat()).unwrap_or(0);
-                    let timelock = out.and_then(|s| s.get_timelock()).unwrap_or(0);
-                    let report = SwapReport::maker_recovery(
-                        format!("recovery_timelock_{}", contract_txid),
-                        "timelock",
-                        0,
-                        amount,
-                        "N/A".to_string(),
-                        contract_txid.to_string(),
-                        spending_txid.to_string(),
-                        timelock as u16,
-                        network.clone(),
-                    );
-                    report.print();
-                    let _ = report.save_to_disk(&maker.data_dir);
-                }
+                let recovery_txids: Vec<String> = recovered
+                    .resolved
+                    .iter()
+                    .map(|(_, spending_txid)| spending_txid.to_string())
+                    .collect();
+                RecoveryReport::emit_maker(
+                    &maker.data_dir,
+                    swap_id.clone(),
+                    network.clone(),
+                    "timelock".to_string(),
+                    recovery_txids,
+                );
 
                 #[cfg(feature = "integration-test")]
                 maker.shutdown.store(true, Relaxed);

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -468,7 +468,7 @@ fn emit_maker_success_report<M: Maker>(maker: &Arc<M>, state: &ConnectionState, 
         outgoing_total,
         incoming_txid,
         outgoing_txid,
-        timelock as u16,
+        timelock,
         network,
     );
     report.print();

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin},
-        SwapReport,
+        MakerReport,
     },
 };
 
@@ -461,7 +461,7 @@ fn emit_maker_success_report<M: Maker>(maker: &Arc<M>, state: &ConnectionState, 
         .unwrap_or(0);
     let network = maker.network().to_string();
 
-    let report = SwapReport::maker_success(
+    let report = MakerReport::success(
         swap_id.to_string(),
         state.swap_start_time,
         incoming_total,
@@ -472,7 +472,7 @@ fn emit_maker_success_report<M: Maker>(maker: &Arc<M>, state: &ConnectionState, 
         network,
     );
     report.print();
-    if let Err(e) = report.save_to_disk(maker.data_dir()) {
+    if let Err(e) = report.save(maker.data_dir()) {
         log::warn!("Failed to save maker success report: {:?}", e);
     }
 }

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -41,7 +41,7 @@ use crate::{
     utill::{check_tor_status, generate_maker_keys, get_taker_dir, read_message, send_message},
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin, WatchOnlySwapCoin},
-        MakerFeeInfo as ReportMakerFeeInfo, RPCConfig, RecoveryOutcome, SwapReport, SwapStatus,
+        MakerFeeInfo as ReportMakerFeeInfo, RPCConfig, RecoveryOutcome, SwapStatus, TakerReport,
         Wallet,
     },
     watch_tower::{
@@ -833,7 +833,7 @@ impl Taker {
     ///
     /// Commits funds on-chain: creates funding transactions, exchanges
     /// contracts with makers, finalizes, and sweeps.
-    pub fn start_coinswap(&mut self, swap_id: &str) -> Result<SwapReport, TakerError> {
+    pub fn start_coinswap(&mut self, swap_id: &str) -> Result<TakerReport, TakerError> {
         let swap_start_time = Instant::now();
 
         // Verify the swap_id matches the prepared swap.
@@ -2070,7 +2070,7 @@ impl Taker {
         start_time: Instant,
         status: SwapStatus,
         error_message: Option<String>,
-    ) -> Result<SwapReport, TakerError> {
+    ) -> Result<TakerReport, TakerError> {
         let swap = self.swap_state()?;
         let swap_duration = start_time.elapsed();
 
@@ -2263,14 +2263,18 @@ impl Taker {
             None
         };
 
-        let report = SwapReport::taker_report(SwapReport {
+        let swap_end_ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let report = TakerReport {
             status,
             swap_id: swap.id.clone(),
             swap_duration_seconds: swap_duration.as_secs_f64(),
             outgoing_amount: swap.params.send_amount.to_sat(),
             incoming_amount: total_output_swap_amount,
-            fee_paid_or_earned: -(total_fee as i64),
-            makers_count: Some(maker_count),
+            fee_paid: total_fee,
+            makers_count: maker_count,
             maker_addresses,
             funding_txids,
             total_maker_fees,
@@ -2286,12 +2290,13 @@ impl Taker {
             error_message,
             incoming_contract_txid,
             outgoing_contract_txid,
-            ..Default::default()
-        });
+            end_timestamp: swap_end_ts,
+            start_timestamp: swap_end_ts.saturating_sub(swap_duration.as_secs()),
+        };
 
         report.print();
         let data_dir = self.config.data_dir.clone().unwrap_or_else(get_taker_dir);
-        if let Err(e) = report.save_to_disk(&data_dir) {
+        if let Err(e) = report.save(&data_dir) {
             log::warn!("Failed to save taker swap report: {:?}", e);
         }
 

--- a/src/taker/background_services.rs
+++ b/src/taker/background_services.rs
@@ -19,7 +19,7 @@ use bitcoind::bitcoincore_rpc::RpcApi;
 
 use crate::{
     utill::HEART_BEAT_INTERVAL,
-    wallet::{SwapReport, SwapStatus, Wallet},
+    wallet::{RecoveryReport, SwapStatus, Wallet},
     watch_tower::{service::WatchService, watcher::WatcherEvent},
 };
 
@@ -189,14 +189,17 @@ impl RecoveryLoop {
                                     .read()
                                     .map(|w| w.store.network.to_string())
                                     .unwrap_or_default();
-                                SwapReport::emit_taker_recovery_report(
+                                let recovery_type = match status {
+                                    SwapStatus::RecoveryHashlock => "hashlock",
+                                    _ => "timelock",
+                                }
+                                .to_string();
+                                RecoveryReport::emit_taker(
                                     &data_dir,
                                     record.swap_id.clone(),
                                     network,
-                                    record.send_amount_sat,
-                                    status,
-                                    &recovery_txids,
-                                    0.0,
+                                    recovery_type,
+                                    recovery_txids,
                                 );
                             }
 

--- a/src/taker/background_services.rs
+++ b/src/taker/background_services.rs
@@ -19,7 +19,7 @@ use bitcoind::bitcoincore_rpc::RpcApi;
 
 use crate::{
     utill::HEART_BEAT_INTERVAL,
-    wallet::{RecoveryReport, SwapStatus, Wallet},
+    wallet::{RecoveryReport, Wallet},
     watch_tower::{service::WatchService, watcher::WatcherEvent},
 };
 
@@ -168,39 +168,48 @@ impl RecoveryLoop {
                         if let Ok(mut tracker) = swap_tracker.lock() {
                             // Emit recovery reports before marking as cleaned up
                             for record in tracker.incomplete_swaps() {
-                                let recovery_txids: Vec<String> = record
-                                    .recovery
-                                    .incoming
-                                    .iter()
-                                    .chain(record.recovery.outgoing.iter())
-                                    .filter_map(|o| o.spending_txid.map(|t| t.to_string()))
-                                    .collect();
-                                let has_hashlock = record
-                                    .recovery
-                                    .incoming
-                                    .iter()
-                                    .any(|o| o.resolution == ContractResolution::Hashlock);
-                                let status = if has_hashlock {
-                                    SwapStatus::RecoveryHashlock
-                                } else {
-                                    SwapStatus::RecoveryTimelock
-                                };
                                 let network = wallet
                                     .read()
                                     .map(|w| w.store.network.to_string())
                                     .unwrap_or_default();
-                                let recovery_type = match status {
-                                    SwapStatus::RecoveryHashlock => "hashlock",
-                                    _ => "timelock",
+                                let all_outcomes = record
+                                    .recovery
+                                    .incoming
+                                    .iter()
+                                    .chain(record.recovery.outgoing.iter());
+                                let mut hashlock_txids: Vec<String> = Vec::new();
+                                let mut timelock_txids: Vec<String> = Vec::new();
+                                for o in all_outcomes {
+                                    if let Some(txid) = o.spending_txid {
+                                        match o.resolution {
+                                            ContractResolution::Hashlock => {
+                                                hashlock_txids.push(txid.to_string())
+                                            }
+                                            ContractResolution::Timelock => {
+                                                timelock_txids.push(txid.to_string())
+                                            }
+                                            _ => {}
+                                        }
+                                    }
                                 }
-                                .to_string();
-                                RecoveryReport::emit_taker(
-                                    &data_dir,
-                                    record.swap_id.clone(),
-                                    network,
-                                    recovery_type,
-                                    recovery_txids,
-                                );
+                                if !hashlock_txids.is_empty() {
+                                    RecoveryReport::emit_taker(
+                                        &data_dir,
+                                        record.swap_id.clone(),
+                                        network.clone(),
+                                        "hashlock".to_string(),
+                                        hashlock_txids,
+                                    );
+                                }
+                                if !timelock_txids.is_empty() {
+                                    RecoveryReport::emit_taker(
+                                        &data_dir,
+                                        record.swap_id.clone(),
+                                        network,
+                                        "timelock".to_string(),
+                                        timelock_txids,
+                                    );
+                                }
                             }
 
                             for swap_id in &swap_ids {

--- a/src/wallet/ffi.rs
+++ b/src/wallet/ffi.rs
@@ -12,7 +12,9 @@ use bitcoin::{Amount, OutPoint, Txid};
 use bitcoind::bitcoincore_rpc::{json::ListTransactionResult, RpcApi};
 use std::path::{Path, PathBuf};
 
-pub use super::report::{MakerFeeInfo, SwapReport, SwapRole, SwapStatus};
+pub use super::report::{
+    MakerFeeInfo, MakerReport, RecoveryReport, SwapRole, SwapStatus, TakerReport,
+};
 
 /// Restores a wallet from an encrypted or unencrypted JSON backup file for GUI/FFI applications.
 ///

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -20,7 +20,7 @@ pub use fidelity::FidelityBond;
 pub(crate) use fidelity::{
     verify_fidelity_checks, FidelityError, MAX_FIDELITY_TIMELOCK, MIN_FIDELITY_TIMELOCK,
 };
-pub use report::{MakerFeeInfo, SwapReport, SwapRole, SwapStatus};
+pub use report::{MakerFeeInfo, MakerReport, RecoveryReport, SwapRole, SwapStatus, TakerReport};
 pub use rpc::RPCConfig;
 pub use spend::Destination;
 pub use storage::AddressType;

--- a/src/wallet/report.rs
+++ b/src/wallet/report.rs
@@ -1,43 +1,37 @@
 #![allow(clippy::too_many_arguments)]
-//! Swap report for both Taker and Maker.
+//! Unified swap report file for all coinswap participants.
 //!
-//! This module provides a single [`SwapReport`] structure that captures all relevant
-//! information about a coinswap transaction, regardless of whether the participant
-//! is a taker or maker. It supports success, failure, and recovery scenarios.
+//! All reports are appended to a single `swap_reports.json` file located one
+//! level above each node's data directory (the coinswap root, e.g. `~/.coinswap/`).
+//!
+//! The file has three sections:
+//! - `taker`   – one entry per taker swap (success or failed)
+//! - `maker`   – one array per maker node, keyed by node name
+//! - `recovery`– one entry per recovery event (hashlock or timelock)
+//! - `deniability_proofs` – reserved for future use
 
 use serde::{Deserialize, Serialize};
 use std::{
-    path::Path,
-    str::FromStr,
-    time::{Duration, Instant},
+    collections::HashMap,
+    fs::OpenOptions,
+    path::{Path, PathBuf},
+    time::Instant,
 };
 
-fn format_unix_timestamp_utc(timestamp: Duration) -> String {
-    let secs = timestamp.as_secs();
-    let millis = timestamp.subsec_millis();
-    let days = (secs / 86_400) as i64;
-    let sod = secs % 86_400;
+// ---------------------------------------------------------------------------
+// Timestamp helper
+// ---------------------------------------------------------------------------
 
-    let z = days + 719_468;
-    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
-    let doe = z - era * 146_097;
-    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = mp + if mp < 10 { 3 } else { -9 };
-    let year = y + if m <= 2 { 1 } else { 0 };
-
-    let hour = sod / 3_600;
-    let minute = (sod % 3_600) / 60;
-    let second = sod % 60;
-
-    format!(
-        "{:04}-{:02}-{:02}T{:02}-{:02}-{:02}.{:03}Z",
-        year, m, d, hour, minute, second, millis
-    )
+fn now_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
+
+// ---------------------------------------------------------------------------
+// Shared enums
+// ---------------------------------------------------------------------------
 
 /// Role of the participant in the swap.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -57,7 +51,7 @@ impl std::fmt::Display for SwapRole {
     }
 }
 
-/// Status of the swap indicating how it completed.
+/// Final outcome of a swap.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum SwapStatus {
     /// Swap completed successfully via cooperative key exchange.
@@ -70,7 +64,7 @@ pub enum SwapStatus {
     Failed,
 }
 
-impl FromStr for SwapStatus {
+impl std::str::FromStr for SwapStatus {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
@@ -94,319 +88,99 @@ impl std::fmt::Display for SwapStatus {
     }
 }
 
-/// Fee information for an individual maker in a swap route.
-///
-/// Used by taker reports to provide a detailed breakdown of fees
-/// charged by each maker in the multi-hop swap.
+/// Per-maker fee breakdown stored in taker reports.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MakerFeeInfo {
-    /// Zero-based index of the Maker in the swap route.
+    /// Zero-based index of the maker in the swap route.
     pub maker_index: usize,
-    /// Network address of the Maker (e.g., onion address with port).
+    /// Network address of the maker.
     pub maker_address: String,
-    /// Fixed base fee charged by this maker (in satoshis).
+    /// Fixed base fee charged by this maker (satoshis).
     pub base_fee: f64,
-    /// Fee proportional to the swap amount (in satoshis).
+    /// Fee proportional to the swap amount (satoshis).
     pub amount_relative_fee: f64,
-    /// Fee proportional to the timelock duration (in satoshis).
+    /// Fee proportional to the timelock duration (satoshis).
     pub time_relative_fee: f64,
-    /// Total fee charged by this maker (sum of all fee components).
+    /// Sum of all fee components for this maker (satoshis).
     pub total_fee: f64,
 }
 
-/// Swap report capturing all details of a coinswap transaction.
+// ---------------------------------------------------------------------------
+// Report structs
+// ---------------------------------------------------------------------------
+
+/// Taker-perspective record for one swap (success or failed).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SwapReport {
-    /// Unique identifier for this swap (typically derived from preimage hash).
+pub struct TakerReport {
+    /// Unique swap identifier derived from the preimage hash.
     pub swap_id: String,
-    /// Role of the participant who generated this report.
-    pub role: SwapRole,
-    /// Final status of the swap.
+    /// Final outcome of the swap.
     pub status: SwapStatus,
+    /// Bitcoin network (mainnet, testnet, signet, regtest).
+    pub network: String,
     /// Total duration of the swap in seconds.
     pub swap_duration_seconds: f64,
-    /// Duration of the recovery phase in seconds (0 if no recovery).
-    pub recovery_duration_seconds: f64,
     /// Unix timestamp when the swap started.
     pub start_timestamp: u64,
     /// Unix timestamp when the swap completed.
     pub end_timestamp: u64,
-    /// Bitcoin network used (mainnet, testnet, signet, regtest).
-    pub network: String,
-    /// Error message if the swap failed or triggered recovery.
+    /// Error description if the swap failed.
     pub error_message: Option<String>,
 
-    /// Amount received in the incoming contract (satoshis).
-    /// For makers: amount received from the previous hop.
-    /// For takers: total output amount after swap.
-    pub incoming_amount: u64,
-    /// Amount sent in the outgoing contract (satoshis).
-    /// For makers: amount sent to the next hop.
-    /// For takers: target swap amount.
+    /// Amount the taker sent (satoshis).
     pub outgoing_amount: u64,
-    /// Net fee result (satoshis).
-    /// Positive for makers (fee earned).
-    /// Negative for takers (fee paid).
-    pub fee_paid_or_earned: i64,
-
-    /// Transaction IDs of the incoming contracts.
-    pub incoming_contract_txid: Option<String>,
-    /// Transaction IDs of the outgoing contracts.
-    pub outgoing_contract_txid: Option<String>,
-    /// Funding transaction IDs organized by hop (taker only).
-    /// Each inner vector contains txids for one hop in the swap route.
-    pub funding_txids: Vec<Vec<String>>,
-    /// Transaction IDs of recovery transactions (hashlock/timelock).
-    pub recovery_txids: Option<Vec<String>>,
-
-    /// Timelock value in blocks for the contract.
-    pub timelock: u16,
-    /// Number of makers involved in the swap (taker only).
-    pub makers_count: Option<usize>,
-    /// List of maker addresses used in the swap route (taker only).
-    pub maker_addresses: Vec<String>,
-
-    /// Detailed fee information for each maker (taker only).
-    pub maker_fee_info: Vec<MakerFeeInfo>,
-    /// Total fees paid to all makers (satoshis, taker only).
-    pub total_maker_fees: u64,
-    /// Mining fees paid for all transactions (satoshis, taker only).
+    /// Amount the taker received back after the swap (satoshis).
+    pub incoming_amount: u64,
+    /// Total fee paid (outgoing − incoming, satoshis).
+    pub fee_paid: u64,
+    /// Mining fees paid for all transactions (satoshis).
     pub mining_fee: u64,
-    /// Total fee as a percentage of the target amount (taker only).
+    /// Total fee as a percentage of the target amount.
     pub fee_percentage: f64,
+    /// Total fees paid to all makers (satoshis).
+    pub total_maker_fees: u64,
+
+    /// Transaction ID of the taker's outgoing contract.
+    pub outgoing_contract_txid: Option<String>,
+    /// Transaction ID of the taker's incoming contract.
+    pub incoming_contract_txid: Option<String>,
+    /// Funding transaction IDs organised by hop.
+    pub funding_txids: Vec<Vec<String>>,
+
+    /// Number of makers in the swap route.
+    pub makers_count: usize,
+    /// Addresses of all makers in route order.
+    pub maker_addresses: Vec<String>,
+    /// Detailed fee breakdown per maker.
+    pub maker_fee_info: Vec<MakerFeeInfo>,
 
     /// Input UTXO amounts consumed by the swap (satoshis).
     pub input_utxos: Vec<u64>,
-    /// Change output amounts returned to regular wallet (satoshis, taker only).
+    /// Change output amounts returned to the regular wallet (satoshis).
     pub output_change_amounts: Vec<u64>,
-    /// Swap output amounts received from the swap (satoshis, taker only).
+    /// Swap output amounts received from the swap (satoshis).
     pub output_swap_amounts: Vec<u64>,
-    /// Change UTXOs with amounts and addresses (amount in sats, address).
+    /// Change UTXOs with amounts and addresses.
     pub output_change_utxos: Vec<(u64, String)>,
-    /// Swap UTXOs with amounts and addresses (amount in sats, address).
+    /// Swap UTXOs with amounts and addresses.
     pub output_swap_utxos: Vec<(u64, String)>,
 }
 
-impl Default for SwapReport {
-    fn default() -> Self {
-        Self {
-            swap_id: String::new(),
-            role: SwapRole::Taker,
-            status: SwapStatus::Failed,
-            swap_duration_seconds: 0.0,
-            recovery_duration_seconds: 0.0,
-            start_timestamp: 0,
-            end_timestamp: 0,
-            network: String::new(),
-            error_message: None,
-            incoming_amount: 0,
-            outgoing_amount: 0,
-            fee_paid_or_earned: 0,
-            incoming_contract_txid: None,
-            outgoing_contract_txid: None,
-            funding_txids: vec![],
-            recovery_txids: None,
-            timelock: 0,
-            makers_count: None,
-            maker_addresses: vec![],
-            maker_fee_info: vec![],
-            total_maker_fees: 0,
-            mining_fee: 0,
-            fee_percentage: 0.0,
-            input_utxos: vec![],
-            output_change_amounts: vec![],
-            output_swap_amounts: vec![],
-            output_change_utxos: vec![],
-            output_swap_utxos: vec![],
-        }
-    }
-}
-
-impl SwapReport {
-    fn maker_report(mut report: Self, swap_duration_seconds: f64) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default();
-        let end_timestamp = now.as_secs();
-
-        report.role = SwapRole::Maker;
-        report.swap_duration_seconds = swap_duration_seconds;
-        report.start_timestamp = end_timestamp.saturating_sub(swap_duration_seconds as u64);
-        report.end_timestamp = end_timestamp;
-        report
+impl TakerReport {
+    /// Save to the shared report file.
+    pub fn save(&self, data_dir: &Path) -> std::io::Result<()> {
+        let report = self.clone();
+        write_to_file(data_dir, |f| f.taker.push(report))
     }
 
-    /// Create a successful maker swap report.
-    pub fn maker_success(
-        swap_id: String,
-        start_time: Instant,
-        incoming_amount: u64,
-        outgoing_amount: u64,
-        incoming_contract_txid: String,
-        outgoing_contract_txid: String,
-        timelock: u16,
-        network: String,
-    ) -> Self {
-        let swap_duration = start_time.elapsed();
-
-        Self::maker_report(
-            Self {
-                swap_id,
-                status: SwapStatus::Success,
-                network,
-                incoming_amount,
-                outgoing_amount,
-                fee_paid_or_earned: (incoming_amount as i64) - (outgoing_amount as i64),
-                incoming_contract_txid: Some(incoming_contract_txid),
-                outgoing_contract_txid: Some(outgoing_contract_txid),
-                timelock,
-                ..Default::default()
-            },
-            swap_duration.as_secs_f64(),
-        )
-    }
-
-    /// Create a maker recovery report (hashlock or timelock).
-    pub fn maker_recovery(
-        swap_id: String,
-        recovery_type: &str,
-        incoming_amount: u64,
-        outgoing_amount: u64,
-        incoming_contract_txid: String,
-        outgoing_contract_txid: String,
-        recovery_txid: String,
-        timelock: u16,
-        network: String,
-    ) -> Self {
-        let status = match recovery_type {
-            "hashlock" => SwapStatus::RecoveryHashlock,
-            "timelock" => SwapStatus::RecoveryTimelock,
-            _ => SwapStatus::Failed,
-        };
-
-        Self::maker_report(
-            Self {
-                swap_id,
-                status,
-                network,
-                incoming_amount,
-                outgoing_amount,
-                incoming_contract_txid: Some(incoming_contract_txid),
-                outgoing_contract_txid: Some(outgoing_contract_txid),
-                recovery_txids: Some(vec![recovery_txid]),
-                timelock,
-                ..Default::default()
-            },
-            0.0,
-        )
-    }
-
-    /// Create a taker swap report for any status (success, failed, or recovery).
-    pub fn taker_report(mut report: Self) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default();
-        let end_timestamp = now.as_secs();
-        report.role = SwapRole::Taker;
-        report.start_timestamp = end_timestamp.saturating_sub(report.swap_duration_seconds as u64);
-        report.end_timestamp = end_timestamp;
-        report
-    }
-
-    /// Emit a minimal taker recovery report to disk and console.
-    pub fn emit_taker_recovery_report(
-        data_dir: &Path,
-        swap_id: String,
-        network: String,
-        outgoing_amount: u64,
-        status: SwapStatus,
-        recovery_txids: &[String],
-        recovery_duration: f64,
-    ) {
-        let report = Self::taker_report(SwapReport {
-            status,
-            swap_id,
-            outgoing_amount,
-            network,
-            recovery_txids: Some(recovery_txids.to_vec()),
-            recovery_duration_seconds: recovery_duration,
-            ..Default::default()
-        });
-
-        report.print();
-        if let Err(e) = report.save_to_disk(data_dir) {
-            log::warn!("Failed to save taker recovery report: {:?}", e);
-        }
-        log::info!(
-            "For full details of the failed swap, see the accompanying report in: {}/swap_reports/",
-            data_dir.display()
-        );
-    }
-
-    /// Save the report to disk as a JSON file.
-    ///
-    /// The report is saved to `{data_dir}/swap_reports/{role}_{status}_{timestamp}_{swap_id}.json`.
-    pub fn save_to_disk(&self, data_dir: &Path) -> std::io::Result<()> {
-        let reports_dir = data_dir.join("swap_reports");
-        std::fs::create_dir_all(&reports_dir)?;
-
-        let role_prefix = match self.role {
-            SwapRole::Taker => "taker",
-            SwapRole::Maker => "maker",
-        };
-
-        let status_prefix = match self.status {
-            SwapStatus::Success => "success",
-            SwapStatus::Failed => "failed",
-            SwapStatus::RecoveryHashlock => "recoveryhashlock",
-            SwapStatus::RecoveryTimelock => "recoverytimelock",
-        };
-
-        let sanitized_swap_id: String = self
-            .swap_id
-            .chars()
-            .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
-            .take(64)
-            .collect();
-
-        let safe_swap_id = if sanitized_swap_id.is_empty() {
-            "unknown".to_string()
-        } else {
-            sanitized_swap_id
-        };
-
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default();
-        let timestamp = format_unix_timestamp_utc(now);
-
-        let filename = format!(
-            "{}_{}_{}_{}.json",
-            role_prefix, status_prefix, timestamp, safe_swap_id
-        );
-        let filepath = reports_dir.join(filename);
-
-        let json = serde_json::to_string_pretty(self).map_err(std::io::Error::other)?;
-        std::fs::write(&filepath, json)?;
-
-        log::info!("Saved swap report to: {}", filepath.display());
-        Ok(())
-    }
-
-    /// Print the report to console with colored formatting.
-    ///
-    /// Displays a human-readable summary of the swap including status,
-    /// amounts, transaction IDs, and fee breakdown (for taker reports).
+    /// Print a human-readable summary to stdout.
     pub fn print(&self) {
-        let role_str = self.role.to_string().to_uppercase();
-
         println!("\n\x1b[1;36m================================================================================");
-        println!("                         {} SWAP REPORT", role_str);
+        println!("                           TAKER SWAP REPORT");
         println!("================================================================================\x1b[0m\n");
 
         println!("\x1b[1;37mSwap ID           :\x1b[0m {}", self.swap_id);
         println!("\x1b[1;37mStatus            :\x1b[0m {}", self.status);
-
         if self.swap_duration_seconds > 0.0 {
             println!(
                 "\x1b[1;37mDuration          :\x1b[0m {:.2} seconds",
@@ -414,78 +188,47 @@ impl SwapReport {
             );
         }
 
-        if self.recovery_duration_seconds > 0.0 {
-            println!(
-                "\x1b[1;37mRecovery Duration :\x1b[0m {:.2} seconds",
-                self.recovery_duration_seconds
-            );
-        }
-
         println!("\n\x1b[1;36m--------------------------------------------------------------------------------");
         println!("                              Swap Details");
         println!("--------------------------------------------------------------------------------\x1b[0m");
 
-        match self.role {
-            SwapRole::Maker => {
-                println!(
-                    "\x1b[1;37mIncoming Amount   :\x1b[0m {} sats",
-                    self.incoming_amount
-                );
-                println!(
-                    "\x1b[1;37mOutgoing Amount   :\x1b[0m {} sats",
-                    self.outgoing_amount
-                );
-                println!(
-                    "\x1b[1;37mFee Earned        :\x1b[0m \x1b[1;32m{} sats\x1b[0m",
-                    self.fee_paid_or_earned
-                );
-            }
-            SwapRole::Taker => {
-                println!(
-                    "\x1b[1;37mTarget Amount     :\x1b[0m {} sats",
-                    self.outgoing_amount
-                );
-                println!(
-                    "\x1b[1;37mTotal Output      :\x1b[0m {} sats",
-                    self.incoming_amount
-                );
-                println!(
-                    "\x1b[1;37mTotal Fee Paid    :\x1b[0m \x1b[1;31m{} sats\x1b[0m",
-                    -self.fee_paid_or_earned
-                );
-                if self.mining_fee > 0 {
-                    println!(
-                        "\x1b[1;37mMining Fee        :\x1b[0m {} sats",
-                        self.mining_fee
-                    );
-                }
-            }
-        }
-
-        if self.timelock > 0 {
+        println!(
+            "\x1b[1;37mTarget Amount     :\x1b[0m {} sats",
+            self.outgoing_amount
+        );
+        println!(
+            "\x1b[1;37mTotal Output      :\x1b[0m {} sats",
+            self.incoming_amount
+        );
+        println!(
+            "\x1b[1;37mTotal Fee Paid    :\x1b[0m \x1b[1;31m{} sats\x1b[0m",
+            self.fee_paid
+        );
+        println!(
+            "\x1b[1;37mFee Percentage    :\x1b[0m {:.4}%",
+            self.fee_percentage
+        );
+        if self.mining_fee > 0 {
             println!(
-                "\x1b[1;37mTimelock          :\x1b[0m {} blocks",
-                self.timelock
+                "\x1b[1;37mMining Fee        :\x1b[0m {} sats",
+                self.mining_fee
             );
         }
         println!("\x1b[1;37mNetwork           :\x1b[0m {}", self.network);
-
-        if let Some(count) = self.makers_count {
-            println!("\x1b[1;37mMakers Used       :\x1b[0m {}", count);
-            for (i, addr) in self.maker_addresses.iter().enumerate() {
-                println!("  Maker {}         : {}", i + 1, addr);
-            }
+        println!("\x1b[1;37mMakers Used       :\x1b[0m {}", self.makers_count);
+        for (i, addr) in self.maker_addresses.iter().enumerate() {
+            println!("  Maker {}         : {}", i + 1, addr);
         }
 
         println!("\n\x1b[1;36m--------------------------------------------------------------------------------");
         println!("                            Transaction IDs");
         println!("--------------------------------------------------------------------------------\x1b[0m");
 
-        if let Some(ref txid) = self.incoming_contract_txid {
-            println!("\x1b[1;37mIncoming Contract :\x1b[0m {}", txid);
-        }
         if let Some(ref txid) = self.outgoing_contract_txid {
             println!("\x1b[1;37mOutgoing Contract :\x1b[0m {}", txid);
+        }
+        if let Some(ref txid) = self.incoming_contract_txid {
+            println!("\x1b[1;37mIncoming Contract :\x1b[0m {}", txid);
         }
         if !self.funding_txids.is_empty() {
             println!("\x1b[1;37mFunding Txs       :\x1b[0m");
@@ -495,9 +238,6 @@ impl SwapReport {
                     println!("    {}. {}", i + 1, txid);
                 }
             }
-        }
-        if let Some(ref txids) = self.recovery_txids {
-            println!("\x1b[1;37mRecovery Tx       :\x1b[0m {:?}", txids);
         }
 
         if !self.maker_fee_info.is_empty() {
@@ -552,4 +292,315 @@ impl SwapReport {
         println!("                                END REPORT");
         println!("================================================================================\x1b[0m\n");
     }
+}
+
+/// Maker-perspective record for one swap.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MakerReport {
+    /// Unique swap identifier derived from the preimage hash.
+    pub swap_id: String,
+    /// Final outcome of the swap.
+    pub status: SwapStatus,
+    /// Bitcoin network (mainnet, testnet, signet, regtest).
+    pub network: String,
+    /// Total duration of the swap in seconds.
+    pub swap_duration_seconds: f64,
+    /// Unix timestamp when the swap started.
+    pub start_timestamp: u64,
+    /// Unix timestamp when the swap completed.
+    pub end_timestamp: u64,
+
+    /// Amount received in the incoming contract (satoshis).
+    pub incoming_amount: u64,
+    /// Amount sent in the outgoing contract (satoshis).
+    pub outgoing_amount: u64,
+    /// Fee earned (incoming − outgoing, satoshis).
+    pub fee_earned: u64,
+
+    /// Transaction ID of the incoming contract.
+    pub incoming_contract_txid: String,
+    /// Transaction ID of the outgoing contract.
+    pub outgoing_contract_txid: String,
+    /// Timelock value in blocks for the outgoing contract.
+    pub timelock: u16,
+}
+
+impl MakerReport {
+    /// Build a success report from raw swap state values.
+    pub fn success(
+        swap_id: String,
+        start_time: Instant,
+        incoming_amount: u64,
+        outgoing_amount: u64,
+        incoming_contract_txid: String,
+        outgoing_contract_txid: String,
+        timelock: u16,
+        network: String,
+    ) -> Self {
+        let swap_duration_seconds = start_time.elapsed().as_secs_f64();
+        let end = now_unix_secs();
+        Self {
+            swap_id,
+            status: SwapStatus::Success,
+            network,
+            swap_duration_seconds,
+            start_timestamp: end.saturating_sub(swap_duration_seconds as u64),
+            end_timestamp: end,
+            incoming_amount,
+            outgoing_amount,
+            fee_earned: incoming_amount.saturating_sub(outgoing_amount),
+            incoming_contract_txid,
+            outgoing_contract_txid,
+            timelock,
+        }
+    }
+
+    /// Save to the shared report file under this maker's node name.
+    pub fn save(&self, data_dir: &Path) -> std::io::Result<()> {
+        let node_name = data_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let report = self.clone();
+        write_to_file(data_dir, |f| {
+            f.maker.entry(node_name).or_default().push(report);
+        })
+    }
+
+    /// Print a human-readable summary to stdout.
+    pub fn print(&self) {
+        println!("\n\x1b[1;36m================================================================================");
+        println!("                           MAKER SWAP REPORT");
+        println!("================================================================================\x1b[0m\n");
+
+        println!("\x1b[1;37mSwap ID           :\x1b[0m {}", self.swap_id);
+        println!("\x1b[1;37mStatus            :\x1b[0m {}", self.status);
+        if self.swap_duration_seconds > 0.0 {
+            println!(
+                "\x1b[1;37mDuration          :\x1b[0m {:.2} seconds",
+                self.swap_duration_seconds
+            );
+        }
+
+        println!("\n\x1b[1;36m--------------------------------------------------------------------------------");
+        println!("                              Swap Details");
+        println!("--------------------------------------------------------------------------------\x1b[0m");
+
+        println!(
+            "\x1b[1;37mIncoming Amount   :\x1b[0m {} sats",
+            self.incoming_amount
+        );
+        println!(
+            "\x1b[1;37mOutgoing Amount   :\x1b[0m {} sats",
+            self.outgoing_amount
+        );
+        println!(
+            "\x1b[1;37mFee Earned        :\x1b[0m \x1b[1;32m{} sats\x1b[0m",
+            self.fee_earned
+        );
+        println!(
+            "\x1b[1;37mTimelock          :\x1b[0m {} blocks",
+            self.timelock
+        );
+        println!("\x1b[1;37mNetwork           :\x1b[0m {}", self.network);
+
+        println!("\n\x1b[1;36m--------------------------------------------------------------------------------");
+        println!("                            Transaction IDs");
+        println!("--------------------------------------------------------------------------------\x1b[0m");
+
+        println!(
+            "\x1b[1;37mIncoming Contract :\x1b[0m {}",
+            self.incoming_contract_txid
+        );
+        println!(
+            "\x1b[1;37mOutgoing Contract :\x1b[0m {}",
+            self.outgoing_contract_txid
+        );
+
+        println!("\n\x1b[1;36m================================================================================");
+        println!("                                END REPORT");
+        println!("================================================================================\x1b[0m\n");
+    }
+}
+
+/// Recovery event record (written by whichever party performs the recovery).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecoveryReport {
+    /// Unique swap identifier derived from the preimage hash.
+    pub swap_id: String,
+    /// Role of the party that performed the recovery.
+    pub role: SwapRole,
+    /// Maker node name when role is Maker; None for Taker.
+    pub node: Option<String>,
+    /// Recovery path used: `"hashlock"` or `"timelock"`.
+    pub recovery_type: String,
+    /// Transaction IDs of the recovery transactions.
+    pub recovery_txids: Vec<String>,
+    /// Bitcoin network (mainnet, testnet, signet, regtest).
+    pub network: String,
+    /// Unix timestamp of the recovery event.
+    pub timestamp: u64,
+}
+
+impl RecoveryReport {
+    /// Emit a taker recovery report — prints to console and saves to file.
+    pub fn emit_taker(
+        data_dir: &Path,
+        swap_id: String,
+        network: String,
+        recovery_type: String,
+        recovery_txids: Vec<String>,
+    ) {
+        let report = Self {
+            swap_id,
+            role: SwapRole::Taker,
+            node: None,
+            recovery_type,
+            recovery_txids,
+            network,
+            timestamp: now_unix_secs(),
+        };
+        report.print();
+        if let Err(e) = report.save(data_dir) {
+            log::warn!("Failed to save taker recovery report: {:?}", e);
+        }
+        log::info!(
+            "For full details, see: {}",
+            coinswap_root(data_dir).join("swap_reports.json").display()
+        );
+    }
+
+    /// Emit a maker recovery report — prints to console and saves to file.
+    pub fn emit_maker(
+        data_dir: &Path,
+        swap_id: String,
+        network: String,
+        recovery_type: String,
+        recovery_txids: Vec<String>,
+    ) {
+        let node = data_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|s| s.to_string());
+        let report = Self {
+            swap_id,
+            role: SwapRole::Maker,
+            node,
+            recovery_type,
+            recovery_txids,
+            network,
+            timestamp: now_unix_secs(),
+        };
+        report.print();
+        if let Err(e) = report.save(data_dir) {
+            log::warn!("Failed to save maker recovery report: {:?}", e);
+        }
+    }
+
+    fn save(&self, data_dir: &Path) -> std::io::Result<()> {
+        let report = self.clone();
+        write_to_file(data_dir, |f| f.recovery.push(report))
+    }
+
+    fn print(&self) {
+        println!("\n\x1b[1;33m================================================================================");
+        println!("                           RECOVERY REPORT");
+        println!("================================================================================\x1b[0m\n");
+        println!("\x1b[1;37mSwap ID       :\x1b[0m {}", self.swap_id);
+        println!("\x1b[1;37mRole          :\x1b[0m {}", self.role);
+        if let Some(ref node) = self.node {
+            println!("\x1b[1;37mNode          :\x1b[0m {}", node);
+        }
+        println!("\x1b[1;37mRecovery Type :\x1b[0m {}", self.recovery_type);
+        println!("\x1b[1;37mNetwork       :\x1b[0m {}", self.network);
+        println!("\x1b[1;37mRecovery Txs  :\x1b[0m {:?}", self.recovery_txids);
+        println!("\n\x1b[1;33m================================================================================");
+        println!("                              END REPORT");
+        println!("================================================================================\x1b[0m\n");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Top-level file structure
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SwapReportFile {
+    pub taker: Vec<TakerReport>,
+    pub maker: HashMap<String, Vec<MakerReport>>,
+    pub recovery: Vec<RecoveryReport>,
+    pub deniability_proofs: Vec<serde_json::Value>,
+}
+
+// ---------------------------------------------------------------------------
+// File I/O helpers
+// ---------------------------------------------------------------------------
+
+fn coinswap_root(data_dir: &Path) -> PathBuf {
+    data_dir.parent().unwrap_or(data_dir).to_path_buf()
+}
+
+struct LockGuard {
+    path: PathBuf,
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn acquire_lock(lock_path: &Path) -> std::io::Result<LockGuard> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(lock_path)
+        {
+            Ok(_) => {
+                return Ok(LockGuard {
+                    path: lock_path.to_owned(),
+                })
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                if std::time::Instant::now() > deadline {
+                    // Stale lock — force remove and retry once.
+                    std::fs::remove_file(lock_path)?;
+                    continue;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+fn write_to_file<F>(data_dir: &Path, mutate: F) -> std::io::Result<()>
+where
+    F: FnOnce(&mut SwapReportFile),
+{
+    let root = coinswap_root(data_dir);
+    std::fs::create_dir_all(&root)?;
+
+    let file_path = root.join("swap_reports.json");
+    let lock_path = root.join("swap_reports.json.lock");
+
+    let _lock = acquire_lock(&lock_path)?;
+
+    let mut report_file: SwapReportFile = if file_path.exists() {
+        let content = std::fs::read_to_string(&file_path)?;
+        serde_json::from_str(&content).unwrap_or_default()
+    } else {
+        SwapReportFile::default()
+    };
+
+    mutate(&mut report_file);
+
+    let json = serde_json::to_string_pretty(&report_file).map_err(std::io::Error::other)?;
+    std::fs::write(&file_path, json)?;
+
+    log::info!("Saved swap report to: {}", file_path.display());
+    Ok(())
 }

--- a/src/wallet/report.rs
+++ b/src/wallet/report.rs
@@ -322,7 +322,7 @@ pub struct MakerReport {
     /// Transaction ID of the outgoing contract.
     pub outgoing_contract_txid: String,
     /// Timelock value in blocks for the outgoing contract.
-    pub timelock: u16,
+    pub timelock: u32,
 }
 
 impl MakerReport {
@@ -334,7 +334,7 @@ impl MakerReport {
         outgoing_amount: u64,
         incoming_contract_txid: String,
         outgoing_contract_txid: String,
-        timelock: u16,
+        timelock: u32,
         network: String,
     ) -> Self {
         let swap_duration_seconds = start_time.elapsed().as_secs_f64();
@@ -552,7 +552,8 @@ impl Drop for LockGuard {
 }
 
 fn acquire_lock(lock_path: &Path) -> std::io::Result<LockGuard> {
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+    let mut deadline = std::time::Instant::now() + TIMEOUT;
     loop {
         match OpenOptions::new()
             .write(true)
@@ -566,9 +567,17 @@ fn acquire_lock(lock_path: &Path) -> std::io::Result<LockGuard> {
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 if std::time::Instant::now() > deadline {
-                    // Stale lock — force remove and retry once.
-                    std::fs::remove_file(lock_path)?;
-                    continue;
+                    let is_stale = std::fs::metadata(lock_path)
+                        .and_then(|m| m.modified())
+                        .map(|mtime| mtime.elapsed().unwrap_or_default() > TIMEOUT)
+                        .unwrap_or(true);
+
+                    if is_stale {
+                        std::fs::remove_file(lock_path)?;
+                    } else {
+                        // Owner is still active — extend and keep waiting.
+                        deadline = std::time::Instant::now() + TIMEOUT;
+                    }
                 }
                 std::thread::sleep(std::time::Duration::from_millis(10));
             }
@@ -591,7 +600,7 @@ where
 
     let mut report_file: SwapReportFile = if file_path.exists() {
         let content = std::fs::read_to_string(&file_path)?;
-        serde_json::from_str(&content).unwrap_or_default()
+        serde_json::from_str(&content).map_err(std::io::Error::other)?
     } else {
         SwapReportFile::default()
     };
@@ -599,7 +608,14 @@ where
     mutate(&mut report_file);
 
     let json = serde_json::to_string_pretty(&report_file).map_err(std::io::Error::other)?;
-    std::fs::write(&file_path, json)?;
+    let tmp_path = file_path.with_extension("partial");
+    {
+        use std::io::Write;
+        let mut tmp = std::fs::File::create(&tmp_path)?;
+        tmp.write_all(json.as_bytes())?;
+        tmp.sync_all()?;
+    }
+    std::fs::rename(&tmp_path, &file_path)?;
 
     log::info!("Saved swap report to: {}", file_path.display());
     Ok(())


### PR DESCRIPTION
# Pull Request

## Description
This pr unifies multiple swap reports into a single json file.
## Related Issue(s)
Closes #843 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated swap reporting into a single on-disk report file with dedicated taker, maker, and recovery sections (replacing per-swap files).
  * Recovery reporting now emits consolidated hashlock/timelock recovery entries instead of multiple per-contract entries.
* **New Features**
  * Introduced distinct Taker, Maker, and Recovery report types with save and print capabilities.
* **Bug Fixes**
  * Improved atomic, concurrency-safe report persistence with locking and safe write/replace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->