### PR TITLE
route relay via tor proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ sha2 = "0.10.9"
 rust-coinselect = "0.1.6"
 crossterm = "0.29.0"
 zmq = "0.10.0"
-tungstenite = { version = "0.28.0", features = ["rustls-tls-webpki-roots"]}
+tungstenite = { version = "0.28.0", features = ["native-tls"]}
 nostr = "0.44.2"
 crossbeam-channel = "0.5.15"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ sha2 = "0.10.9"
 rust-coinselect = "0.1.6"
 crossterm = "0.29.0"
 zmq = "0.10.0"
-tungstenite = { version = "0.28.0", features = ["native-tls"]}
+tungstenite = { version = "0.28.0", features = ["rustls-tls-webpki-roots"]}
 nostr = "0.44.2"
 crossbeam-channel = "0.5.15"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ sha2 = "0.10.9"
 rust-coinselect = "0.1.6"
 crossterm = "0.29.0"
 zmq = "0.10.0"
-tungstenite = { version = "0.28.0", features = ["native-tls"]}
+tungstenite = { version = "0.28.0", features = ["rustls-tls-webpki-roots"]}
+rustls = { version = "0.23.40", default-features = false, features = ["std", "ring"] }
 nostr = "0.44.2"
 crossbeam-channel = "0.5.15"
 
@@ -50,3 +51,5 @@ default = []
 # Only used for running the integration tests
 integration-test = []
 
+[package.metadata.cargo-machete]
+ignored = ["rustls"]

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -401,7 +401,7 @@ pub struct IdleSwapData {
 
 impl MakerServer {
     /// Initialize a new maker server with full setup.
-    pub fn init(config: MakerServerConfig) -> Result<Self, MakerError> {
+    pub fn init(mut config: MakerServerConfig) -> Result<Self, MakerError> {
         let data_dir = config.data_dir.clone();
         std::fs::create_dir_all(&data_dir).map_err(MakerError::IO)?;
 
@@ -419,6 +419,15 @@ impl MakerServer {
         let mut wallet = wallet;
         log::info!("Sync at:----MakerServer init----");
         wallet.sync_and_save()?;
+        let wallet_network = wallet.store.network;
+        if config.network != wallet_network {
+            log::info!(
+                "Maker config network ({:?}) differs from wallet network ({:?}); using wallet network",
+                config.network,
+                wallet_network
+            );
+            config.network = wallet_network;
+        }
 
         // Initialize watch service
         let watch_service = crate::watch_tower::service::start_maker_watch_service(

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -229,14 +229,23 @@ fn spawn_nostr_broadcast_thread(
 
     let maker_clone = Arc::clone(maker);
     let relays = maker.nostr_relays.clone();
+    let nostr_network = maker
+        .wallet
+        .read()
+        .map(|w| w.store.network)
+        .unwrap_or_else(|_| maker.config.network);
 
     let handle = thread::Builder::new()
         .name("nostr-thread".to_string())
         .spawn(move || {
             // Initial broadcast
-            if let Err(e) =
-                broadcast_bond_on_nostr(fidelity.clone(), maker_clone.config.network, &relays)
-            {
+            if let Err(e) = broadcast_bond_on_nostr(
+                fidelity.clone(),
+                nostr_network,
+                &relays,
+                maker_clone.config.socks_port,
+                &maker_clone.config.tor_auth_password,
+            ) {
                 log::warn!("Initial nostr broadcast failed: {:?}", e);
             }
 
@@ -256,9 +265,13 @@ fn spawn_nostr_broadcast_thread(
 
                 log::debug!("Re-pinging nostr relays with bond announcement");
 
-                if let Err(e) =
-                    broadcast_bond_on_nostr(fidelity.clone(), maker_clone.config.network, &relays)
-                {
+                if let Err(e) = broadcast_bond_on_nostr(
+                    fidelity.clone(),
+                    nostr_network,
+                    &relays,
+                    maker_clone.config.socks_port,
+                    &maker_clone.config.tor_auth_password,
+                ) {
                     log::warn!("Nostr re-ping failed: {:?}", e);
                 }
             }

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -229,23 +229,12 @@ fn spawn_nostr_broadcast_thread(
 
     let maker_clone = Arc::clone(maker);
     let relays = maker.nostr_relays.clone();
-    let nostr_network = maker
-        .wallet
-        .read()
-        .map(|w| w.store.network)
-        .unwrap_or_else(|_| maker.config.network);
-
     let handle = thread::Builder::new()
         .name("nostr-thread".to_string())
         .spawn(move || {
             // Initial broadcast
-            if let Err(e) = broadcast_bond_on_nostr(
-                fidelity.clone(),
-                nostr_network,
-                &relays,
-                maker_clone.config.socks_port,
-                &maker_clone.config.tor_auth_password,
-            ) {
+            if let Err(e) = broadcast_bond_on_nostr(fidelity.clone(), &relays, &maker_clone.config)
+            {
                 log::warn!("Initial nostr broadcast failed: {:?}", e);
             }
 
@@ -265,13 +254,9 @@ fn spawn_nostr_broadcast_thread(
 
                 log::debug!("Re-pinging nostr relays with bond announcement");
 
-                if let Err(e) = broadcast_bond_on_nostr(
-                    fidelity.clone(),
-                    nostr_network,
-                    &relays,
-                    maker_clone.config.socks_port,
-                    &maker_clone.config.tor_auth_password,
-                ) {
+                if let Err(e) =
+                    broadcast_bond_on_nostr(fidelity.clone(), &relays, &maker_clone.config)
+                {
                     log::warn!("Nostr re-ping failed: {:?}", e);
                 }
             }

--- a/src/nostr_coinswap.rs
+++ b/src/nostr_coinswap.rs
@@ -76,7 +76,7 @@ pub(crate) fn connect_nostr_websocket(
         Socks5Stream::connect_with_password(
             socks_addr.as_str(),
             target_addr.as_str(),
-            "",
+            host,
             tor_auth_password,
         )
     }

--- a/src/nostr_coinswap.rs
+++ b/src/nostr_coinswap.rs
@@ -22,7 +22,10 @@ use nostr::{
 use socks::Socks5Stream;
 use tungstenite::{http::Uri, stream::MaybeTlsStream, Message, WebSocket};
 
-use crate::{maker::MakerError, protocol::common_messages::FidelityProof};
+use crate::{
+    maker::{MakerError, MakerServerConfig},
+    protocol::common_messages::FidelityProof,
+};
 
 /// nostr url for coinswap
 #[cfg(not(feature = "integration-test"))]
@@ -94,14 +97,12 @@ pub(crate) fn connect_nostr_websocket(
 /// Broadcasts a fidelity bond announcement over Nostr.
 pub fn broadcast_bond_on_nostr(
     fidelity: FidelityProof,
-    network: Network,
     relays: &[String],
-    socks_port: u16,
-    tor_auth_password: &str,
+    config: &MakerServerConfig,
 ) -> Result<(), MakerError> {
     let outpoint = fidelity.bond.outpoint;
     let content = format!("{}:{}", outpoint.txid, outpoint.vout);
-    let kind = coinswap_kind(network);
+    let kind = coinswap_kind(config.network);
     // Coinswap kinds are in the NIP-33 parameterized-replaceable range (30000..39999),
     // so included a stable `d` tag to keep relay handling spec-compliant.
     let d_tag = format!("fidelity:{}", content);
@@ -163,7 +164,7 @@ pub fn broadcast_bond_on_nostr(
 
     for relay in relays {
         for attempt in 1..=MAX_RETRIES {
-            match broadcast_to_relay(relay, &msg, socks_port, tor_auth_password) {
+            match broadcast_to_relay(relay, &msg, config.socks_port, &config.tor_auth_password) {
                 Ok(()) => {
                     success = true;
                     break;

--- a/src/nostr_coinswap.rs
+++ b/src/nostr_coinswap.rs
@@ -5,7 +5,11 @@
 //! fidelity bond information and other coordination signals required
 //! by the Coinswap protocol.
 
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{
+    io,
+    net::TcpStream,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use bitcoin::Network;
 use nostr::{
@@ -15,7 +19,8 @@ use nostr::{
     types::Timestamp,
     util::JsonUtil,
 };
-use tungstenite::Message;
+use socks::Socks5Stream;
+use tungstenite::{http::Uri, stream::MaybeTlsStream, Message, WebSocket};
 
 use crate::{maker::MakerError, protocol::common_messages::FidelityProof};
 
@@ -39,11 +44,60 @@ pub fn coinswap_kind(network: Network) -> u16 {
 /// Expiration time for noster event (24 hours)
 pub(crate) const EXPIRATION_SECS: u64 = 86400;
 
+pub(crate) fn connect_nostr_websocket(
+    relay_url: &str,
+    socks_port: u16,
+    tor_auth_password: &str,
+) -> Result<WebSocket<MaybeTlsStream<TcpStream>>, tungstenite::Error> {
+    if cfg!(feature = "integration-test") {
+        return tungstenite::connect(relay_url).map(|(ws, _)| ws);
+    }
+
+    let invalid_relay = || io::Error::new(io::ErrorKind::InvalidInput, "invalid relay url");
+    let uri: Uri = relay_url.parse().map_err(|_| invalid_relay())?;
+    let scheme = uri.scheme_str().ok_or_else(invalid_relay)?;
+    if scheme != "ws" && scheme != "wss" {
+        return Err(invalid_relay().into());
+    }
+    let authority = uri.authority().ok_or_else(invalid_relay)?;
+    let host = authority.host();
+    let port = authority
+        .port_u16()
+        .unwrap_or(if scheme == "wss" { 443 } else { 80 });
+
+    let socks_addr = format!("127.0.0.1:{socks_port}");
+    let target_addr = format!("{host}:{port}");
+    let tcp = if tor_auth_password.is_empty() {
+        Socks5Stream::connect(socks_addr.as_str(), target_addr.as_str())
+    } else {
+        Socks5Stream::connect_with_password(
+            socks_addr.as_str(),
+            target_addr.as_str(),
+            "",
+            tor_auth_password,
+        )
+    }
+    .map_err(|e| io::Error::other(e.to_string()))?
+    .into_inner();
+
+    tcp.set_read_timeout(Some(Duration::from_secs(30)))?;
+    tcp.set_write_timeout(Some(Duration::from_secs(30)))?;
+    match tungstenite::client_tls_with_config(relay_url, tcp, None, None) {
+        Ok((ws, _)) => Ok(ws),
+        Err(tungstenite::HandshakeError::Failure(e)) => Err(e),
+        Err(tungstenite::HandshakeError::Interrupted(_)) => {
+            Err(io::Error::other("tls handshake interrupted").into())
+        }
+    }
+}
+
 /// Broadcasts a fidelity bond announcement over Nostr.
 pub fn broadcast_bond_on_nostr(
     fidelity: FidelityProof,
     network: Network,
     relays: &[String],
+    socks_port: u16,
+    tor_auth_password: &str,
 ) -> Result<(), MakerError> {
     let outpoint = fidelity.bond.outpoint;
     let content = format!("{}:{}", outpoint.txid, outpoint.vout);
@@ -109,7 +163,7 @@ pub fn broadcast_bond_on_nostr(
 
     for relay in relays {
         for attempt in 1..=MAX_RETRIES {
-            match broadcast_to_relay(relay, &msg) {
+            match broadcast_to_relay(relay, &msg, socks_port, tor_auth_password) {
                 Ok(()) => {
                     success = true;
                     break;
@@ -138,11 +192,17 @@ pub fn broadcast_bond_on_nostr(
 }
 
 /// Sends a Nostr event to a single relay and waits for confirmation.
-fn broadcast_to_relay(relay: &str, msg: &ClientMessage) -> Result<(), MakerError> {
-    let (mut socket, _) = tungstenite::connect(relay).map_err(|e| {
-        log::warn!("failed to connect to nostr relay {}: {}", relay, e);
-        MakerError::General("failed to connect to nostr relay")
-    })?;
+fn broadcast_to_relay(
+    relay: &str,
+    msg: &ClientMessage,
+    socks_port: u16,
+    tor_auth_password: &str,
+) -> Result<(), MakerError> {
+    let mut socket =
+        connect_nostr_websocket(relay, socks_port, tor_auth_password).map_err(|e| {
+            log::warn!("failed to connect to nostr relay {}: {}", relay, e);
+            MakerError::General("failed to connect to nostr relay")
+        })?;
 
     socket
         .write(Message::Text(msg.as_json().into()))

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -632,8 +632,17 @@ impl Taker {
         let initial_sync_clone = initial_sync_complete.clone();
 
         let nostr_relays = config.nostr_relays.clone();
-        let mut watcher =
-            Watcher::<Taker>::new(backend, registry, rx_requests, tx_events, nostr_relays);
+        let mut watcher = Watcher::<Taker>::new(
+            backend,
+            registry,
+            rx_requests,
+            tx_events,
+            nostr_relays,
+            Some((
+                config.socks_port,
+                config.tor_auth_password.clone().unwrap_or_default(),
+            )),
+        );
         let _ = thread::Builder::new()
             .name("Watcher thread".to_string())
             .spawn(move || watcher.run(rpc_config_watcher, initial_sync_clone));

--- a/src/watch_tower/nostr_discovery.rs
+++ b/src/watch_tower/nostr_discovery.rs
@@ -6,6 +6,7 @@
 
 use std::{
     borrow::Cow,
+    net::TcpStream,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
@@ -23,7 +24,7 @@ use nostr::{
 use tungstenite::{stream::MaybeTlsStream, Message};
 
 use crate::{
-    nostr_coinswap::{coinswap_kind, EXPIRATION_SECS},
+    nostr_coinswap::{coinswap_kind, connect_nostr_websocket, EXPIRATION_SECS},
     watch_tower::{
         registry_storage::FileRegistry,
         rest_backend::BitcoinRest,
@@ -41,6 +42,7 @@ pub fn run_discovery(
     shutdown: Arc<AtomicBool>,
     initial_sync_complete: Arc<AtomicBool>,
     relays: &[String],
+    nostr_tor_config: (u16, String),
 ) -> Result<(), WatcherError> {
     log::info!("Starting market discovery via Nostr");
 
@@ -57,18 +59,20 @@ pub fn run_discovery(
         let bitcoin_rpc = Arc::clone(&bitcoin_rpc);
         let seen_txid = Arc::clone(&seen_txid);
         let initial_sync_complete = initial_sync_complete.clone();
+        let nostr_tor_config = nostr_tor_config.clone();
 
         std::thread::Builder::new()
             .name(format!("nostr-session-{}", relay))
             .spawn(move || {
                 run_nostr_session_for_relay(
-                    &relay.clone(),
+                    &relay,
                     kind,
                     registry,
                     shutdown,
                     bitcoin_rpc,
                     &seen_txid,
                     &initial_sync_complete,
+                    (nostr_tor_config.0, nostr_tor_config.1.as_str()),
                 );
             })?;
     }
@@ -78,6 +82,7 @@ pub fn run_discovery(
 
 /// Runs a long-lived Nostr session for a single relay.
 /// Reconnects automatically until shutdown is requested.
+#[allow(clippy::too_many_arguments)]
 fn run_nostr_session_for_relay(
     relay_url: &str,
     kind: Kind,
@@ -86,6 +91,7 @@ fn run_nostr_session_for_relay(
     bitcoin_rpc: Arc<BitcoinRest>,
     seen_txid: &Arc<Mutex<SeenTxids>>,
     initial_sync_complete: &Arc<AtomicBool>,
+    nostr_tor_config: (u16, &str),
 ) {
     log::info!("Starting Nostr session for relay {}", relay_url);
 
@@ -98,6 +104,7 @@ fn run_nostr_session_for_relay(
             bitcoin_rpc.clone(),
             seen_txid,
             initial_sync_complete,
+            nostr_tor_config,
         ) {
             Ok(()) => {
                 // Likely exited due to shutdown
@@ -119,6 +126,7 @@ fn run_nostr_session_for_relay(
 
 /// Establishes websocket connection to single Nostr relay and processes events until error or shutdown.
 /// Subscribe to Nostr events on the Coinswap kind for the active network.
+#[allow(clippy::too_many_arguments)]
 fn connect_and_run_once(
     relay_url: &str,
     kind: Kind,
@@ -127,8 +135,9 @@ fn connect_and_run_once(
     bitcoin_rpc: Arc<BitcoinRest>,
     seen_txid: &Arc<Mutex<SeenTxids>>,
     initial_sync_complete: &Arc<AtomicBool>,
+    nostr_tor_config: (u16, &str),
 ) -> Result<(), WatcherError> {
-    let (mut socket, _) = tungstenite::connect(relay_url)?;
+    let mut socket = connect_nostr_websocket(relay_url, nostr_tor_config.0, nostr_tor_config.1)?;
 
     let since = registry.load_nostr_cursor(relay_url).map(Timestamp::from);
 
@@ -172,7 +181,7 @@ fn connect_and_run_once(
 #[allow(clippy::too_many_arguments)]
 fn read_event_loop(
     registry: Arc<FileRegistry>,
-    mut socket: tungstenite::WebSocket<MaybeTlsStream<std::net::TcpStream>>,
+    mut socket: tungstenite::WebSocket<MaybeTlsStream<TcpStream>>,
     shutdown: Arc<AtomicBool>,
     bitcoin_rpc: Arc<BitcoinRest>,
     relay_url: &str,

--- a/src/watch_tower/service.rs
+++ b/src/watch_tower/service.rs
@@ -107,7 +107,7 @@ pub fn start_maker_watch_service(
     // Watcher
     let rpc_config_watcher = rpc_config.clone();
     let mut watcher =
-        Watcher::<MakerRole>::new(backend, registry, rx_requests, tx_events, Vec::new());
+        Watcher::<MakerRole>::new(backend, registry, rx_requests, tx_events, Vec::new(), None);
 
     // Makers don't run discovery, so pass an already-complete flag.
     thread::Builder::new()

--- a/src/watch_tower/watcher.rs
+++ b/src/watch_tower/watcher.rs
@@ -161,9 +161,6 @@ impl<R: Role> Watcher<R> {
                             log::error!("Discovery thread failed: {:?}", e);
                         }
                     });
-                } else {
-                    log::warn!("Nostr discovery skipped: Tor config not provided");
-                    initial_sync_complete.store(true, Ordering::SeqCst);
                 }
             } else {
                 // No discovery — mark initial sync as trivially complete.

--- a/src/watch_tower/watcher.rs
+++ b/src/watch_tower/watcher.rs
@@ -40,6 +40,7 @@ pub struct Watcher<R: Role> {
     rx_requests: StdReceiver<WatcherCommand>,
     tx_events: CbSender<WatcherEvent>,
     nostr_relays: Vec<String>,
+    nostr_tor_config: Option<(u16, String)>,
     _role: PhantomData<R>,
 }
 
@@ -94,6 +95,7 @@ impl<R: Role> Watcher<R> {
         rx_requests: StdReceiver<WatcherCommand>,
         tx_events: CbSender<WatcherEvent>,
         nostr_relays: Vec<String>,
+        nostr_tor_config: Option<(u16, String)>,
     ) -> Self {
         Self {
             backend,
@@ -101,6 +103,7 @@ impl<R: Role> Watcher<R> {
             rx_requests,
             tx_events,
             nostr_relays,
+            nostr_tor_config,
             _role: PhantomData,
         }
     }
@@ -139,22 +142,29 @@ impl<R: Role> Watcher<R> {
         let discovery_shutdown = Arc::new(AtomicBool::new(false));
         let registry = self.registry.clone();
         let nostr_relays = self.nostr_relays.clone();
+        let nostr_tor_config = self.nostr_tor_config.clone();
         std::thread::scope(move |s| {
             let discovery_clone = discovery_shutdown.clone();
             if R::RUN_DISCOVERY {
                 let initial_sync_complete = initial_sync_complete.clone();
-                s.spawn(move || {
-                    if let Err(e) = nostr_discovery::run_discovery(
-                        rest_backend_1,
-                        network,
-                        registry,
-                        discovery_shutdown.clone(),
-                        initial_sync_complete,
-                        &nostr_relays,
-                    ) {
-                        log::error!("Discovery thread failed: {:?}", e);
-                    }
-                });
+                if let Some(nostr_tor_config) = nostr_tor_config {
+                    s.spawn(move || {
+                        if let Err(e) = nostr_discovery::run_discovery(
+                            rest_backend_1,
+                            network,
+                            registry,
+                            discovery_shutdown.clone(),
+                            initial_sync_complete,
+                            &nostr_relays,
+                            nostr_tor_config,
+                        ) {
+                            log::error!("Discovery thread failed: {:?}", e);
+                        }
+                    });
+                } else {
+                    log::warn!("Nostr discovery skipped: Tor config not provided");
+                    initial_sync_complete.store(true, Ordering::SeqCst);
+                }
             } else {
                 // No discovery — mark initial sync as trivially complete.
                 initial_sync_complete.store(true, Ordering::SeqCst);


### PR DESCRIPTION
# Pull Request

## Description

## Related Issue(s)
Fixes #696

<!-- Add multiple lines if this PR closes multiple issues -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [x] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [x] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [x] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [x] All unit tests pass (`cargo test`)
- [x] Integration tests pass (`cargo test --features integration-test`)
- [x] Changes were manually tested on **signet**
- [x] End-to-end maker ↔ taker swap tested (where applicable)
- [x] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

## How to Test
<!-- Step-by-step instructions so reviewers can verify quickly. -->

```bash
# Standard swap (good baseline)
cargo test --test standard_swap --features integration-test -- --nocapture

# Abort scenarios
cargo test --test abort1 --features integration-test -- --nocapture
cargo test --test taproot_taker_abort1 --features integration-test -- --nocapture

# Malicious behavior & recovery
cargo test --test malice1 --features integration-test -- --nocapture
cargo test --test taproot_timelock_recovery --features integration-test -- --nocapture

# Or run the full suite
cargo test --features integration-test
```

<!-- Add any additional manual steps specific to this PR
     (e.g. regtest node config, docker-setup, specific taker commands): -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tor/SOCKS5 proxy support with optional authentication for Nostr relay connections.
  * More robust WebSocket handling: explicit TLS validation, TCP read/write timeouts, and relay connection retries.
  * Nostr discovery and relay sessions can be routed through Tor where configured.

* **Bug Fixes**
  * Startup validation ensures wallet/network settings and runtime config are consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->