### PR TITLE
fix: Reject swaps that exceed maker's active liquidity

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -1030,8 +1030,52 @@ impl MakerTrait for MakerServer {
         Ok(())
     }
 
-    fn store_connection_state(&self, swap_id: &str, state: &ConnectionState) {
-        let mut swaps = self.ongoing_swaps.lock().unwrap();
+    fn store_connection_state(
+        &self,
+        swap_id: &str,
+        state: &ConnectionState,
+    ) -> Result<(), MakerError> {
+        let should_check_liquidity = {
+            let swaps = self.ongoing_swaps.lock()?;
+            !swaps.contains_key(swap_id)
+        };
+
+        let swap_liquidity = if should_check_liquidity {
+            let wallet = self
+                .wallet
+                .read()
+                .map_err(|_| MakerError::General("Failed to lock wallet"))?;
+            let balances = wallet.get_balances().map_err(MakerError::Wallet)?;
+            Some(balances.regular + balances.swap)
+        } else {
+            None
+        };
+
+        let mut swaps = self.ongoing_swaps.lock()?;
+        if let Some(swap_liquidity) = swap_liquidity.filter(|_| !swaps.contains_key(swap_id)) {
+            let reserved_liquidity = swaps
+                .values()
+                .filter(|state| state.phase != SwapPhase::Completed)
+                .fold(Amount::ZERO, |total, state| total + state.swap_amount);
+            let required_liquidity = reserved_liquidity + state.swap_amount;
+
+            if swap_liquidity < required_liquidity {
+                log::warn!(
+                    "[{}] Rejecting swap {}: available liquidity {}, active reservations {}, requested {}",
+                    self.config.network_port,
+                    swap_id,
+                    swap_liquidity,
+                    reserved_liquidity,
+                    state.swap_amount,
+                );
+                return Err(MakerError::InsufficientLiquidity {
+                    available: swap_liquidity,
+                    reserved: reserved_liquidity,
+                    requested: state.swap_amount,
+                });
+            }
+        }
+
         let swap_state = swaps.entry(swap_id.to_string()).or_default();
         swap_state.swap_amount = state.swap_amount;
         swap_state.timelock = state.timelock;
@@ -1053,6 +1097,8 @@ impl MakerTrait for MakerServer {
             state.protocol,
             state.outgoing_swapcoins.len()
         );
+
+        Ok(())
     }
 
     fn get_connection_state(&self, swap_id: &str) -> Option<ConnectionState> {

--- a/src/maker/error.rs
+++ b/src/maker/error.rs
@@ -2,7 +2,7 @@
 
 use std::sync::{MutexGuard, PoisonError, RwLockReadGuard, RwLockWriteGuard};
 
-use bitcoin::secp256k1;
+use bitcoin::{secp256k1, Amount};
 
 use crate::{
     error::NetError, protocol::error::ProtocolError, utill::TorError, wallet::WalletError,
@@ -30,6 +30,15 @@ pub enum MakerError {
     },
     /// Represents a general error with a static message.
     General(&'static str),
+    /// Represents a maker-side liquidity rejection for a new swap.
+    InsufficientLiquidity {
+        /// Currently spendable swap liquidity.
+        available: Amount,
+        /// Liquidity already reserved by active swaps.
+        reserved: Amount,
+        /// Liquidity requested by the new swap.
+        requested: Amount,
+    },
     /// Represents a mutex poisoning error.
     MutexPossion,
     /// Represents an error related to secp256k1 operations.

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -234,7 +234,11 @@ pub trait Maker: Send + Sync {
     fn sweep_incoming_swapcoins(&self) -> Result<(), MakerError>;
 
     /// Store connection state for persistence across connections.
-    fn store_connection_state(&self, swap_id: &str, state: &ConnectionState);
+    fn store_connection_state(
+        &self,
+        swap_id: &str,
+        state: &ConnectionState,
+    ) -> Result<(), MakerError>;
 
     /// Retrieve stored connection state.
     fn get_connection_state(&self, swap_id: &str) -> Option<ConnectionState>;
@@ -468,7 +472,7 @@ fn handle_swap_details<M: Maker>(
     state.protocol = details.protocol_version;
     state.phase = SwapPhase::AwaitingContractData;
 
-    maker.store_connection_state(&details.id, state);
+    maker.store_connection_state(&details.id, state)?;
 
     let (_, tweakable_point) = maker.get_tweakable_keypair()?;
 

--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -103,7 +103,7 @@ fn process_req_contract_sigs_for_sender<M: Maker>(
     );
 
     // Store connection state for persistence
-    maker.store_connection_state(&req.id, state);
+    maker.store_connection_state(&req.id, state)?;
 
     let response = crate::protocol::legacy_messages::RespContractSigsForSender { id: req.id, sigs };
 
@@ -342,7 +342,7 @@ fn process_proof_of_funding<M: Maker>(
     }
 
     state.phase = SwapPhase::AwaitingSignaturesOrPreimage;
-    maker.store_connection_state(&pof.id, state);
+    maker.store_connection_state(&pof.id, state)?;
 
     log::info!(
         "[{}] Created {} outgoing swapcoins, requesting signatures",
@@ -446,7 +446,7 @@ fn process_resp_contract_sigs_for_recvr_and_sender<M: Maker>(
             for outgoing in &state.outgoing_swapcoins {
                 maker.save_outgoing_swapcoin(outgoing)?;
             }
-            maker.store_connection_state(&resp.id, state);
+            maker.store_connection_state(&resp.id, state)?;
             return Err(MakerError::General("Test: skipped funding broadcast"));
         }
     }
@@ -489,7 +489,7 @@ fn process_resp_contract_sigs_for_recvr_and_sender<M: Maker>(
         }
     }
 
-    maker.store_connection_state(&resp.id, state);
+    maker.store_connection_state(&resp.id, state)?;
 
     #[cfg(feature = "integration-test")]
     {

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -262,7 +262,7 @@ fn process_taproot_contract<M: Maker>(
             state.phase = SwapPhase::AwaitingPrivateKeyHandover;
             maker.save_incoming_swapcoin(&incoming_swapcoin)?;
             maker.save_outgoing_swapcoin(&outgoing_swapcoin)?;
-            maker.store_connection_state(&data.id, state);
+            maker.store_connection_state(&data.id, state)?;
             return Err(MakerError::General("Test: skipped funding broadcast"));
         }
     }
@@ -295,7 +295,7 @@ fn process_taproot_contract<M: Maker>(
     maker.save_incoming_swapcoin(&incoming_swapcoin)?;
     maker.save_outgoing_swapcoin(&outgoing_swapcoin)?;
 
-    maker.store_connection_state(&data.id, state);
+    maker.store_connection_state(&data.id, state)?;
 
     #[cfg(feature = "integration-test")]
     {

--- a/tests/integration/concurrent_takers.rs
+++ b/tests/integration/concurrent_takers.rs
@@ -66,7 +66,7 @@ fn test_concurrent_takers_legacy() {
         &makers,
         bitcoind,
         2,
-        Amount::from_btc(0.05).unwrap(),
+        Amount::from_btc(0.03).unwrap(),
         AddressType::P2TR,
     );
 
@@ -153,7 +153,7 @@ fn test_concurrent_takers_legacy() {
 
         s.spawn(move || {
             info!("Taker 2 starting concurrent coinswap");
-            let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500000), 2)
+            let swap_params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(900000), 2)
                 .with_tx_count(3)
                 .with_required_confirms(1);
 
@@ -193,6 +193,8 @@ fn test_concurrent_takers_legacy() {
     // With limited liquidity, we expect one to succeed and one to fail
     // The UTXO reservation mechanism prevents double-spend of maker UTXOs
     assert!(success_count >= 1, "At least one taker should succeed");
+    let log_path = format!("{}/taker/debug.log", test_framework.temp_dir.display());
+    test_framework.assert_log("Rejecting swap ", &log_path);
     assert_eq!(
         completed_count, 2,
         "Both takers should have completed (success or failure)"

--- a/tests/integration/taproot_concurrent_takers.rs
+++ b/tests/integration/taproot_concurrent_takers.rs
@@ -66,7 +66,7 @@ fn test_concurrent_takers_taproot() {
         &makers,
         bitcoind,
         2,
-        Amount::from_btc(0.05).unwrap(),
+        Amount::from_btc(0.03).unwrap(),
         AddressType::P2TR,
     );
 
@@ -155,7 +155,7 @@ fn test_concurrent_takers_taproot() {
         s.spawn(move || {
             info!("Taker 2 starting concurrent Taproot coinswap");
             let swap_params =
-                SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500000), 2)
+                SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(900000), 2)
                     .with_tx_count(3)
                     .with_required_confirms(1);
 
@@ -195,6 +195,8 @@ fn test_concurrent_takers_taproot() {
     // With limited liquidity, we expect one to succeed and one to fail
     // The UTXO reservation mechanism prevents double-spend of maker UTXOs
     assert!(success_count >= 1, "At least one taker should succeed");
+    let log_path = format!("{}/taker/debug.log", test_framework.temp_dir.display());
+    test_framework.assert_log("Rejecting swap ", &log_path);
     assert_eq!(
         completed_count, 2,
         "Both takers should have completed (success or failure)"


### PR DESCRIPTION
# Pull Request

## Description
Checks if maker has an ongoing swap, if yes then check that the maker have enough liquidity to accept another swap, if enough liquidity is not present, it rejects that particular offer.

```
2026-05-04T01:08:31.990476+05:30 INFO coinswap::maker::server - [6104] New connection from 127.0.0.1:57379
2026-05-04T01:08:32.190592+05:30 INFO coinswap::maker::server - [6104] New connection from 127.0.0.1:57380
2026-05-04T01:08:32.502638+05:30 INFO coinswap::maker::handlers - [6104] Received TakerHello
2026-05-04T01:08:32.502652+05:30 INFO coinswap::maker::handlers - [6104] Supported protocols: [Legacy, Taproot]
2026-05-04T01:08:32.783954+05:30 INFO coinswap::maker::handlers - [6104] Received TakerHello
2026-05-04T01:08:32.783967+05:30 INFO coinswap::maker::handlers - [6104] Supported protocols: [Legacy, Taproot]
2026-05-04T01:08:33.327753+05:30 INFO coinswap::maker::handlers - [6104] Received GetOffer request
2026-05-04T01:08:33.328503+05:30 INFO coinswap::maker::handlers - [6104] Sending offer: min=10000, max=9989534
2026-05-04T01:08:33.626042+05:30 INFO coinswap::maker::handlers - [6104] Received GetOffer request
2026-05-04T01:08:33.626758+05:30 INFO coinswap::maker::handlers - [6104] Sending offer: min=10000, max=9989534
2026-05-04T01:08:34.213696+05:30 INFO coinswap::maker::handlers - [6104] Received SwapDetails: amount=0.07998784 BTC, timelock=5837, protocol=Taproot
2026-05-04T01:08:34.214428+05:30 INFO coinswap::maker::handlers - [6104] Accepting swap (id: e1573e45fca999c0)
2026-05-04T01:08:34.508183+05:30 INFO coinswap::maker::handlers - [6104] Received SwapDetails: amount=0.07899084 BTC, timelock=5837, protocol=Taproot
2026-05-04T01:08:34.508210+05:30 WARN coinswap::maker::api - [6104] Rejecting swap 25015b21e9d14163: available liquidity 0.09989534 BTC, active reservations 0.07998784 BTC, requested 0.07899084 BTC
2026-05-04T01:08:34.508219+05:30 ERROR coinswap::maker::server - [6104] Handler error: General("Not enough liquidity for this swap amount")
```

## Related Issue(s)
Fixes #860 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [x] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [x] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [x] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [x] All unit tests pass (`cargo test`)
- [x] Integration tests pass (`cargo test --features integration-test`)
- [x] Changes were manually tested on **signet**
- [x] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added liquidity validation to reject swap requests when available funds are insufficient.
  * Exposes a clear "insufficient liquidity" error with available/reserved/requested amounts.

* **Bug Fixes**
  * Persistence of connection/swap state now correctly aborts operations on failure instead of silently continuing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->