### PR TITLE
minor fixes around modules

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -622,8 +622,7 @@ impl MakerServer {
                         }
                     }
                     Ok((index, txid)) => {
-                        // Wait for confirmation WITHOUT holding the wallet lock,
-                        // so other operations (swaps, balance reads, etc.) aren't blocked.
+                        // Wait for confirmation without holding the write lock.
                         log::info!(
                             "[{}] Fidelity bond broadcast, waiting for confirmation: {}",
                             self.config.network_port,
@@ -633,7 +632,7 @@ impl MakerServer {
                             .wallet
                             .read()
                             .map_err(|_| MakerError::General("Failed to lock wallet"))?
-                            .wait_for_tx_confirmation(txid, Some(&self.shutdown))
+                            .wait_for_tx_confirmation(&[txid], 1, Some(&self.shutdown), None)
                             .map_err(MakerError::Wallet)?;
 
                         // Re-acquire write lock briefly to finalize

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -1723,13 +1723,6 @@ impl Taker {
             txids.len()
         );
 
-        let start = Instant::now();
-        let timeout = if cfg!(feature = "integration-test") {
-            Duration::from_secs(120)
-        } else {
-            Duration::from_secs(600)
-        };
-
         loop {
             let mut all_confirmed = true;
             let mut max_confirm_height: u32 = 0;
@@ -1779,10 +1772,6 @@ impl Taker {
                     log::warn!("Breach detected by background detector — aborting wait");
                     return Err(TakerError::ContractsBroadcasted(vec![]));
                 }
-            }
-
-            if start.elapsed() > timeout {
-                return Err(TakerError::FundingTxWaitTimeOut);
             }
 
             thread::sleep(Duration::from_secs(5));

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -24,7 +24,7 @@ use bitcoin::{
         rand::{rngs::OsRng, RngCore},
         SecretKey,
     },
-    Amount, OutPoint, PublicKey, Txid,
+    Amount, OutPoint, PublicKey,
 };
 use bitcoind::bitcoincore_rpc::{json::ListUnspentResultEntry, RpcApi};
 use socks::Socks5Stream;
@@ -1699,83 +1699,6 @@ impl Taker {
             .map_err(|e| TakerError::General(format!("Failed to set socket timeout: {}", e)))?;
 
         Ok(socket)
-    }
-
-    /// Wait for transactions to reach the required number of confirmations.
-    ///
-    /// Returns the highest block height at which any of the transactions was
-    /// confirmed (i.e. `current_height - confirmations + 1`). Returns 0 if
-    /// `required_confirms` is 0 or `txids` is empty.
-    #[hotpath::measure]
-    pub(crate) fn net_wait_for_confirmation(
-        &self,
-        txids: &[Txid],
-        breach_detector: Option<&BreachDetector>,
-    ) -> Result<u32, TakerError> {
-        let required_confirms = self.swap_state()?.params.required_confirms;
-        if required_confirms == 0 || txids.is_empty() {
-            return Ok(0);
-        }
-
-        log::info!(
-            "Waiting for {} confirmation(s) on {} transaction(s)...",
-            required_confirms,
-            txids.len()
-        );
-
-        loop {
-            let mut all_confirmed = true;
-            let mut max_confirm_height: u32 = 0;
-
-            {
-                let wallet = self.read_wallet()?;
-                let current_height = wallet.rpc.get_block_count().map_err(|e| {
-                    TakerError::General(format!("Failed to get block count: {:?}", e))
-                })? as u32;
-                for txid in txids {
-                    match wallet.rpc.get_raw_transaction_info(txid, None) {
-                        Ok(tx_info) => {
-                            let confirms = tx_info.confirmations.unwrap_or(0);
-                            if confirms < required_confirms {
-                                log::debug!(
-                                    "Tx {} has {} confirmations (need {})",
-                                    txid,
-                                    confirms,
-                                    required_confirms
-                                );
-                                all_confirmed = false;
-                            } else {
-                                // confirmation height = current - confirms + 1
-                                let confirm_height = current_height.saturating_sub(confirms) + 1;
-                                max_confirm_height = max_confirm_height.max(confirm_height);
-                            }
-                        }
-                        Err(e) => {
-                            log::debug!("Error getting tx info for {}: {:?}", txid, e);
-                            all_confirmed = false;
-                        }
-                    }
-                }
-            }
-
-            if all_confirmed {
-                log::info!(
-                    "All transactions confirmed (latest at height {})",
-                    max_confirm_height
-                );
-                return Ok(max_confirm_height);
-            }
-
-            // Check for adversarial contract activity via the background detector thread.
-            if let Some(detector) = breach_detector {
-                if detector.is_breached() {
-                    log::warn!("Breach detected by background detector — aborting wait");
-                    return Err(TakerError::ContractsBroadcasted(vec![]));
-                }
-            }
-
-            thread::sleep(Duration::from_secs(5));
-        }
     }
 
     /// Finalize the swap by exchanging private keys with all makers.

--- a/src/taker/error.rs
+++ b/src/taker/error.rs
@@ -24,8 +24,6 @@ pub enum TakerError {
     Net(NetError),
     /// Error indicating the send amount was not set for a transaction.
     SendAmountNotSet,
-    /// Error indicating a timeout while waiting for the funding transaction.
-    FundingTxWaitTimeOut,
     /// Error deserializing data, typically related to CBOR-encoded data.
     Deserialize(String),
     /// Error indicating an MPSC channel failure.

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -311,7 +311,16 @@ impl Taker {
                     .iter()
                     .filter_map(|sc| sc.funding_tx.as_ref().map(|tx| tx.compute_txid()))
                     .collect();
-                prev_confirm_height = self.net_wait_for_confirmation(&funding_txids, None)?;
+                let required_confirms = self.swap_state()?.params.required_confirms;
+                prev_confirm_height = {
+                    let wallet = self.read_wallet()?;
+                    wallet.wait_for_tx_confirmation(
+                        &funding_txids,
+                        required_confirms,
+                        None,
+                        None,
+                    )?
+                };
                 _taker_funding_confirmed = true;
                 self.swap_state_mut()?.makers[maker_idx]
                     .legacy_exchange_mut()?
@@ -608,8 +617,27 @@ impl Taker {
                 .map(|i| i.funding_tx.compute_txid())
                 .collect();
 
-            let maker_confirm_height = self
-                .net_wait_for_confirmation(&maker_funding_txids, self.breach_detector.as_ref())?;
+            let required_confirms = self.swap_state()?.params.required_confirms;
+            let abort_check = || {
+                self.breach_detector
+                    .as_ref()
+                    .is_some_and(|d| d.is_breached())
+            };
+            let maker_confirm_height = {
+                let wallet = self.read_wallet()?;
+                match wallet.wait_for_tx_confirmation(
+                    &maker_funding_txids,
+                    required_confirms,
+                    None,
+                    Some(&abort_check),
+                ) {
+                    Ok(h) => h,
+                    Err(crate::wallet::WalletError::Interrupted(_)) => {
+                        return Err(TakerError::ContractsBroadcasted(vec![]));
+                    }
+                    Err(e) => return Err(e.into()),
+                }
+            };
 
             // Verify that the maker's funding confirmed within a few blocks of the
             // previous hop. For legacy (CSV relative locktime), a large gap between

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -568,7 +568,11 @@ impl Taker {
             .iter()
             .map(|sc| sc.contract_tx.compute_txid())
             .collect();
-        self.net_wait_for_confirmation(&contract_txids, None)?;
+        let required_confirms = self.swap_state()?.params.required_confirms;
+        {
+            let wallet = self.read_wallet()?;
+            wallet.wait_for_tx_confirmation(&contract_txids, required_confirms, None, None)?;
+        }
 
         log::info!("Contract transactions broadcast and confirmed");
         Ok(())

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -2589,7 +2589,8 @@ impl Wallet {
                 Ok(spend_tx) => {
                     match self.send_tx(&spend_tx) {
                         Ok(txid) => {
-                            let conf_height = self.wait_for_tx_confirmation(txid, None)?;
+                            let conf_height =
+                                self.wait_for_tx_confirmation(&[txid], 1, None, None)?;
                             log::info!(
                                 "Sweep transaction {} confirmed at blockheight: {}",
                                 txid,
@@ -2631,44 +2632,99 @@ impl Wallet {
         Ok(outcome)
     }
 
-    /// Waits for a transaction to confirm and returns its block height.
+    /// Wait for one or more transactions to reach the required number of confirmations.
     ///
-    /// If a `shutdown` flag is provided, the wait is interrupted when it becomes `true`,
-    /// returning `WalletError::General` instead of blocking indefinitely.
+    /// Returns the highest block height at which any of the transactions was confirmed
+    /// (i.e. `current_height - confirmations + 1`). Returns 0 if `required_confirms` is 0
+    /// or `txids` is empty.
+    ///
+    /// If a `shutdown` flag is provided, the wait is interrupted when it becomes `true`.
+    /// If an `abort_check` is provided, it is polled during the wait; if it returns `true`,
+    /// the wait is interrupted.
     #[hotpath::measure]
     pub fn wait_for_tx_confirmation(
         &self,
-        txid: Txid,
+        txids: &[Txid],
+        required_confirms: u32,
         shutdown: Option<&std::sync::atomic::AtomicBool>,
+        abort_check: Option<&dyn Fn() -> bool>,
     ) -> Result<u32, WalletError> {
-        let sleep_increment = 10;
-        let mut sleep_multiplier = 0;
+        if required_confirms == 0 || txids.is_empty() {
+            return Ok(0);
+        }
 
-        let ht = loop {
+        log::info!(
+            "Waiting for {} confirmation(s) on {} transaction(s)...",
+            required_confirms,
+            txids.len()
+        );
+
+        // cap at ~1 block interval
+        let max_backoff_secs: u64 = 600;
+        let sleep_increment_secs: u64 = 10;
+        let mut attempt: u64 = 0;
+
+        loop {
             if shutdown.is_some_and(|s| s.load(std::sync::atomic::Ordering::Relaxed)) {
-                return Err(WalletError::General("Shutdown requested".to_string()));
+                return Err(WalletError::Interrupted("Shutdown requested"));
+            }
+            if abort_check.is_some_and(|f| f()) {
+                return Err(WalletError::Interrupted("Abort requested"));
             }
 
-            sleep_multiplier += 1;
+            attempt = attempt.saturating_add(1);
 
-            let get_tx_result = self.rpc.get_transaction(&txid, None)?;
-            if let Some(ht) = get_tx_result.info.blockheight {
-                log::info!("Transaction confirmed at blockheight: {ht}, txid : {txid}");
-                break ht;
-            } else {
-                log::info!("Transaction seen in mempool,waiting for confirmation, txid: {txid}");
-                let total_sleep = sleep_increment * sleep_multiplier.min(10 * 60); // Caps at 10 minutes
-                log::info!("Next sync in {total_sleep:?} secs");
-                // Sleep in 1-second increments so we can check the shutdown flag
-                for _ in 0..total_sleep {
-                    if shutdown.is_some_and(|s| s.load(std::sync::atomic::Ordering::Relaxed)) {
-                        return Err(WalletError::General("Shutdown requested".to_string()));
+            let mut all_confirmed = true;
+            let mut max_confirm_height: u32 = 0;
+
+            let current_height = self.rpc.get_block_count()? as u32;
+            for txid in txids {
+                match self.rpc.get_raw_transaction_info(txid, None) {
+                    Ok(tx_info) => {
+                        let confirms: u32 = tx_info.confirmations.unwrap_or(0);
+                        if confirms < required_confirms {
+                            log::debug!(
+                                "Tx {} has {} confirmations (need {})",
+                                txid,
+                                confirms,
+                                required_confirms
+                            );
+                            all_confirmed = false;
+                        } else {
+                            let confirm_height = current_height.saturating_sub(confirms) + 1;
+                            max_confirm_height = max_confirm_height.max(confirm_height);
+                        }
                     }
-                    thread::sleep(Duration::from_secs(1));
+                    Err(e) => {
+                        log::debug!("Error getting tx info for {}: {:?}", txid, e);
+                        all_confirmed = false;
+                    }
                 }
             }
-        };
 
-        Ok(ht)
+            if all_confirmed {
+                log::info!(
+                    "All transactions confirmed (latest at height {})",
+                    max_confirm_height
+                );
+                return Ok(max_confirm_height);
+            }
+
+            let total_sleep = sleep_increment_secs
+                .saturating_mul(attempt)
+                .min(max_backoff_secs);
+            log::info!("Next sync in {} secs", total_sleep);
+
+            // Sleep in 1-second increments so we can check shutdown/abort.
+            for _ in 0..total_sleep {
+                if shutdown.is_some_and(|s| s.load(std::sync::atomic::Ordering::Relaxed)) {
+                    return Err(WalletError::Interrupted("Shutdown requested"));
+                }
+                if abort_check.is_some_and(|f| f()) {
+                    return Err(WalletError::Interrupted("Abort requested"));
+                }
+                thread::sleep(Duration::from_secs(1));
+            }
+        }
     }
 }

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -45,6 +45,9 @@ pub enum WalletError {
     /// Use this variant for errors that do not fall under any specific category.
     General(String),
 
+    /// Waiting was interrupted by an external signal (shutdown/abort).
+    Interrupted(&'static str),
+
     /// Represents an invalid Merkle proof for a transaction.
     ///
     /// `got` contains the txids returned by `verifytxoutproof`, which may be
@@ -216,6 +219,7 @@ impl std::fmt::Display for WalletError {
             WalletError::BIP32(e) => write!(f, "BIP32 error: {}", e),
             WalletError::BIP39(e) => write!(f, "BIP39 error: {}", e),
             WalletError::General(msg) => write!(f, "{}", msg),
+            WalletError::Interrupted(reason) => write!(f, "Interrupted: {}", reason),
             WalletError::MerkleProofInvalid { expected, got } => {
                 write!(
                     f,

--- a/src/watch_tower/nostr_discovery.rs
+++ b/src/watch_tower/nostr_discovery.rs
@@ -207,7 +207,10 @@ fn read_event_loop(
                 continue;
             }
             Err(tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed) => {
-                return Ok(());
+                if shutdown.load(Ordering::SeqCst) {
+                    return Ok(());
+                }
+                return Err(tungstenite::Error::ConnectionClosed.into());
             }
             Err(e) => return Err(e.into()),
         };

--- a/src/watch_tower/nostr_discovery.rs
+++ b/src/watch_tower/nostr_discovery.rs
@@ -194,7 +194,23 @@ fn read_event_loop(
     initial_sync_complete: &Arc<AtomicBool>,
 ) -> Result<(), WatcherError> {
     while !shutdown.load(Ordering::SeqCst) {
-        let msg = socket.read()?;
+        let msg = match socket.read() {
+            Ok(msg) => msg,
+            Err(tungstenite::Error::Io(e))
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::WouldBlock
+                        | std::io::ErrorKind::TimedOut
+                        | std::io::ErrorKind::Interrupted
+                ) =>
+            {
+                continue;
+            }
+            Err(tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed) => {
+                return Ok(());
+            }
+            Err(e) => return Err(e.into()),
+        };
 
         let text = match msg {
             Message::Text(t) => t,

--- a/src/watch_tower/watcher.rs
+++ b/src/watch_tower/watcher.rs
@@ -10,6 +10,7 @@ use std::{
         mpsc::{Receiver as StdReceiver, TryRecvError},
         Arc,
     },
+    time::Duration,
 };
 
 use bitcoin::{consensus::deserialize, Block, Network, OutPoint, Transaction};
@@ -182,6 +183,9 @@ impl<R: Role> Watcher<R> {
 
                 if let Some(event) = self.backend.poll() {
                     self.handle_event(event);
+                } else {
+                    // Avoid busy-looping when there are no commands and no ZMQ events.
+                    std::thread::sleep(Duration::from_millis(5));
                 }
             }
         });

--- a/tests/integration/fidelity.rs
+++ b/tests/integration/fidelity.rs
@@ -146,7 +146,7 @@ fn test_fidelity() {
             .wallet
             .read()
             .unwrap()
-            .wait_for_tx_confirmation(txid, None)
+            .wait_for_tx_confirmation(&[txid], 1, None, None)
             .unwrap();
         maker
             .wallet
@@ -311,7 +311,7 @@ fn test_fidelity_spending() {
             .wallet
             .read()
             .unwrap()
-            .wait_for_tx_confirmation(txid, None)
+            .wait_for_tx_confirmation(&[txid], 1, None, None)
             .unwrap();
         maker
             .wallet
@@ -515,7 +515,7 @@ fn test_fidelity_spending() {
             .wallet
             .read()
             .unwrap()
-            .wait_for_tx_confirmation(txid, None)
+            .wait_for_tx_confirmation(&[txid], 1, None, None)
             .unwrap();
         maker
             .wallet


### PR DESCRIPTION
# Pull Request

## Description
Fixes small bugs -:
1-) removed `timeout` from `net_wait_for_confirmation` api. as generally most of the blocks are not mined under 10min, so wait until the txn is confirmed. 
2-) Currently while testing on signet i was getting a lot of WouldBlock spam from nostr relay response, i.e.
```rust
2026-05-04T00:04:48.302868+05:30 WARN coinswap::watch_tower::nostr_discovery - Nostr session error on wss://relay.damus.io: WebSocket(Io(Os { code: 35, kind: WouldBlock, message: "Resource temporarily unavailable" })), retrying in 5s
2026-05-04T00:04:52.673107+05:30 WARN coinswap::watch_tower::nostr_discovery - Nostr session error on wss://nos.lol: WebSocket(Io(Os { code: 35, kind: WouldBlock, message: "Resource temporarily unavailable" })), retrying in 5s
```
Now, In `read_event_loop`, WouldBlock / TimedOut / Interrupted are now treated as non-fatal (continue loop), to avoid reconnections.

3-) Currently in a typical swap, we have a lot of calls to `zmq::poll` && `zmq::recv_event`, so I added a small idle backoff in the watcher loop.
Changes in Profiling-:
```rust
Earlier
coinswap::watch_tower::zmq_backend::poll                                         114548537    1218.59 s     10.64 µs     16.05 µs    97.12%
coinswap::watch_tower::zmq_backend::recv_event                                   114548537    1168.99 s     10.21 µs     15.46 µs    93.17%

Now
Current
coinswap::watch_tower::zmq_backend::poll                                           67661       2.51 s     37.10 µs     62.11 µs     0.60%
coinswap::watch_tower::zmq_backend::recv_event                                     67662       2.14 s     31.60 µs     45.57 µs     0.51%
```
## Related Issue(s)
Closes #<!-- replace with issue number if applicable -->
<!-- Add multiple lines if this PR closes multiple issues -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [x] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [x] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [x] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [x] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [ ] All unit tests pass (`cargo test`)
- [ ] Integration tests pass (`cargo test --features integration-test`)
- [ ] Changes were manually tested on **regtest**
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Longer non-test transaction confirmation timeout to reduce false timeouts.
  * Treat transient WebSocket I/O errors as recoverable to keep discovery/monitoring running.
  * Add brief idle sleep in the watcher loop to lower CPU usage when idle.

* **Reliability / UX**
  * Confirmation waiting now uses a wallet-backed, multi-transaction waiter with interrupt/abort support and clearer interruption reporting.

* **Tests**
  * Integration tests updated to match the new confirmation-wait behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/citadel-tech/coinswap/pull/863)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->