### PR TITLE
remove .onion postfix from tor addresses in OP_RETURN

### DIFF
--- a/src/wallet/fidelity.rs
+++ b/src/wallet/fidelity.rs
@@ -579,6 +579,7 @@ impl Wallet {
             }
         };
 
+        let onion = onion.strip_suffix(".onion").unwrap_or(onion);
         let payload = format!("{onion}#{locktime_height}");
         Ok(payload.into_bytes().into_boxed_slice())
     }

--- a/src/watch_tower/utils.rs
+++ b/src/watch_tower/utils.rs
@@ -52,8 +52,12 @@ fn extract_op_return_data(script: &[u8]) -> Option<&[u8]> {
 }
 
 #[cfg(not(feature = "integration-test"))]
-fn is_valid_onion_address(s: &str) -> bool {
-    s.ends_with(".onion") && s.len() > ".onion".len()
+fn normalize_onion_address(s: &str) -> Option<String> {
+    let onion = s.strip_suffix(".onion").unwrap_or(s);
+    if onion.is_empty() || onion.contains('.') {
+        return None;
+    }
+    Some(format!("{onion}.onion"))
 }
 
 #[cfg(feature = "integration-test")]
@@ -83,17 +87,20 @@ fn parse_fidelity_op_return(data: &[u8]) -> Option<FidelityAnnouncement> {
     let expires_at_height = locktime_str.parse::<u32>().ok()?;
 
     #[cfg(not(feature = "integration-test"))]
-    if !is_valid_onion_address(endpoint) {
-        return None;
+    let onion = normalize_onion_address(endpoint)?;
+
+    #[cfg(feature = "integration-test")]
+    {
+        if !is_valid_address(endpoint) {
+            return None;
+        }
     }
 
     #[cfg(feature = "integration-test")]
-    if !is_valid_address(endpoint) {
-        return None;
-    }
+    let onion = endpoint.to_string();
 
     Some(FidelityAnnouncement {
-        onion: endpoint.to_string(),
+        onion,
         expires_at_height,
     })
 }
@@ -211,7 +218,7 @@ mod tests {
     use bitcoind::tempfile::TempDir;
 
     #[cfg(not(feature = "integration-test"))]
-    const TEST_ADDR: &[u8] = b"aslkdfjbiakdsfn.onion#500";
+    const TEST_ADDR: &[u8] = b"aslkdfjbiakdsfn#500";
     #[cfg(feature = "integration-test")]
     const TEST_ADDR: &[u8] = b"127.0.0.1:9050#500";
 
@@ -260,6 +267,24 @@ mod tests {
         assert_eq!(ann.onion, "aslkdfjbiakdsfn.onion");
         #[cfg(feature = "integration-test")]
         assert_eq!(ann.onion, "127.0.0.1:9050");
+        assert_eq!(ann.expires_at_height, 500);
+    }
+
+    #[cfg(not(feature = "integration-test"))]
+    #[test]
+    fn test_process_fidelity_accepts_legacy_onion_suffix() {
+        let tx = tx(
+            500,
+            vec![OutPoint::null()],
+            vec![
+                ScriptBuf::new(),
+                op_return(b"aslkdfjbiakdsfn.onion#500").into(),
+            ],
+        );
+
+        let ann = process_fidelity(&tx).expect("expected valid fidelity announcement");
+
+        assert_eq!(ann.onion, "aslkdfjbiakdsfn.onion");
         assert_eq!(ann.expires_at_height, 500);
     }
 


### PR DESCRIPTION
# Pull Request

## Description
Backward compatible .onion postfix removal from maker's fidelity bond txn's OP_RETURN

## Related Issue(s)
Fixes #851 

<!-- Add multiple lines if this PR closes multiple issues -->

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [ ] I ran `cargo +nightly fmt --all` and committed the result
- [ ] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [ ] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [ ] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ ] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [ ] All unit tests pass (`cargo test`)
- [ ] Integration tests pass (`cargo test --features integration-test`)
- [ ] Changes were manually tested on **regtest**
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

## How to Test
<!-- Step-by-step instructions so reviewers can verify quickly. -->

```bash
# Standard swap (good baseline)
cargo test --test standard_swap --features integration-test -- --nocapture

# Abort scenarios
cargo test --test abort1 --features integration-test -- --nocapture
cargo test --test taproot_taker_abort1 --features integration-test -- --nocapture

# Malicious behavior & recovery
cargo test --test malice1 --features integration-test -- --nocapture
cargo test --test taproot_timelock_recovery --features integration-test -- --nocapture

# Or run the full suite
cargo test --features integration-test
```

<!-- Add any additional manual steps specific to this PR
     (e.g. regtest node config, docker-setup, specific taker commands): -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in onion address handling across wallet and monitoring systems.

* **Tests**
  * Updated tests to verify proper handling of onion addresses in both legacy and current formats.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/citadel-tech/coinswap/pull/866)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->