### PR TITLE
ci: add hotpath profiling && comment ci

### DIFF
--- a/.github/workflows/hotpath-comment.yml
+++ b/.github/workflows/hotpath-comment.yml
@@ -1,0 +1,62 @@
+name: hotpath-comment
+
+on:
+  workflow_run:
+    workflows: ["hotpath-profile"]
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: profile-metrics
+          path: /tmp/metrics/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Install hotpath-utils CLI
+        run: |
+          cargo install hotpath --version 0.15.0 --features utils --bin hotpath-utils --locked
+
+      - name: Post PR comment (maker)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          export GITHUB_BASE_REF=$(cat /tmp/metrics/base_ref.txt)
+          export GITHUB_HEAD_REF=$(cat /tmp/metrics/head_ref.txt)
+          hotpath-utils profile-pr \
+            --head-metrics /tmp/metrics/head_maker.json \
+            --base-metrics /tmp/metrics/base_maker.json \
+            --github-token "$GH_TOKEN" \
+            --pr-number "$(cat /tmp/metrics/pr_number.txt)" \
+            --benchmark-id "maker"
+
+      - name: Post PR comment (taker)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          export GITHUB_BASE_REF=$(cat /tmp/metrics/base_ref.txt)
+          export GITHUB_HEAD_REF=$(cat /tmp/metrics/head_ref.txt)
+          hotpath-utils profile-pr \
+            --head-metrics /tmp/metrics/head_taker.json \
+            --base-metrics /tmp/metrics/base_taker.json \
+            --github-token "$GH_TOKEN" \
+            --pr-number "$(cat /tmp/metrics/pr_number.txt)" \
+            --benchmark-id "taker"

--- a/.github/workflows/hotpath-profile.yml
+++ b/.github/workflows/hotpath-profile.yml
@@ -1,0 +1,79 @@
+name: hotpath-profile
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  profile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Create metrics directory
+        run: mkdir -p /tmp/metrics
+
+      - name: Head benchmark
+        env:
+          BITCOIND_DOWNLOAD_ENDPOINT: https://bitcoincore.org/bin/bitcoin-core-28.1
+          HOTPATH_OUTPUT_FORMAT: json
+          HOTPATH_OUTPUT_PATH: /tmp/head_full.json
+          COINSWAP_HOTPATH_MAKER_OUTPUT_PATH: /tmp/metrics/head_maker.json
+          COINSWAP_HOTPATH_TAKER_OUTPUT_PATH: /tmp/metrics/head_taker.json
+          HOTPATH_METRICS_SERVER_OFF: "1"
+          HOTPATH_FUNCTIONS_LIMIT: "0"
+          HOTPATH_FUNCTIONS_NAME_DEPTH: "0"
+          HOTPATH_THREADS_LIMIT: "0"
+        run: |
+          cargo test --release --test integration hotpath_profile_swap \
+            --features='integration-test hotpath hotpath-alloc' -- --nocapture
+
+      - name: Checkout base
+        run: git checkout ${{ github.event.pull_request.base.sha }}
+
+      - name: Clean build artifacts before base benchmark
+        run: cargo clean
+
+      - name: Base benchmark
+        env:
+          BITCOIND_DOWNLOAD_ENDPOINT: https://bitcoincore.org/bin/bitcoin-core-28.1
+          HOTPATH_OUTPUT_FORMAT: json
+          HOTPATH_OUTPUT_PATH: /tmp/base_full.json
+          COINSWAP_HOTPATH_MAKER_OUTPUT_PATH: /tmp/metrics/base_maker.json
+          COINSWAP_HOTPATH_TAKER_OUTPUT_PATH: /tmp/metrics/base_taker.json
+          HOTPATH_METRICS_SERVER_OFF: "1"
+          HOTPATH_FUNCTIONS_LIMIT: "0"
+          HOTPATH_FUNCTIONS_NAME_DEPTH: "0"
+          HOTPATH_THREADS_LIMIT: "0"
+        run: |
+          cargo test --release --test integration hotpath_profile_swap \
+            --features='integration-test hotpath hotpath-alloc' -- --nocapture
+
+      - name: Save PR metadata
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          echo "$PR_NUMBER" > /tmp/metrics/pr_number.txt
+          echo "$BASE_REF" > /tmp/metrics/base_ref.txt
+          echo "$HEAD_REF" > /tmp/metrics/head_ref.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: profile-metrics
+          path: /tmp/metrics/
+          retention-days: 1

--- a/src/hotpath_local.rs
+++ b/src/hotpath_local.rs
@@ -86,6 +86,12 @@ fn read_json_with_retries(path: &Path) -> std::io::Result<Value> {
     Err(last_err)
 }
 
+/// Test-only public wrapper for integration benchmarks.
+#[cfg(feature = "integration-test")]
+pub fn read_json_report_with_retries(path: &Path) -> std::io::Result<Value> {
+    read_json_with_retries(path)
+}
+
 fn write_json_pretty(path: &Path, v: &Value) -> std::io::Result<()> {
     let file = fs::OpenOptions::new()
         .create(true)

--- a/tests/integration/hotpath_profile.rs
+++ b/tests/integration/hotpath_profile.rs
@@ -1,0 +1,156 @@
+#![cfg(feature = "hotpath")]
+
+use crate::test_framework;
+
+use bitcoin::Amount;
+use coinswap::{
+    maker::{start_server, MakerBehavior},
+    protocol::common_messages::ProtocolVersion,
+    taker::{SwapParams, TakerBehavior},
+    wallet::AddressType,
+};
+use serde_json::Value;
+use std::{env, path::PathBuf, sync::atomic::Ordering::Relaxed, thread};
+
+fn write_filtered_report_by_prefixes(
+    input_report_path: &std::path::Path,
+    output_report_path: &std::path::Path,
+    prefixes: &[&str],
+) -> std::io::Result<()> {
+    let mut report = coinswap::hotpath_local::read_json_report_with_retries(input_report_path)?;
+    for section_key in ["functions_timing", "functions_alloc"] {
+        let Some(rows) = report
+            .get_mut(section_key)
+            .and_then(|section| section.get_mut("data"))
+            .and_then(Value::as_array_mut)
+        else {
+            continue;
+        };
+
+        rows.retain(|row| {
+            row.get("name")
+                .and_then(Value::as_str)
+                .is_some_and(|name| prefixes.iter().any(|p| name.starts_with(p)))
+        });
+    }
+
+    if let Some(parent) = output_report_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(output_report_path)?;
+    serde_json::to_writer_pretty(std::io::BufWriter::new(file), &report)
+        .map_err(std::io::Error::other)
+}
+
+#[test]
+fn hotpath_profile_swap() {
+    let full_report_path = env::var_os("HOTPATH_OUTPUT_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis();
+            std::env::temp_dir().join(format!("coinswap_hotpath_full_{ts}.json"))
+        });
+
+    let maker_report_path = env::var_os("COINSWAP_HOTPATH_MAKER_OUTPUT_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| full_report_path.with_file_name("maker.json").to_path_buf());
+    let taker_report_path = env::var_os("COINSWAP_HOTPATH_TAKER_OUTPUT_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| full_report_path.with_file_name("taker.json").to_path_buf());
+
+    let hotpath_run = coinswap::hotpath_local::HotpathRun::start(
+        "hotpath_profile_swap",
+        full_report_path.clone(),
+    )
+    .expect("hotpath should start");
+
+    let makers_config_map = vec![(7102, Some(19061)), (17102, Some(19062))];
+    let taker_behavior = vec![TakerBehavior::Normal];
+    let maker_behaviors = vec![MakerBehavior::Normal, MakerBehavior::Normal];
+
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        test_framework::TestFramework::init(makers_config_map, taker_behavior, maker_behaviors);
+
+    let bitcoind = &test_framework.bitcoind;
+    let taker = takers.get_mut(0).expect("taker must exist");
+
+    let _taker_spendable = test_framework::fund_taker(
+        taker,
+        bitcoind,
+        3,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    test_framework::fund_makers(
+        &makers,
+        bitcoind,
+        4,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker_clone = maker.clone();
+            thread::spawn(move || start_server(maker_clone).expect("maker server should start"))
+        })
+        .collect::<Vec<_>>();
+
+    test_framework::wait_for_makers_setup(&makers, 120);
+
+    let swap_params = SwapParams::new(ProtocolVersion::Taproot, Amount::from_sat(500_000), 2)
+        .with_tx_count(3)
+        .with_required_confirms(1);
+
+    test_framework::generate_blocks(bitcoind, 1);
+
+    let summary = taker
+        .prepare_coinswap(swap_params)
+        .expect("prepare_coinswap must succeed");
+
+    taker
+        .start_coinswap(&summary.swap_id)
+        .expect("start_coinswap must succeed");
+
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+
+    for t in maker_threads {
+        t.join().expect("maker thread must join");
+    }
+
+    drop(hotpath_run);
+    test_framework.stop();
+    block_generation_handle
+        .join()
+        .expect("block generation thread must join");
+
+    write_filtered_report_by_prefixes(&full_report_path, &maker_report_path, &["coinswap::maker"])
+        .expect("maker filtered report should be written");
+    write_filtered_report_by_prefixes(&full_report_path, &taker_report_path, &["coinswap::taker"])
+        .expect("taker filtered report should be written");
+
+    println!(
+        "\n[hotpath] full JSON report: {}",
+        full_report_path.display()
+    );
+    println!(
+        "[hotpath] maker JSON report: {}",
+        maker_report_path.display()
+    );
+    println!(
+        "[hotpath] taker JSON report: {}",
+        taker_report_path.display()
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -33,6 +33,8 @@ mod wallet_backup;
 mod concurrent_takers;
 mod fidelity_timelock_violation;
 mod funding_dynamic_splits;
+#[cfg(feature = "hotpath")]
+mod hotpath_profile;
 mod liquidity_test;
 mod offerbook_sync_race;
 mod taker_cli;


### PR DESCRIPTION
# Pull Request

## Description
Adds hotpath to ci for profiling, by introducing a `hotpath-profile` workflow that runs a single integration test `hotpath_profile` on both PR head and base commits, generates maker and taker JSON metrics, and uploads them as a profile-metrics artifact, plus a `hotpath-comment` workflow that triggers on the profile workflow completion, downloads that artifact, and posts maker/taker base-vs-head comparison comments to the PR.


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [x] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [x] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [x] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [x] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [x] All unit tests pass (`cargo test`)
- [x] Integration tests pass (`cargo test --features integration-test`)
- [x] Changes were manually tested on **regtest**
- [x] End-to-end maker ↔ taker swap tested (where applicable)
- [x] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated hotpath performance profiling: scheduled benchmarks collect metrics and post summarized results as PR comments.

* **Tests**
  * Added an integration test that runs hotpath benchmarks and produces separate maker/taker profiling reports.
  * Test harness now conditionally enables the hotpath profiling test when the feature is active.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/citadel-tech/coinswap/pull/867)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->