### PR TITLE
taker(api): reject duplicate makers

### DIFF
--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -740,6 +740,18 @@ impl Taker {
             )));
         }
 
+        if let Some(preferred_makers) = &params.preferred_makers {
+            let mut seen = HashSet::new();
+            for maker in preferred_makers {
+                if !seen.insert(maker.trim()) {
+                    return Err(TakerError::General(format!(
+                        "Duplicate maker in route: {}",
+                        maker
+                    )));
+                }
+            }
+        }
+
         let mut preimage = [0u8; 32];
         OsRng.fill_bytes(&mut preimage);
 


### PR DESCRIPTION
# Pull Request

## Description
Added a minimal preflight validation in `Taker::prepare_coinswap` to reject duplicate manually preferred maker addresses before swap state creation.

For eg-: Currently if we pass 2 same maker address via `--maker-address` flag in the cli, the swap start and ends up with the taker recovering it's funds via timelock. Therefore this check prevents this at an early stage by checking  If `SwapParams.preferred_makers` contains the same address more than once, returning an error if present.

## Related Issue(s)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [x] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [x] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [x] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [x] All unit tests pass (`cargo test`)
- [x] Integration tests pass (`cargo test --features integration-test`)
- [x] Changes were manually tested on **regtest**
- [x] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [x] This change preserves **trustlessness** and **atomic swap guarantees**
- [x] No regression in **sybil resistance** or **fidelity bond** logic
- [x] Tor anonymity and P2P message flow were reviewed
- [x] No new attack vectors or trust assumptions introduced
- [x] Edge cases and error handling considered
- [x] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [x] `integration-test` feature flag is not reachable in production code paths



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for maker selections to detect and reject duplicate addresses during route preparation, preventing configuration errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/citadel-tech/coinswap/pull/869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->