### PR TITLE
logs:made nostr discovery logs more verbose

### DIFF
--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -15,6 +15,7 @@ use crate::{
     maker::rpc::server::MakerRpc,
     nostr_coinswap::broadcast_bond_on_nostr,
     protocol::common_messages::{FidelityProof, MakerToTakerMessage, TakerToMakerMessage},
+    utill::HEART_BEAT_INTERVAL,
     wallet::RecoveryReport,
 };
 
@@ -23,9 +24,6 @@ use super::{
     error::MakerError,
     handlers::{handle_message, ConnectionState, Maker},
 };
-
-/// Heartbeat interval for connections.
-pub const HEART_BEAT_INTERVAL: Duration = Duration::from_secs(3);
 
 /// Idle connection timeout (production).
 #[cfg(not(feature = "integration-test"))]

--- a/src/nostr_coinswap.rs
+++ b/src/nostr_coinswap.rs
@@ -156,7 +156,7 @@ pub fn broadcast_bond_on_nostr(
 
     let msg = ClientMessage::Event(std::borrow::Cow::Owned(event));
 
-    log::debug!("nostr wire msg: {}", msg.as_json());
+    log::debug!("Nostr wire message built | payload={}", msg.as_json());
 
     const RELAY_DELAY: Duration = Duration::from_secs(2);
     const MAX_RETRIES: usize = 3;
@@ -165,6 +165,13 @@ pub fn broadcast_bond_on_nostr(
 
     for relay in relays {
         for attempt in 1..=MAX_RETRIES {
+            log::debug!(
+                "Publishing Nostr event | relay={} | attempt={}/{} | payload={}",
+                relay,
+                attempt,
+                MAX_RETRIES,
+                msg.as_json()
+            );
             match broadcast_to_relay(relay, &msg, config.socks_port, &config.tor_auth_password) {
                 Ok(()) => {
                     success = true;
@@ -172,7 +179,7 @@ pub fn broadcast_bond_on_nostr(
                 }
                 Err(e) => {
                     log::warn!(
-                        "failed to broadcast to {} (attempt {}/{}): {:?}",
+                        "Nostr event publish failed | relay={} | attempt={}/{} | error={:?}",
                         relay,
                         attempt,
                         MAX_RETRIES,
@@ -203,14 +210,14 @@ fn broadcast_to_relay(
 ) -> Result<(), MakerError> {
     let mut socket =
         connect_nostr_websocket(relay, socks_port, tor_auth_password).map_err(|e| {
-            log::warn!("failed to connect to nostr relay {}: {}", relay, e);
+            log::warn!("Nostr relay connect failed | relay={} | error={}", relay, e);
             MakerError::General("failed to connect to nostr relay")
         })?;
 
     socket
         .write(Message::Text(msg.as_json().into()))
         .map_err(|e| {
-            log::warn!("nostr relay write failed: {}", e);
+            log::warn!("Nostr relay write failed | relay={} | error={}", relay, e);
             MakerError::General("failed to write to nostr relay")
         })?;
     socket.flush().ok();
@@ -224,7 +231,11 @@ fn broadcast_to_relay(
                         status: true,
                         ..
                     } => {
-                        log::info!("nostr relay {} accepted event {}", relay, event_id);
+                        log::info!(
+                            "Nostr relay accepted event | relay={} | event_id={}",
+                            relay,
+                            event_id
+                        );
                         return Ok(());
                     }
                     RelayMessage::Ok {
@@ -233,7 +244,7 @@ fn broadcast_to_relay(
                         message,
                     } => {
                         log::warn!(
-                            "nostr relay {} rejected event {}: {}",
+                            "Nostr relay rejected event | relay={} | event_id={} | message={}",
                             relay,
                             event_id,
                             message
@@ -245,9 +256,9 @@ fn broadcast_to_relay(
         }
         Ok(_) => {}
         Err(e) => {
-            log::warn!("nostr relay {} read error: {}", relay, e);
+            log::warn!("Nostr relay read failed | relay={} | error={}", relay, e);
         }
     }
-    log::warn!("nostr relay {} did not confirm event", relay);
+    log::warn!("Nostr relay did not confirm event | relay={}", relay);
     Err(MakerError::General("nostr relay did not confirm event"))
 }

--- a/src/nostr_coinswap.rs
+++ b/src/nostr_coinswap.rs
@@ -165,7 +165,7 @@ pub fn broadcast_bond_on_nostr(
 
     for relay in relays {
         for attempt in 1..=MAX_RETRIES {
-            log::debug!(
+            log::info!(
                 "Publishing Nostr event | relay={} | attempt={}/{} | payload={}",
                 relay,
                 attempt,

--- a/src/watch_tower/nostr_discovery.rs
+++ b/src/watch_tower/nostr_discovery.rs
@@ -45,9 +45,13 @@ pub fn run_discovery(
     relays: &[String],
     nostr_tor_config: (u16, String),
 ) -> Result<(), WatcherError> {
-    log::info!("Starting market discovery via Nostr");
-
     let kind = Kind::Custom(coinswap_kind(network));
+    log::info!(
+        "Starting market discovery via Nostr | network={} | kind={} | relays={:?}",
+        network,
+        kind,
+        relays
+    );
 
     let seen_txid = Arc::new(Mutex::new(SeenTxids::new()));
     let registry = Arc::new(registry);
@@ -95,7 +99,7 @@ fn run_nostr_session_for_relay(
     initial_sync_complete: &Arc<AtomicBool>,
     nostr_tor_config: (u16, &str),
 ) {
-    log::info!("Starting Nostr session for relay {}", relay_url);
+    log::info!("Starting Nostr session | relay={relay_url}");
 
     while !shutdown.load(Ordering::SeqCst) {
         match connect_and_run_once(
@@ -114,16 +118,14 @@ fn run_nostr_session_for_relay(
             }
             Err(e) => {
                 log::warn!(
-                    "Nostr session error on {}: {:?}, retrying in 5s",
-                    relay_url,
-                    e
+                    "Nostr session error | relay={relay_url} | error={e:?} | retry_in_secs=5"
                 );
                 std::thread::sleep(std::time::Duration::from_secs(5));
             }
         }
     }
 
-    log::info!("Stopped Nostr session for relay {}", relay_url);
+    log::info!("Stopped Nostr session | relay={relay_url}");
 }
 
 /// Establishes websocket connection to single Nostr relay and processes events until error or shutdown.
@@ -161,10 +163,11 @@ fn connect_and_run_once(
     socket.flush()?;
 
     log::info!(
-        "Subscribed to fidelity announcements on {} (kind={}, since={:?})",
+        "Subscribed to fidelity announcements | relay={} | kind={} | since={:?} | request={}",
         relay_url,
         kind,
-        since
+        since,
+        req.as_json()
     );
 
     read_event_loop(
@@ -220,6 +223,13 @@ fn read_event_loop(
             _ => continue,
         };
 
+        log::debug!(
+            "Nostr relay message received | relay={} | bytes={} | payload={}",
+            relay_url,
+            text.len(),
+            text
+        );
+
         let relay_msg = RelayMessage::from_json(&text)?;
 
         let is_eose = handle_relay_message(
@@ -258,8 +268,11 @@ fn handle_relay_message(
 
             if event.is_expired() || event.tags.expiration().is_none() {
                 log::debug!(
-                    "Ignoring expired event or event without expiration tag from {}",
-                    relay_url
+                    "Ignoring expired Nostr event | relay={} | event_id={} | created_at={} | has_expiration={}",
+                    relay_url,
+                    event.id,
+                    event.created_at,
+                    event.tags.expiration().is_some()
                 );
                 return Ok(false);
             }
@@ -270,15 +283,33 @@ fn handle_relay_message(
                 > EXPIRATION_SECS
             {
                 log::debug!(
-                    "Skipping stale event from {relay_url} older than {} hours",
+                    "Skipping stale Nostr event | relay={} | event_id={} | created_at={} | max_age_hours={}",
+                    relay_url,
+                    event.id,
+                    event.created_at,
                     EXPIRATION_SECS / 3600
                 );
                 return Ok(false);
             }
 
             let Some((txid, vout)) = parse_fidelity_event(&event) else {
+                log::debug!(
+                    "Ignoring unparsable fidelity event | relay={} | event_id={} | content={}",
+                    relay_url,
+                    event.id,
+                    event.content
+                );
                 return Ok(false);
             };
+
+            log::debug!(
+                "Parsed fidelity event | relay={} | event_id={} | txid={} | vout={} | created_at={}",
+                relay_url,
+                event.id,
+                txid,
+                vout,
+                event.created_at
+            );
 
             // Check the seen-cache before any RPC work to avoid wasted
             // `get_raw_tx` calls on duplicate events.
@@ -299,12 +330,28 @@ fn handle_relay_message(
             log::info!("Added txid to Nostr discovery cache: {txid}");
             match process_fidelity(&tx) {
                 Some(fidelity) => {
+                    let maker_address = fidelity.onion.clone();
+                    let expires_at_height = fidelity.expires_at_height;
                     if registry.insert_fidelity(txid, fidelity) {
-                        log::info!("Stored verified fidelity via {relay_url}: {txid}:{vout}");
+                        log::info!(
+                                "Stored verified fidelity | relay={} | event_id={} | txid={} | vout={} | maker_address={} | expires_at_height={}",
+                                relay_url,
+                                event.id,
+                                txid,
+                                vout,
+                                maker_address,
+                                expires_at_height
+                            );
                     }
                 }
                 None => {
-                    log::warn!("Invalid fidelity {txid}:{vout} via {relay_url}");
+                    log::warn!(
+                        "Invalid fidelity transaction | relay={} | event_id={} | txid={} | vout={}",
+                        relay_url,
+                        event.id,
+                        txid,
+                        vout
+                    );
                 }
             }
             registry.save_nostr_cursor(relay_url, event.created_at.as_secs());

--- a/src/watch_tower/registry_storage.rs
+++ b/src/watch_tower/registry_storage.rs
@@ -192,7 +192,7 @@ impl FileRegistry {
     pub fn load_nostr_cursor(&self, relay_url: &str) -> Option<u64> {
         let cursor = self.with_data(|data| data.nostr_cursors.get(relay_url).copied());
         log::debug!(
-            "Nostr cursor load: relay_url={}, cursor={:?}",
+            "Nostr cursor load | relay={} | cursor={:?}",
             relay_url,
             cursor
         );
@@ -211,7 +211,7 @@ impl FileRegistry {
             (prev, next, next != prev)
         });
         log::debug!(
-            "Nostr cursor save: relay_url={}, incoming={}, previous={}, stored={}, advanced={}",
+            "Nostr cursor save | relay={} | incoming={} | previous={} | stored={} | advanced={}",
             relay_url,
             created_at_secs,
             prev,


### PR DESCRIPTION
# Pull Request

## Description
Add more details to nostr discovery logs

## Related Issue(s)
Fixes #848 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [x] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [x] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [x] I ran `cargo +nightly fmt --all` and committed the result
- [x] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [x] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [x] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [x] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [x] All unit tests pass (`cargo test`)
- [x] Integration tests pass (`cargo test --features integration-test`)
- [x] Changes were manually tested on **regtest**
- [x] End-to-end maker ↔ taker swap tested (where applicable)
- [x] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced structured logging and diagnostics across Nostr flows for clearer debug, info, and warning output
  * Improved per-relay visibility for publishes, retries, reads, and responses with contextual fields (relay, event id, payload, errors)
  * More detailed logs for discovery, subscription, event parsing, fidelity validation, caching, and sync progress
  * Heartbeat timing now sourced centrally for background loop consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/citadel-tech/coinswap/pull/870?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->